### PR TITLE
#92 Excluded this argument from step name display when extension method is used

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,11 @@ Version 2.3.3
 ----------------------------------------
 Summary:
 + #90 Allowed to install new FeatureCoordinator when previous one is disposed in order to allow NCrunch reusing the same process to run LightBDD multiple times
++ #92 Excluded this argument from step name display when extension method is used
+Details:
++ #90 (Core)(Change) Allowed to install new FeatureCoordinator when previous one is disposed in order to allow NCrunch reusing the same process to run LightBDD multiple times
++ #92 (Core)(Change) Excluded this argument from step name display when extension method is used
++ #92 (Core)(Change) Corrected parameter placement in name when having appended parameter of lower index than matching in-text replacement at the end of the name, like: void Step_with_param(string other, string param)
 
 Version 2.3.2
 ----------------------------------------

--- a/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
+++ b/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
@@ -141,7 +141,7 @@ namespace LightBDD.Core.Extensibility
         /// <returns><see cref="IStepNameInfo"/> object.</returns>
         public IStepNameInfo GetStepName(StepDescriptor stepDescriptor, string previousStepTypeName)
         {
-            var formattedStepName = _nameParser.GetNameFormat(stepDescriptor.RawName, stepDescriptor.Parameters);
+            var formattedStepName = _nameParser.GetNameFormat(stepDescriptor.MethodInfo, stepDescriptor.RawName, stepDescriptor.Parameters);
             return new StepNameInfo(
                 _stepTypeProcessor.GetStepTypeName(stepDescriptor.PredefinedStepType, ref formattedStepName, previousStepTypeName),
                 formattedStepName,
@@ -315,7 +315,7 @@ namespace LightBDD.Core.Extensibility
         {
             try
             {
-                var formattedStepName = _nameParser.GetNameFormat(scenarioDescriptor.MethodInfo.Name, scenarioDescriptor.Parameters);
+                var formattedStepName = _nameParser.GetNameFormat(scenarioDescriptor.MethodInfo, scenarioDescriptor.MethodInfo.Name, scenarioDescriptor.Parameters);
                 var arguments = scenarioDescriptor.Parameters.Select(p => new MethodArgument(p, GetParameterFormatter(p.ParameterInfo))).ToArray();
                 return new NameInfo(
                     formattedStepName,

--- a/src/LightBDD.Core/Extensibility/Implementation/NameParser.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/NameParser.cs
@@ -29,7 +29,7 @@ namespace LightBDD.Core.Extensibility.Implementation
                 .Skip(shiftByThisArgument)
                 .Select((param, index) => ToArgumentReplacement(name, param.RawName, index + shiftByThisArgument))
                 .OrderBy(r => r.Position)
-                .ToArray();
+                .ThenBy(r => r.Priority);
             var lastPos = 0;
             foreach (var replacement in replacements)
             {
@@ -46,12 +46,16 @@ namespace LightBDD.Core.Extensibility.Implementation
         private static ArgumentReplacement ToArgumentReplacement(string stepName, string parameterName, int argumentIndex)
         {
             var position = FindArgument(stepName, parameterName.ToUpperInvariant(), StringComparison.Ordinal);
+
             if (position >= 0)
-                return new ArgumentReplacement(position, $"\"{{{argumentIndex}}}\"", parameterName.Length);
+                return new ArgumentReplacement(position, $"\"{{{argumentIndex}}}\"", parameterName.Length, 0);
+
             position = FindArgument(stepName, parameterName, StringComparison.OrdinalIgnoreCase);
+
             if (position >= 0)
-                return new ArgumentReplacement(position + parameterName.Length, $" \"{{{argumentIndex}}}\"", 0);
-            return new ArgumentReplacement(stepName.Length, $" [{parameterName}: \"{{{argumentIndex}}}\"]", 0);
+                return new ArgumentReplacement(position + parameterName.Length, $" \"{{{argumentIndex}}}\"", 0, 0);
+
+            return new ArgumentReplacement(stepName.Length, $" [{parameterName}: \"{{{argumentIndex}}}\"]", 0, 1);
         }
 
         private static int FindArgument(string name, string argument, StringComparison stringComparison)
@@ -69,13 +73,14 @@ namespace LightBDD.Core.Extensibility.Implementation
 
         private class ArgumentReplacement
         {
-            public ArgumentReplacement(int position, string value, int charactersToReplace)
+            public ArgumentReplacement(int position, string value, int charactersToReplace, byte priority)
             {
                 Position = position;
                 Value = value;
                 CharactersToReplace = charactersToReplace;
+                Priority = priority;
             }
-
+            public byte Priority { get; }
             public int Position { get; }
             public string Value { get; }
             public int CharactersToReplace { get; }

--- a/src/LightBDD.Core/Extensibility/Implementation/NameParser.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/NameParser.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using LightBDD.Core.Formatting;
 
@@ -16,13 +18,16 @@ namespace LightBDD.Core.Extensibility.Implementation
             _nameFormatter = nameFormatter;
         }
 
-        public string GetNameFormat(string stepRawName, ParameterDescriptor[] stepParameters)
+        public string GetNameFormat(MethodBase targetMethod, string stepRawName, ParameterDescriptor[] stepParameters)
         {
+            var shiftByThisArgument = targetMethod != null && targetMethod.IsDefined(typeof(ExtensionAttribute), true) ? 1 : 0;
+
             var name = _nameFormatter.FormatName(stepRawName);
             var sb = new StringBuilder();
 
             var replacements = stepParameters
-                .Select((param, index) => ToArgumentReplacement(name, param.RawName, index))
+                .Skip(shiftByThisArgument)
+                .Select((param, index) => ToArgumentReplacement(name, param.RawName, index + shiftByThisArgument))
                 .OrderBy(r => r.Position)
                 .ToArray();
             var lastPos = 0;

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
@@ -50,13 +50,15 @@ namespace LightBDD.Core.UnitTests
             _runner.Test().TestScenario(
                 TestStep.CreateAsync(Method_with_replaced_parameter_PARAM_in_name, "abc"),
                 TestStep.CreateAsync(Method_with_inserted_parameter_param_in_name, "abc"),
-                TestStep.CreateAsync(Method_with_appended_parameter_at_the_end_of_name, "abc"));
+                TestStep.CreateAsync(Method_with_appended_parameter_at_the_end_of_name, "abc"),
+                TestStep.CreateAsync(ExtensionSteps.Extension_method_with_parameter_PARAM, "target", "abc"));
 
             var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
             StepResultExpectation.AssertEqual(steps,
-                new StepResultExpectation(1, 3, "Method with replaced parameter \"abc\" in name", ExecutionStatus.Passed),
-                new StepResultExpectation(2, 3, "Method with inserted parameter param \"abc\" in name", ExecutionStatus.Passed),
-                new StepResultExpectation(3, 3, "Method with appended parameter at the end of name [param: \"abc\"]", ExecutionStatus.Passed)
+                new StepResultExpectation(1, 4, "Method with replaced parameter \"abc\" in name", ExecutionStatus.Passed),
+                new StepResultExpectation(2, 4, "Method with inserted parameter param \"abc\" in name", ExecutionStatus.Passed),
+                new StepResultExpectation(3, 4, "Method with appended parameter at the end of name [param: \"abc\"]", ExecutionStatus.Passed),
+                new StepResultExpectation(4, 4, "Extension method with parameter \"abc\"", ExecutionStatus.Passed)
             );
         }
 
@@ -176,5 +178,10 @@ namespace LightBDD.Core.UnitTests
         private void Method_with_inserted_parameter_param_in_name(object param) { }
         private void Method_with_replaced_parameter_PARAM_in_name(object param) { }
         private void Method_with_wrong_formatter_param([Format("{0")]object param) { }
+    }
+
+    static class ExtensionSteps
+    {
+        public static void Extension_method_with_parameter_PARAM(this object target, object param) { }
     }
 }

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
@@ -51,14 +51,19 @@ namespace LightBDD.Core.UnitTests
                 TestStep.CreateAsync(Method_with_replaced_parameter_PARAM_in_name, "abc"),
                 TestStep.CreateAsync(Method_with_inserted_parameter_param_in_name, "abc"),
                 TestStep.CreateAsync(Method_with_appended_parameter_at_the_end_of_name, "abc"),
-                TestStep.CreateAsync(ExtensionSteps.Extension_method_with_parameter_PARAM, "target", "abc"));
+                TestStep.CreateAsync(ExtensionSteps.Extension_method_with_parameter_PARAM, "target", "abc"),
+                TestStep.CreateAsync(Method_with_param1_param2_param3, "abc", "def", "123"),
+                TestStep.CreateAsync(Method_with_appended_and_normal_param, "abc", "def", "123")
+                );
 
             var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
             StepResultExpectation.AssertEqual(steps,
-                new StepResultExpectation(1, 4, "Method with replaced parameter \"abc\" in name", ExecutionStatus.Passed),
-                new StepResultExpectation(2, 4, "Method with inserted parameter param \"abc\" in name", ExecutionStatus.Passed),
-                new StepResultExpectation(3, 4, "Method with appended parameter at the end of name [param: \"abc\"]", ExecutionStatus.Passed),
-                new StepResultExpectation(4, 4, "Extension method with parameter \"abc\"", ExecutionStatus.Passed)
+                new StepResultExpectation(1, 6, "Method with replaced parameter \"abc\" in name", ExecutionStatus.Passed),
+                new StepResultExpectation(2, 6, "Method with inserted parameter param \"abc\" in name", ExecutionStatus.Passed),
+                new StepResultExpectation(3, 6, "Method with appended parameter at the end of name [param: \"abc\"]", ExecutionStatus.Passed),
+                new StepResultExpectation(4, 6, "Extension method with parameter \"abc\"", ExecutionStatus.Passed),
+                new StepResultExpectation(5, 6, "Method with param1 \"def\" param2 \"123\" param3 \"abc\"", ExecutionStatus.Passed),
+                new StepResultExpectation(6, 6, "Method with appended and normal param \"def\" [appended1: \"abc\"] [appended2: \"123\"]", ExecutionStatus.Passed)
             );
         }
 
