### PR TITLE
Directory fix for Unix based systems

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,8 +5,10 @@ Version 2.3.1
 ----------------------------------------
 Summary:
 + #73 Fixed "Tests accessing Application Settings fails on NET45x with SerializationException: TestContextProvider is not marked as serializable"
++ #87 Fixed directory separator for Unix systems
 Details:
 + #73 (Framework)(Fix) Corrected AsyncLocalContext<T> in LightBDD targeting NET45x to marshal stored context by ref when transferring it between domains
++ #87 (Framework)(Fix) Use the System.IO.Path.DirectorySeparatorChar in file paths to match Unix and Win paths
 
 Version 2.3.0
 ----------------------------------------

--- a/src/LightBDD.Framework/Reporting/Configuration/ReportWritersConfiguration.cs
+++ b/src/LightBDD.Framework/Reporting/Configuration/ReportWritersConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using LightBDD.Core.Configuration;
 using LightBDD.Core.Reporting;
 using LightBDD.Framework.Reporting.Formatters;
@@ -15,12 +16,12 @@ namespace LightBDD.Framework.Reporting.Configuration
         private readonly List<IReportWriter> _writers = new List<IReportWriter>();
 
         /// <summary>
-        /// Default constructor initializing configuration to generate <c>~\\Reports\\FeaturesReport.xml</c> and <c>~\\Reports\\FeaturesReport.html</c> reports.
+        /// Default constructor initializing configuration to generate <c>~\\Reports\\FeaturesReport.xml</c>(Win) <c>~/Reports/FeaturesReport.xml</c>(Unix) and <c>~\\Reports\\FeaturesReport.html</c>(Win) <c>~/Reports/FeaturesReport.html</c>(Unix) reports.
         /// </summary>
         public ReportWritersConfiguration()
         {
-            Add(new ReportFileWriter(new XmlReportFormatter(), "~\\Reports\\FeaturesReport.xml"));
-            Add(new ReportFileWriter(new HtmlReportFormatter(), "~\\Reports\\FeaturesReport.html"));
+            Add(new ReportFileWriter(new XmlReportFormatter(), "~" + Path.DirectorySeparatorChar + "Reports" + Path.DirectorySeparatorChar + "FeaturesReport.xml"));
+            Add(new ReportFileWriter(new HtmlReportFormatter(), "~" + Path.DirectorySeparatorChar + "Reports" + Path.DirectorySeparatorChar + "FeaturesReport.html"));
         }
 
         /// <summary>

--- a/test/LightBDD.AcceptanceTests/ConfiguredLightBddScopeAttribute.cs
+++ b/test/LightBDD.AcceptanceTests/ConfiguredLightBddScopeAttribute.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using LightBDD.AcceptanceTests;
 using LightBDD.AcceptanceTests.Helpers;
 using LightBDD.Core.Configuration;
@@ -17,7 +18,7 @@ namespace LightBDD.AcceptanceTests
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
             configuration.ReportWritersConfiguration()
-                .Add(new ReportFileWriter(new PlainTextReportFormatter(), "~\\Reports\\FeaturesReport.txt"));
+                .Add(new ReportFileWriter(new PlainTextReportFormatter(), "~" + Path.DirectorySeparatorChar + "Reports" + Path.DirectorySeparatorChar + "FeaturesReport.txt"));
         }
 
         protected override void OnTearDown()

