### PR TITLE
#117 Added experimental ClassCollectionBehavior attribute allowing inter-class test parallelization

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -10,6 +10,7 @@ Summary:
 + #59 (Autofac)(New) Added LightBDD.Autofac integration for Autofac DI container
 + #67 (Fixie)(New) Added LightBdd.Fixie2 integration project with https://github.com/fixie/fixie
 + #70 (all)(New) Added Table<TRow> and VerifiableTable<TRow> to represent tabular step method parameters
++ #117 (XUnit2)(New) Added experimental ClassCollectionBehavior attribute allowing inter-class test parallelization
 
 Version 2.3.6
 ----------------------------------------

--- a/LightBDD.sln
+++ b/LightBDD.sln
@@ -71,7 +71,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.LightBDD.Fixie2", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightBDD.Autofac", "src\LightBDD.Autofac\LightBDD.Autofac.csproj", "{BA30A12E-C25B-47DF-9761-C3D752C59D3A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBDD.Autofac.UnitTests", "test\LightBDD.Autofac.UnitTests\LightBDD.Autofac.UnitTests.csproj", "{F130AD38-3852-43B1-840E-689E57D38790}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LightBDD.Autofac.UnitTests", "test\LightBDD.Autofac.UnitTests\LightBDD.Autofac.UnitTests.csproj", "{F130AD38-3852-43B1-840E-689E57D38790}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/examples/Example.LightBDD.XUnit2/ConfiguredLightBddScopeAttribute.cs
+++ b/examples/Example.LightBDD.XUnit2/ConfiguredLightBddScopeAttribute.cs
@@ -11,6 +11,12 @@ using LightBDD.XUnit2;
  * or customize it in a way that is shown below.
  */
 [assembly: ConfiguredLightBddScope]
+/*
+ * This is a LightBDD specific attribute enabling inter-class test parallelization
+ * (as long as class does not implement IClassFixture<T> or ICollectionFixture<T> attribute
+ * or have defined named collection)
+ */
+[assembly: ClassCollectionBehavior(AllowTestParallelization = true)]
 
 namespace Example.LightBDD.XUnit2
 {

--- a/examples/Example.LightBDD.XUnit2/ConfiguredLightBddScopeAttribute.cs
+++ b/examples/Example.LightBDD.XUnit2/ConfiguredLightBddScopeAttribute.cs
@@ -12,9 +12,9 @@ using LightBDD.XUnit2;
  */
 [assembly: ConfiguredLightBddScope]
 /*
- * This is a LightBDD specific attribute enabling inter-class test parallelization
- * (as long as class does not implement IClassFixture<T> or ICollectionFixture<T> attribute
- * or have defined named collection)
+ * This is a LightBDD specific, experimental attribute enabling inter-class test parallelization
+ * (as long as class does not implement IClassFixture<T> nor ICollectionFixture<T> attribute
+ * nor have defined named collection [Collection] attribute)
  */
 [assembly: ClassCollectionBehavior(AllowTestParallelization = true)]
 

--- a/src/LightBDD.XUnit2/ClassCollectionBehaviorAttribute.cs
+++ b/src/LightBDD.XUnit2/ClassCollectionBehaviorAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LightBDD.XUnit2
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class ClassCollectionBehaviorAttribute : Attribute
+    {
+        public bool AllowTestParallelization { get; set; }
+    }
+}

--- a/src/LightBDD.XUnit2/ClassCollectionBehaviorAttribute.cs
+++ b/src/LightBDD.XUnit2/ClassCollectionBehaviorAttribute.cs
@@ -1,10 +1,23 @@
 ﻿using System;