@@ -178,6 +183,8 @@ namespace LightBDD.Core.UnitTests
         private void Method_with_inserted_parameter_param_in_name(object param) { }
         private void Method_with_replaced_parameter_PARAM_in_name(object param) { }
         private void Method_with_wrong_formatter_param([Format("{0")]object param) { }
+        private void Method_with_appended_and_normal_param(object appended1, object param, object appended2) { }
+        private void Method_with_param1_param2_param3(object param3, object param1, object param2) { }
     }
 
     static class ExtensionSteps

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Parameterized_scenario_runner_parameter_capture_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Parameterized_scenario_runner_parameter_capture_tests.cs
@@ -12,7 +12,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
     [TestFixture]
     public class Parameterized_scenario_runner_parameter_capture_tests : ParameterizedScenariosTestBase<NoContext>
     {
-
         [Test]
         public void It_should_capture_constant_parameters_in_sync_mode()
         {
@@ -136,6 +135,49 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
 
         private void Some_step(string parameter)
         {
+        }
+
+        [Test]
+        public void It_should_capture_extension_method_parameters_in_sync_mode()
+        {
+            ExpectSynchronousScenarioRun();
+            var expectedValue = 5;
+            Runner.RunScenario(x => this.Extension_method_with_parameter(expectedValue));
+
+            var step = CapturedSteps.Single();
+            Assert.That(step.Parameters.Length, Is.EqualTo(2));
+            Assert.That(step.Parameters[0].ValueEvaluator.Invoke(null), Is.SameAs(this));
+            Assert.That(step.Parameters[1].ValueEvaluator.Invoke(null), Is.EqualTo(expectedValue));
+        }
+
+        [Test]
+        public async Task It_should_capture_extension_method_parameters_in_async_mode()
+        {
+            ExpectAsynchronousScenarioRun();
+            var expectedValue = 5;
+            await Runner.RunScenarioAsync(x => this.Extension_method_with_parameter_async(expectedValue));
+
+            var step = CapturedSteps.Single();
+            Assert.That(step.Parameters.Length, Is.EqualTo(2));
+            Assert.That(step.Parameters[0].ValueEvaluator.Invoke(null), Is.SameAs(this));
+            Assert.That(step.Parameters[1].ValueEvaluator.Invoke(null), Is.EqualTo(expectedValue));
+        }
+    }
+
+
+    static class MyContextExtensions
+    {
+        public static void Extension_method_with_parameter(
+            this Parameterized_scenario_runner_parameter_capture_tests ctx,
+            int parameter)
+        {
+        }
+
+        public static Task Extension_method_with_parameter_async(
+            this Parameterized_scenario_runner_parameter_capture_tests ctx,
+            int parameter)
+        {
+            return Task.FromResult(0);
         }
     }
 }

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestStep.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestStep.cs
@@ -42,7 +42,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
         {
             return new StepDescriptor(
                 step.GetMethodInfo(),
-                (ctx, args) => Task.FromResult((IStepResultDescriptor) step.Invoke()));
+                (ctx, args) => Task.FromResult((IStepResultDescriptor)step.Invoke()));
         }
 
         public static StepDescriptor CreateAsync<TArg>(Action<TArg> step, Func<TArg> argEvaluator)