--- a/test/LightBDD.AcceptanceTests/Features/HTML_report_feature.Steps.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HTML_report_feature.Steps.cs
@@ -26,7 +26,7 @@ namespace LightBDD.AcceptanceTests.Features
             public Context()
             {
                 Driver = DriverPool.Acquire();
-                HtmlFileName = Path.GetFullPath(BaseDirectory + "\\" + Guid.NewGuid() + ".html");
+                HtmlFileName = Path.GetFullPath(BaseDirectory + " + Path.DirectorySeparatorChar + " + Guid.NewGuid() + ".html");
                 ResultBuilder = new ResultBuilder();
             }
 

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/XmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/XmlReportFormatter_tests.cs
@@ -20,7 +20,7 @@ namespace LightBDD.Framework.Reporting.UnitTests.Formatters
         public XmlReportFormatter_tests()
         {
             _schema = new XmlSchemaSet();
-            _schema.Add("", AppDomain.CurrentDomain.BaseDirectory + "\\XmlReportFormatterSchema.xsd");
+            _schema.Add("", AppDomain.CurrentDomain.BaseDirectory + Path.DirectorySeparatorChar + "XmlReportFormatterSchema.xsd");
         }
 
         [SetUp]

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_formattable_path_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_formattable_path_tests.cs
@@ -90,8 +90,8 @@ namespace LightBDD.Framework.Reporting.UnitTests
         private void GenerateRelativeDirPathWithTilde()
         {
             _dirPath = Guid.NewGuid().ToString();
-            _realDirPath = AppDomainHelper.BaseDirectory + "\\" + _dirPath;
-            _dirPath = "~\\" + _dirPath;
+            _realDirPath = AppDomainHelper.BaseDirectory + Path.DirectorySeparatorChar + _dirPath;
+            _dirPath = "~" + Path.DirectorySeparatorChar + _dirPath;
         }
 
         private string PrepareFilePath(string name)

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
@@ -13,9 +13,9 @@ namespace LightBDD.Framework.Reporting.UnitTests
         [Test]
         public void It_should_use_appdomain_base_directory_if_output_starts_with_tilde()
         {
-            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "~\\output.txt");
-            var expected = Path.GetFullPath(BaseDirectory + "\\output.txt");
-            Assert.That(writer.OutputPath, Is.EqualTo("~\\output.txt"));
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "~" + Path.DirectorySeparatorChar + "output.txt");
+            var expected = Path.GetFullPath(BaseDirectory + Path.DirectorySeparatorChar + "output.txt");
+            Assert.That(writer.OutputPath, Is.EqualTo("~" + Path.DirectorySeparatorChar + "output.txt"));
             Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
         }
 
@@ -31,9 +31,9 @@ namespace LightBDD.Framework.Reporting.UnitTests
         [Test]
         public void It_should_preserve_output_path_if_it_is_absolute()
         {
-            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "c:\\output.txt");
-            var expected = Path.GetFullPath("c:\\output.txt");
-            Assert.That(writer.OutputPath, Is.EqualTo("c:\\output.txt"));
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "c:" + Path.DirectorySeparatorChar + "output.txt");
+            var expected = Path.GetFullPath("c:" + Path.DirectorySeparatorChar + "output.txt");
+            Assert.That(writer.OutputPath, Is.EqualTo("c:" + Path.DirectorySeparatorChar + "output.txt"));
             Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
         }
 
@@ -41,7 +41,7 @@ namespace LightBDD.Framework.Reporting.UnitTests
         public void Save_should_use_formatter_to_write_data()
         {
             var expectedFileContent = "text";
-            var outputPath = $"~\\{Guid.NewGuid()}\\output.txt";
+            var outputPath = $"~" + Path.DirectorySeparatorChar + "{Guid.NewGuid()}" + Path.DirectorySeparatorChar + "output.txt";
             var expectedPath = outputPath.Replace("~", BaseDirectory);
 
             var formatter = Mock.Of<IReportFormatter>();

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
@@ -41,7 +41,7 @@ namespace LightBDD.Framework.Reporting.UnitTests
         public void Save_should_use_formatter_to_write_data()
         {
             var expectedFileContent = "text";
-            var outputPath = $"~" + Path.DirectorySeparatorChar + "{Guid.NewGuid()}" + Path.DirectorySeparatorChar + "output.txt";
+            var outputPath = "~" + Path.DirectorySeparatorChar + $"{Guid.NewGuid()}" + Path.DirectorySeparatorChar + "output.txt";
             var expectedPath = outputPath.Replace("~", BaseDirectory);
 
             var formatter = Mock.Of<IReportFormatter>();


### PR DESCRIPTION
The directory separator is hardcoded for Win systems and does not work on Unix based systems. So instead of using a double backslash use the System.IO.Path.DirectorySeparatorChar.

#### Details

Issue reference: #87 

List of changes:
Replace all using of the double backslash in paths to create a directory in framework and the corresponding tests.

#### Checklist
- [X] Changes are backward compatible with previous version of Core and Framework,
- [X] Changelog has been updated,
- [X] Debugging experience is good,
- [X] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