+using Xunit;
 
 namespace LightBDD.XUnit2
 {
+    /// <summary>
+    /// An EXPERIMENTAL attribute allowing to control inter-class test parallelization.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
     public sealed class ClassCollectionBehaviorAttribute : Attribute
     {
+        /// <summary>
+        /// If true, the class tests as well as test cases will run in parallel as long as following criteria are met: <br/>
+        /// * test class does not implement <see cref="IClassFixture{TFixture}"/> interface,<br/>
+        /// * test class does not implement <see cref="ICollectionFixture{TFixture}"/> interface,<br/>
+        /// * test class does not have <see cref="CollectionAttribute"/> attribute applied.<br/>
+        ///
+        /// The test parallelization honors the <see cref="CollectionBehaviorAttribute"/> and runner settings such as <see cref="CollectionBehaviorAttribute.DisableTestParallelization"/> or <see cref="CollectionBehaviorAttribute.MaxParallelThreads"/>. <br/>
+        /// The <see cref="CollectionBehavior.CollectionPerAssembly"/> setting is currently not honored.
+        /// </summary>
         public bool AllowTestParallelization { get; set; }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
@@ -1,0 +1,14 @@
+using LightBDD.Framework.ExecutionContext;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class AssemblySettings
+    {
+        private static readonly AsyncLocalContext<AssemblySettings> AsyncLocal = new AsyncLocalContext<AssemblySettings>();
+
+        public static AssemblySettings Current => AsyncLocal.Value ?? new AssemblySettings();
+        public static void SetSettings(AssemblySettings settings) => AsyncLocal.Value = settings;
+
+        public bool EnableInterClassParallelization { get; set; }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseRunner.cs
@@ -68,7 +68,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
                         var test = new XunitTest(TestCase, theoryDisplayName);
 
                         _testRunners.Add(new ScenarioTestRunner(test, MessageBus, TestClass, ConstructorArguments, methodToRun,
-                            convertedDataRow, SkipReason, BeforeAfterAttributes, Aggregator, CancellationTokenSource));
+                            convertedDataRow, SkipReason, BeforeAfterAttributes, new ExceptionAggregator(Aggregator), CancellationTokenSource));
                     }
                 }
             }

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseRunner.cs
@@ -91,9 +91,11 @@ namespace LightBDD.XUnit2.Implementation.Customization
             if (_dataDiscoveryException != null)
                 return RunTest_DataDiscoveryException();
 
-            var runSummary = new RunSummary();
-            foreach (var testRunner in _testRunners)
-                runSummary.Aggregate(await testRunner.RunScenarioAsync());
+
+            var runSummary = await TaskExecutor.RunAsync(
+                CancellationTokenSource.Token,
+                _testRunners.Select(r => (Func<Task<RunSummary>>)r.RunScenarioAsync).ToArray(),
+                TestCase.TestMethod.TestClass);
 
             // Run the cleanup here so we can include cleanup time in the run summary,
             // but save any exceptions so we can surface them during the cleanup phase,

--- a/src/LightBDD.XUnit2/Implementation/Customization/TaskExecutor.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TaskExecutor.cs
@@ -44,7 +44,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
             if (!AssemblySettings.Current.EnableInterClassParallelization)
                 return false;
 
-            if (testClass.TestCollection.CollectionDefinition != null)
+            if (testClass.Class.GetCustomAttributes(typeof(CollectionAttribute)).Any())
                 return false;
 
             return testClass.Class.Interfaces.All(type => !type.IsGenericType || !FixtureTypes.Contains(type.ToRuntimeType().GetGenericTypeDefinition()));

