### PR TITLE
I134 Added State<T> helper struct for managing uninitialized shared state

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,7 @@ Version 2.4.2
 Summary:
 + #127 (LightBDD.Core)(Fix) Fixed FeatureRunnerRepository to instantiate FeatureRunner once per feature type
 + #128 (LightBDD.MsTest2)(Change) Updated progress notifiers to work with scenarios executed in parallel
++ #134 (LightBDD.Framework)(New) Added State<T> helper struct managing uninitialized shared state fields
 
 Version 2.4.1
 ----------------------------------------

--- a/src/LightBDD.Framework/State.cs
+++ b/src/LightBDD.Framework/State.cs
@@ -39,9 +39,9 @@ namespace LightBDD.Framework
         }
 
         /// <summary>
-        /// Returns the held value or <paramref name="defaultValue"/> if state is not initialized or held value is null (in case where <typeparam name="T"></typeparam> is reference type).
+        /// Returns the held value or <paramref name="defaultValue"/> if state is not initialized or held value is null (in case where <typeparamref name="T"/> is reference type).
         /// </summary>
-        public T GetValueOrDefault(T defaultValue = default(T))
+        public T GetValueOrDefault(T defaultValue = default)
         {
             if (!IsInitialized)
                 return defaultValue;

--- a/src/LightBDD.Framework/State.cs
+++ b/src/LightBDD.Framework/State.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace LightBDD.Framework
+{
+    /// <summary>
+    /// A helper struct designed to protect scenario state fields from being accessed without former initialization.
+    /// </summary>
+    public struct State<T>
+    {
+        private readonly T _value;
+        /// <summary>
+        /// Returns true if state is initialized, otherwise false.
+        /// The default instance of <see cref="State{T}"/> type represents uninitialized state.
+        /// </summary>
+        public bool IsInitialized { get; }
+
+        /// <summary>
+        /// Creates state instance, initialized with <paramref name="value"/> value.
+        /// The <see cref="IsInitialized"/> is always set to true, even if <paramref name="value"/> itself is null.
+        /// The <paramref name="value"/> is retrievable with <see cref="GetValue"/> method or implicit cast.
+        /// </summary>
+        /// <param name="value"></param>
+        public State(T value)
+        {
+            _value = value;
+            IsInitialized = true;
+        }
+
+        /// <summary>
+        /// Returns the held value, or throws <see cref="InvalidOperationException"/> if state is not initialized.
+        /// </summary>
+        /// <param name="memberName">If specified, the member name will be used in exception. If not specified, the state type will be used.</param>
+        /// <exception cref="InvalidOperationException">Thrown if value is not initialized.</exception>
+        public T GetValue(string memberName = null)
+        {
+            if (IsInitialized)
+                return _value;
+            throw new InvalidOperationException($"The {memberName ?? typeof(T).Name} state is not initialized.");
+        }
+
+        /// <summary>
+        /// Returns the held value or <paramref name="defaultValue"/> if state is not initialized or held value is null (in case where <typeparam name="T"></typeparam> is reference type).
+        /// </summary>
+        public T GetValueOrDefault(T defaultValue = default(T))
+        {
+            if (!IsInitialized)
+                return defaultValue;
+            return _value != null ? _value : defaultValue;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return IsInitialized ? _value?.ToString() : "<not set>";
+        }
+
+        /// <summary>
+        /// Implicit cast, converting <paramref name="value"/> to initialized state instance.
+        /// </summary>
+        public static implicit operator State<T>(T value) => new State<T>(value);
+        /// <summary>
+        /// Implicit cast, retrieving value of <paramref name="state"/> or throwing <see cref="InvalidOperationException"/> if state is not initialized.
+        /// </summary>
+        /// <param name="state"></param>
+        public static implicit operator T(State<T> state) => state.GetValue();
+    }
+}

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -8,6 +8,7 @@ using LightBDD.AcceptanceTests.Helpers.Builders;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results;
 using LightBDD.Core.Results.Parameters.Tabular;
+using LightBDD.Framework;
 using LightBDD.Framework.Reporting.Formatters;
 using LightBDD.Framework.Resources;
 using LightBDD.UnitTests.Helpers;
@@ -22,10 +23,13 @@ namespace LightBDD.AcceptanceTests.Features
     {
         private readonly ResourceHandle<ChromeDriver> _driverHandle;
         private static string BaseDirectory => AppContext.BaseDirectory;
+        private State<ChromeDriver> _driver;
+        private State<IFeatureResult[]> _features;
+
         private string HtmlFileName { get; }
-        private ChromeDriver Driver { get; set; }
-        private IFeatureResult[] Features { get; set; }
+        private ChromeDriver Driver => _driver.GetValue(nameof(Driver));
         private ResultBuilder ResultBuilder { get; }
+        private IFeatureResult[] Features => _features.GetValue(nameof(Features));
 
         public HtmlReportContext(ResourceHandle<ChromeDriver> driverHandle)
         {
@@ -62,14 +66,14 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Given_a_html_report_is_created()
         {
-            Features = ResultBuilder.Build();
+            _features = ResultBuilder.Build();
             var htmlText = FormatResults(Features.ToArray());
             File.WriteAllText(HtmlFileName, htmlText);
         }
 
         public async Task When_a_html_report_is_opened()
         {
-            Driver = await _driverHandle.ObtainAsync();
+            _driver = await _driverHandle.ObtainAsync();
             Driver.Navigate().GoToUrl(HtmlFileName);
             Driver.EnsurePageIsLoaded();
         }

--- a/test/LightBDD.Framework.UnitTests/State_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/State_tests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace LightBDD.Framework.UnitTests
+{
+    [TestFixture]
+    public class State_tests
+    {
+        [Test]
+        public void State_should_be_uninitialized_by_default()
+        {
+            State<int> state = default;
+            Assert.False(state.IsInitialized);
+            Assert.False(new State<bool>().IsInitialized);
+        }
+
+        [Test]
+        public void It_should_be_possible_to_set_and_retrieve_state()
+        {
+            var state = new State<int>();
+            Assert.False(state.IsInitialized);
+
+            state = 0;
+            AssertInitializedValue(state, 0);
+
+            state = new State<int>(5);
+            AssertInitializedValue(state, 5);
+
+            int x = state;
+            Assert.That(x, Is.EqualTo(5));
+
+            var state2 = new State<string>("text");
+            AssertInitializedValue(state2, "text");
+
+            state2 = null;
+            AssertInitializedValue(state2, null);
+
+            string s = state2;
+            Assert.That(s, Is.Null);
+        }
+
+        [Test]
+        public void GetValue_should_throw_if_state_is_not_initialized()
+        {
+            State<bool> state = default;
+
+            var ex = Assert.Throws<InvalidOperationException>(() => state.GetValue());
+            Assert.That(ex.Message, Is.EqualTo("The Boolean state is not initialized."));
+
+            ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                bool x = state;
+            });
+            Assert.That(ex.Message, Is.EqualTo("The Boolean state is not initialized."));
+
+            ex = Assert.Throws<InvalidOperationException>(() => state.GetValue("myField"));
+            Assert.That(ex.Message, Is.EqualTo("The myField state is not initialized."));
+        }
+
+        [Test]
+        public void GetValueOrDefault_should_return_value_if_initialized_or_default_if_not_or_value_is_null()
+        {
+            var defaultInt = 5;
+            var defaultString = "default";
+
+            State<int> state = default;
+            Assert.AreEqual(defaultInt, state.GetValueOrDefault(defaultInt));
+            state = 0;
+            Assert.AreEqual(0, state.GetValueOrDefault(defaultInt));
+
+            State<string> state2 = default;
+            Assert.AreEqual(defaultString, state2.GetValueOrDefault(defaultString));
+
+            state2 = "value";
+            Assert.AreEqual("value", state2.GetValueOrDefault(defaultString));
+
+            state2 = null;
+            Assert.AreEqual(defaultString, state2.GetValueOrDefault(defaultString));
+        }
+
+        private static void AssertInitializedValue<T>(State<T> state, T expected)
+        {
+            Assert.True(state.IsInitialized);
+            Assert.AreEqual(expected, state.GetValue());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Add breif description here -->

#### Details

Added `State<T>` helper struct for managing uninitialized shared state, offering:
* `IsInitialized` property returning false if state has not been initialized,
* `GetValue()` method retrieving value or throwing meaningful exception for uninitialized state (it's possible to specify the member name that will be included in exception)
* `GetValueOrDefault(T defaultValue = default(T))` method returning default value if state is not initialized or has null value (in case T is reference type),
* implicit conversions from T and to T, allowing code like:
  ```c#
  State<int> _field;
  /* ... */
  _field = 5; // sets value
  /* ... */
  int variable = _field; // gets value or throws if not initialized
  ```

Usage patterns:

1. Simple usage when state is only set or get
```c#
class My_feature: FeatureFixture
{
    private State<int> _productId;
    private State<Product> _product;

    public void Given_product_id(int id)
    {
        // implicit cast
        _productId = id;
    }

    public void When_product_is_loaded()
    {
        // implicit cast of State<int> _id to int - it will throw meaningful exception if uninitialized
        _product = GetProductById(_id);
    }
}
```
2. If additional operations are made on state, it's better to wrap it in helper property
```c#
public class My_feature: FeatureFixture
{
    private State<Product> _product;

    //will throw meaningful exception if used without former initialization
    private Product Product => _product.GetValue(nameof(Product));

    public void When_I_request_a_product_by_reference(string reference)
    {
        //it's possible to assign Product to State<Product> field
        _product = _client.GetProduct(reference);
    }

    public void Then_the_product_should_have_name(string name)
    {
        Assert.That(Product.Name, Is.EqualTo(name));
    }
}
```

Issue reference: #134

List of changes:
* Added `State<T>` helper struct.

#### Checklist
- [x] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
