### PR TITLE
#137 Unable to specify absolute path to report location on Linux

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -7,6 +7,7 @@ Summary:
 + #127 (LightBDD.Core)(Fix) Fixed FeatureRunnerRepository to instantiate FeatureRunner once per feature type
 + #128 (LightBDD.MsTest2)(Change) Updated progress notifiers to work with scenarios executed in parallel
 + #134 (LightBDD.Framework)(New) Added State<T> helper struct managing uninitialized shared state fields
++ #137 (LightBDD.Framework)(Bug) Unable to specify absolute path to report location on Linux
 
 Version 2.4.1
 ----------------------------------------

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
@@ -49,7 +49,6 @@ namespace LightBDD.Framework.Reporting.UnitTests
             var outputPath = @"\\machine\c$\reports\output.txt";
 
             var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
-            var expected = Path.GetFullPath(outputPath);
             Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
             Assert.That(writer.FullOutputPath, Is.EqualTo(outputPath));
         }

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_tests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.IO;
-using LightBDD.Core.Results;
+﻿using LightBDD.Core.Results;
 using LightBDD.Framework.Reporting.Formatters;
 using Moq;
 using NUnit.Framework;
+using System;
+using System.IO;
 
 namespace LightBDD.Framework.Reporting.UnitTests
 {
@@ -13,27 +13,55 @@ namespace LightBDD.Framework.Reporting.UnitTests
         [Test]
         public void It_should_use_appdomain_base_directory_if_output_starts_with_tilde()
         {
-            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "~" + Path.DirectorySeparatorChar + "output.txt");
+            var outputPath = "~" + Path.DirectorySeparatorChar + "output.txt";
+
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
             var expected = Path.GetFullPath(BaseDirectory + Path.DirectorySeparatorChar + "output.txt");
-            Assert.That(writer.OutputPath, Is.EqualTo("~" + Path.DirectorySeparatorChar + "output.txt"));
+            Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
             Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
         }
 
         [Test]
         public void It_should_use_working_directory_if_output_is_relative_path()
         {
-            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "output.txt");
-            var expected = Path.GetFullPath("output.txt");
-            Assert.That(writer.OutputPath, Is.EqualTo("output.txt"));
+            var outputPath = "output.txt";
+
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
+            var expected = Path.GetFullPath(outputPath);
+            Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
             Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
         }
 
         [Test]
         public void It_should_preserve_output_path_if_it_is_absolute()
         {
-            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), "c:" + Path.DirectorySeparatorChar + "output.txt");
-            var expected = Path.GetFullPath("c:" + Path.DirectorySeparatorChar + "output.txt");
-            Assert.That(writer.OutputPath, Is.EqualTo("c:" + Path.DirectorySeparatorChar + "output.txt"));
+            var outputPath = "c:" + Path.DirectorySeparatorChar + "output.txt";
+
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
+            var expected = Path.GetFullPath(outputPath);
+            Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
+            Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_preserve_output_path_if_it_is_unc()
+        {
+            var outputPath = @"\\machine\c$\reports\output.txt";
+
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
+            var expected = Path.GetFullPath(outputPath);
+            Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
+            Assert.That(writer.FullOutputPath, Is.EqualTo(outputPath));
+        }
+
+        [Test]
+        public void It_should_preserve_output_path_but_with_working_directory_root_if_it_refers_to_root_directory()
+        {
+            var outputPath = Path.DirectorySeparatorChar + "output.txt";
+
+            var writer = new ReportFileWriter(Mock.Of<IReportFormatter>(), outputPath);
+            var expected = Path.GetFullPath(outputPath);
+            Assert.That(writer.OutputPath, Is.EqualTo(outputPath));
             Assert.That(writer.FullOutputPath, Is.EqualTo(expected));
         }
 
@@ -53,7 +81,7 @@ namespace LightBDD.Framework.Reporting.UnitTests
 
             Mock.Get(formatter)
                 .Setup(f => f.Format(It.IsAny<Stream>(), results))
-                .Callback((Stream stream,IFeatureResult[] r) =>
+                .Callback((Stream stream, IFeatureResult[] r) =>
                 {
                     using (var writer = new StreamWriter(stream))
                         writer.Write(expectedFileContent);


### PR DESCRIPTION
Before the fix it was not possible to specify absolute path for the report files on Linux (see #137 details).

With this fix, the report file paths should properly handle paths starting with directory separator  characters (like `\`, `/`), as well as UNC paths.

#### Details

Issue reference: #137

List of changes:

|Env|Working dir|Base dir|Output Path|Result|
|--|--|--|--|--|
|Windows|d:\temp|c:\dev\project\bin|~\reports\file.html|c:\dev\project\bin\reports\file.html|
|Windows|d:\temp|c:\dev\project\bin|reports\file.html|d:\temp\reports\file.html|
|Windows|d:\temp|c:\dev\project\bin|\reports\file.html|d:\reports\file.html|
|Windows|d:\temp|c:\dev\project\bin|\\\\machine\reports\file.html|\\\\machine\reports\file.html|
|Windows|d:\temp|c:\dev\project\bin|f:\reports\file.html|f:\reports\file.html|
|Linux|/tmp|/tmp/dev/project/bin|~/reports/file.html|/tmp/dev/project/bin/reports/file.html|
|Linux|/tmp|/tmp/dev/project/bin|reports/file.html|/tmp/reports/file.html|
|Linux|/tmp|/tmp/dev/project/bin|/home/foo/reports/file.html|/home/foo/reports/file.html|

#### Checklist
- [ ] Changes are backward compatible with previous version of Core and Framework,
- [ ] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