@@ -50,7 +50,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
             async Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
                 await Task.Yield();
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return DefaultStepResultDescriptor.Instance;
             }
 
@@ -78,7 +78,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
         {
             Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return Task.FromResult(DefaultStepResultDescriptor.Instance);
             }
 
@@ -90,7 +90,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
         {
             Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return Task.FromResult(DefaultStepResultDescriptor.Instance);
             }
 
@@ -104,7 +104,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
             async Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
                 await Task.Yield();
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return DefaultStepResultDescriptor.Instance;
             }
 
@@ -128,11 +128,27 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
             return new StepDescriptor(step.GetMethodInfo(), StepInvocation, p1, p2);
         }
 
+        public static StepDescriptor CreateAsync<TArg1, TArg2, TArg3>(Action<TArg1, TArg2, TArg3> step, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+        {
+            async Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
+            {
+                await Task.Yield();
+                step.Invoke((TArg1)args[0], (TArg2)args[1], (TArg3)args[2]);
+                return DefaultStepResultDescriptor.Instance;
+            }
+
+            var p1 = ParameterDescriptor.FromConstant(step.GetMethodInfo().GetParameters()[0], arg1);
+            var p2 = ParameterDescriptor.FromConstant(step.GetMethodInfo().GetParameters()[1], arg2);
+            var p3 = ParameterDescriptor.FromConstant(step.GetMethodInfo().GetParameters()[2], arg3);
+
+            return new StepDescriptor(step.GetMethodInfo(), StepInvocation, p1, p2, p3);
+        }
+
         public static StepDescriptor CreateSync<TArg>(Action<TArg> step, TArg arg)
         {
             Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return Task.FromResult(DefaultStepResultDescriptor.Instance);
             }
 
@@ -144,7 +160,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
         {
             Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
             {
-                step.Invoke((TArg) args[0]);
+                step.Invoke((TArg)args[0]);
                 return Task.FromResult(DefaultStepResultDescriptor.Instance);
             }
 

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestStep.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestStep.cs
@@ -112,6 +112,22 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
 
             return new StepDescriptor(step.GetMethodInfo(), StepInvocation, parameter);
         }
+
+        public static StepDescriptor CreateAsync<TArg1, TArg2>(Action<TArg1, TArg2> step, TArg1 arg1, TArg2 arg2)
+        {
+            async Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)
+            {
+                await Task.Yield();
+                step.Invoke((TArg1)args[0], (TArg2)args[1]);
+                return DefaultStepResultDescriptor.Instance;
+            }
+
+            var p1 = ParameterDescriptor.FromConstant(step.GetMethodInfo().GetParameters()[0], arg1);
+            var p2 = ParameterDescriptor.FromConstant(step.GetMethodInfo().GetParameters()[1], arg2);
+
+            return new StepDescriptor(step.GetMethodInfo(), StepInvocation, p1, p2);
+        }
+
         public static StepDescriptor CreateSync<TArg>(Action<TArg> step, TArg arg)
         {
             Task<IStepResultDescriptor> StepInvocation(object ctx, object[] args)


### PR DESCRIPTION
#### Details

Issue reference: #92

List of changes:
- Excluded this argument from step name display when extension method is used;
- Corrected parameter placement in name when having appended parameter of lower index than matching in-text replacement at the end of the name, like: `void Step_with_param(string other, string param)`

#### Checklist
- [x] Changes are backward compatible with previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