--- a/src/LightBDD.XUnit2/Implementation/Customization/TaskExecutor.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TaskExecutor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class TaskExecutor
+    {
+        private static readonly Type[] FixtureTypes = new[] { typeof(IClassFixture<>), typeof(ICollectionFixture<>) };
+
+        private static Task<RunSummary> RunOnThreadPool(CancellationToken token, Func<Task<RunSummary>> code)
+        {
+            if (SynchronizationContext.Current == null)
+                return Task.Run(code, token);
+
+            var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+            return Task.Factory.StartNew(code, token, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler, scheduler).Unwrap();
+        }
+
+        public static async Task<RunSummary> RunAsync(CancellationToken token, Func<Task<RunSummary>>[] tasks, ITestClass testClass)
+        {
+            var summary = new RunSummary();
+            if (tasks.Length > 1 && IsParallelizable(testClass))
+            {
+                var results = await Task.WhenAll(tasks.Select(task => RunOnThreadPool(token, task)));
+                foreach (var result in results)
+                    summary.Aggregate(result);
+            }
+            else
+            {
+                foreach (var task in tasks)
+                    summary.Aggregate(await task());
+            }
+
+            return summary;
+        }
+
+        private static bool IsParallelizable(ITestClass testClass)
+        {
+            if (!AssemblySettings.Current.EnableInterClassParallelization)
+                return false;
+
+            if (testClass.TestCollection.CollectionDefinition != null)
+                return false;
+
+            return testClass.Class.Interfaces.All(type => !type.IsGenericType || !FixtureTypes.Contains(type.ToRuntimeType().GetGenericTypeDefinition()));
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkAssemblyRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkAssemblyRunner.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class TestFrameworkAssemblyRunner : XunitTestAssemblyRunner
+    {
+        public TestFrameworkAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions) : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            return new TestFrameworkCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource)
+                .RunAsync();
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkClassRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkClassRunner.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class TestFrameworkClassRunner : XunitTestClassRunner
+    {
+        public TestFrameworkClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings) : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+        {
+        }
+
+        protected override async Task<RunSummary> RunTestMethodsAsync()
+        {
+            IEnumerable<IXunitTestCase> orderedTestCases;
+            try
+            {
+                orderedTestCases = TestCaseOrderer.OrderTestCases(TestCases);
+            }
+            catch (Exception ex)
+            {
+                var innerEx = ex.Unwrap();
+                DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Test case orderer '{TestCaseOrderer.GetType().FullName}' threw '{innerEx.GetType().FullName}' during ordering: {innerEx.Message}{Environment.NewLine}{innerEx.StackTrace}"));
+                orderedTestCases = TestCases.ToList();
+            }
+
+            var constructorArguments = CreateTestClassConstructorArguments();
+            var tasks = orderedTestCases
+                .GroupBy(tc => tc.TestMethod, TestMethodComparer.Instance)
+                .Select(method => (Func<Task<RunSummary>>)(() => RunTestMethodAsync(method.Key, (IReflectionMethodInfo)method.Key.Method, method, constructorArguments)))
+                .ToArray();
+
+            return await TaskExecutor.RunAsync(CancellationTokenSource.Token, tasks, TestClass);
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkCollectionRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkCollectionRunner.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class TestFrameworkCollectionRunner : XunitTestCollectionRunner
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public TestFrameworkCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource) : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+        {
+            return new TestFrameworkClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings).RunAsync();
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -17,11 +18,13 @@ namespace LightBDD.XUnit2.Implementation.Customization
 
         protected override void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
         {
-            var bddScopeAttribute = GetLightBddScopeAttribute();
+            var assembly = GetAssembly();
+            var bddScopeAttribute = GetLightBddScopeAttribute(assembly);
+            AssemblySettings.SetSettings(new AssemblySettings { EnableInterClassParallelization = ShallEnableInterClassParallelization(assembly, executionOptions) });
             bddScopeAttribute?.SetUp();
             try
             {
-                using (var assemblyRunner = new XunitTestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                using (var assemblyRunner = new TestFrameworkAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
                     assemblyRunner.RunAsync().Wait();
             }
             finally
@@ -30,18 +33,30 @@ namespace LightBDD.XUnit2.Implementation.Customization
             }
         }
 
-        private LightBddScopeAttribute GetLightBddScopeAttribute()
+        private bool ShallEnableInterClassParallelization(Assembly assembly, ITestFrameworkExecutionOptions executionOptions)
+        {
+            var attribute = assembly.GetCustomAttribute<CollectionBehaviorAttribute>();
+            if (executionOptions.DisableParallelization() ?? attribute?.DisableTestParallelization ?? false)
+                return false;
+            return assembly.GetCustomAttribute<ClassCollectionBehaviorAttribute>()?.AllowTestParallelization ?? false;
+        }
+
+        private Assembly GetAssembly()
         {
             var asmName = TestAssembly.Assembly.Name;
 #if NET45
-            var attribs = Assembly.Load(asmName)
+            return Assembly.Load(asmName);
 #else
-            var attribs = Assembly.Load(new AssemblyName(asmName))
+            return Assembly.Load(new AssemblyName(asmName));
 #endif
+        }
+        private LightBddScopeAttribute GetLightBddScopeAttribute(Assembly assembly)
+        {
+            var attribs = assembly
                 .GetCustomAttributes(typeof(LightBddScopeAttribute))
                 .Cast<LightBddScopeAttribute>().ToArray();
             if (attribs.Length > 1)
-                throw new InvalidOperationException($"Only one attribute of {typeof(LightBddScopeAttribute)} type can be defined in assembly {asmName}");
+                throw new InvalidOperationException($"Only one attribute of {typeof(LightBddScopeAttribute)} type can be defined in assembly {assembly.FullName}");
             return attribs.FirstOrDefault();
         }
     }


### PR DESCRIPTION
<!-- Add breif description here -->

#### Details
* Added `ClassCollectionBehaviorAttribute` allowing to enable inter-class test parallelization

the class tests as well as test cases will run in parallel as long as following criteria are met:
* test class does not implement `IClassFixture<T>` interface,
* test class does not implement `ICollectionFixture<T>` interface,
* test class does not have `CollectionAttribute` attribute applied.

Issue reference: #117 

#### Checklist
- [ ] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [x] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
