### PR TITLE
#148 Expect.To.BeAnyTrue<T>() with no sub-expectations should fail

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,8 +4,9 @@ LightBDD
 Version 2.5.0
 ----------------------------------------
 Summary:
-+ #60 Implemented Project Templates in VSIX extension
-+ #61 Implemented snippets for scenario and composite steps in VSIX extension
++ #60 (VSIX)(New) Implemented Project Templates in VSIX extension
++ #61 (VSIX)(New) Implemented snippets for scenario and composite steps in VSIX extension
++ #148 (Framework)(Fix) Expect.To.BeAnyTrue<T>() with no sub-expectations should fail
 
 Version 2.4.3
 ----------------------------------------

--- a/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
+++ b/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using LightBDD.Core.Formatting.Values;
+using LightBDD.Framework.Expectations.Implementation;
+using LightBDD.Framework.Parameters;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
-using LightBDD.Core.Formatting.Values;
-using LightBDD.Framework.Expectations.Implementation;
-using LightBDD.Framework.Parameters;
 
 namespace LightBDD.Framework.Expectations
 {
@@ -320,7 +320,7 @@ namespace LightBDD.Framework.Expectations
         /// <param name="expectationBuilder">Expectation builder</param>
         public static Expectation<T> BeAllTrue<T>(this IExpectationComposer composer, params Func<IExpectationComposer, IExpectation<T>>[] expectationBuilder)
         {
-            return composer.Compose(new AndExpectation<T>(expectationBuilder.Select(x => x.Invoke(Expect.To)).ToArray()));
+            return composer.Compose(new AndExpectation<T>("all true ", expectationBuilder.Select(x => x.Invoke(Expect.To)).ToArray()));
         }
 
         /// <summary>
@@ -331,7 +331,7 @@ namespace LightBDD.Framework.Expectations
         /// <param name="expectationBuilder">Expectation builder</param>
         public static Expectation<T> BeAnyTrue<T>(this IExpectationComposer composer, params Func<IExpectationComposer, IExpectation<T>>[] expectationBuilder)
         {
-            return composer.Compose(new OrExpectation<T>(expectationBuilder.Select(x => x.Invoke(Expect.To)).ToArray()));
+            return composer.Compose(new OrExpectation<T>("any true ", expectationBuilder.Select(x => x.Invoke(Expect.To)).ToArray()));
         }
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace LightBDD.Framework.Expectations
         /// </summary>
         public static Expectation<T> And<T>(this IExpectation<T> expectation, Func<IExpectationComposer, IExpectation<T>> andExpectation)
         {
-            return new AndExpectation<T>(expectation, andExpectation(Expect.To));
+            return new AndExpectation<T>(string.Empty, expectation, andExpectation(Expect.To));
         }
 
         /// <summary>
@@ -347,7 +347,7 @@ namespace LightBDD.Framework.Expectations
         /// </summary>
         public static Expectation<T> Or<T>(this IExpectation<T> expectation, Func<IExpectationComposer, IExpectation<T>> orExpectation)
         {
-            return new OrExpectation<T>(expectation, orExpectation(Expect.To));
+            return new OrExpectation<T>(string.Empty, expectation, orExpectation(Expect.To));
         }
 
         /// <summary>

--- a/src/LightBDD.Framework/Expectations/Implementation/AndExpectation.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/AndExpectation.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using LightBDD.Core.Formatting.Values;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using LightBDD.Core.Formatting.Values;
 
 namespace LightBDD.Framework.Expectations.Implementation
 {
     [DebuggerStepThrough]
     internal class AndExpectation<T> : Expectation<T>
     {
+        private readonly string _prefix;
         private readonly IExpectation<T>[] _expectations;
 
-        public AndExpectation(params IExpectation<T>[] expectations)
+        public AndExpectation(string prefix, params IExpectation<T>[] expectations)
         {
+            _prefix = prefix;
             _expectations = expectations;
         }
 
@@ -32,7 +34,7 @@ namespace LightBDD.Framework.Expectations.Implementation
 
         public override string Format(IValueFormattingService formattingService)
         {
-            return $"({string.Join(" and ", _expectations.Select(x => x.Format(formattingService)))})";
+            return $"{_prefix}({string.Join(" and ", _expectations.Select(x => x.Format(formattingService)))})";
         }
     }
 }

--- a/src/LightBDD.Framework/Expectations/Implementation/OrExpectation.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/OrExpectation.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using LightBDD.Core.Formatting.Values;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using LightBDD.Core.Formatting.Values;
 
 namespace LightBDD.Framework.Expectations.Implementation
 {
     [DebuggerStepThrough]
     internal class OrExpectation<T> : Expectation<T>
     {
+        private readonly string _prefix;
         private readonly IExpectation<T>[] _expectations;
 
-        public OrExpectation(params IExpectation<T>[] expectations)
+        public OrExpectation(string prefix, params IExpectation<T>[] expectations)
         {
+            _prefix = prefix;
             _expectations = expectations;
         }
 
@@ -25,14 +27,12 @@ namespace LightBDD.Framework.Expectations.Implementation
                     return ExpectationResult.Success;
                 details.Add(result.Message);
             }
-            return !details.Any()
-                ? ExpectationResult.Success
-                : FormatFailure(formattingService, $"got: '{formattingService.FormatValue(value)}'", details);
+            return FormatFailure(formattingService, $"got: '{formattingService.FormatValue(value)}'", details);
         }
 
         public override string Format(IValueFormattingService formattingService)
         {
-            return $"({string.Join(" or ", _expectations.Select(x => x.Format(formattingService)))})";
+            return $"{_prefix}({string.Join(" or ", _expectations.Select(x => x.Format(formattingService)))})";
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Expectations/AllTrueExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/AllTrueExpectation_tests.cs
@@ -22,8 +22,17 @@ namespace LightBDD.Framework.UnitTests.Expectations
         }
 
         [Test]
-        [TestCase(3, "expected: (greater than '2' and less than '5' and not equals '3'), but got: '3'\n\texpected: not equals '3', but it was")]
-        [TestCase(6, "expected: (greater than '2' and less than '5' and not equals '3'), but got: '6'\n\texpected: less than '5', but got: '6'")]
+        public void It_should_pass_when_no_parameters()
+        {
+            var expectation = Expect.To.BeAllTrue<int>();
+            var result = expectation.Verify(0, ValueFormattingServices.Current);
+            Assert.True(result);
+            Assert.That(expectation.ToString(), Is.EqualTo("all true ()"));
+        }
+
+        [Test]
+        [TestCase(3, "expected: all true (greater than '2' and less than '5' and not equals '3'), but got: '3'\n\texpected: not equals '3', but it was")]
+        [TestCase(6, "expected: all true (greater than '2' and less than '5' and not equals '3'), but got: '6'\n\texpected: less than '5', but got: '6'")]
         public void It_should_fail_validation(int value, string expectedMessage)
         {
             var expectation = Expect.To.BeAllTrue(x => x.BeGreaterThan(2), x => x.BeLessThan(5), x => x.Not.Equal(3));
@@ -33,7 +42,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
         }
 
         [Test]
-        [TestCase(4, "expected: not (greater than '2' and less than '5' and not equals '3'), but it was")]
+        [TestCase(4, "expected: not all true (greater than '2' and less than '5' and not equals '3'), but it was")]
         public void It_should_fail_negated_validation(int value, string expectedMessage)
         {
             var expectation = Expect.To.Not.BeAllTrue(x => x.BeGreaterThan(2), x => x.BeLessThan(5), x => x.Not.Equal(3));
@@ -45,7 +54,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
         [Test]
         public void It_should_format()
         {
-            Assert.That(Expect.To.BeAllTrue(x => x.BeGreaterThan(2), x => x.BeLessThan(5), x => x.Not.Equal(3)).ToString(), Is.EqualTo("(greater than '2' and less than '5' and not equals '3')"));
+            Assert.That(Expect.To.BeAllTrue(x => x.BeGreaterThan(2), x => x.BeLessThan(5), x => x.Not.Equal(3)).ToString(), Is.EqualTo("all true (greater than '2' and less than '5' and not equals '3')"));
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Expectations/AnyTrueExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/AnyTrueExpectation_tests.cs
@@ -24,7 +24,15 @@ namespace LightBDD.Framework.UnitTests.Expectations
         }
 
         [Test]
-        [TestCase(3, "expected: (less than '2' or greater than '5' or equals '4'), but got: '3'\n\texpected: less than '2', but got: '3'\n\texpected: greater than '5', but got: '3'\n\texpected: equals '4', but got: '3'")]
+        public void It_should_fail_when_no_parameters()
+        {
+            var result = Expect.To.BeAnyTrue<int>().Verify(0, ValueFormattingServices.Current);
+            Assert.False(result);
+            Assert.That(result.Message, Is.EqualTo("expected: any true (), but got: '0'"));
+        }
+
+        [Test]
+        [TestCase(3, "expected: any true (less than '2' or greater than '5' or equals '4'), but got: '3'\n\texpected: less than '2', but got: '3'\n\texpected: greater than '5', but got: '3'\n\texpected: equals '4', but got: '3'")]
         public void It_should_fail_validation(int value, string expectedMessage)
         {
             var expectation = Expect.To.BeAnyTrue(x => x.BeLessThan(2), x => x.BeGreaterThan(5), x => x.Equal(4));
@@ -34,9 +42,9 @@ namespace LightBDD.Framework.UnitTests.Expectations
         }
 
         [Test]
-        [TestCase(4, "expected: not (less than '2' or greater than '5' or equals '4'), but it was")]
-        [TestCase(1, "expected: not (less than '2' or greater than '5' or equals '4'), but it was")]
-        [TestCase(6, "expected: not (less than '2' or greater than '5' or equals '4'), but it was")]
+        [TestCase(4, "expected: not any true (less than '2' or greater than '5' or equals '4'), but it was")]
+        [TestCase(1, "expected: not any true (less than '2' or greater than '5' or equals '4'), but it was")]
+        [TestCase(6, "expected: not any true (less than '2' or greater than '5' or equals '4'), but it was")]
         public void It_should_fail_negated_validation(int value, string expectedMessage)
         {
             var expectation = Expect.To.Not.BeAnyTrue(x => x.BeLessThan(2), x => x.BeGreaterThan(5), x => x.Equal(4));
@@ -48,7 +56,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
         [Test]
         public void It_should_format()
         {
-            Assert.That(Expect.To.BeAnyTrue(x => x.BeLessThan(2), x => x.BeGreaterThan(5), x => x.Equal(4)).ToString(), Is.EqualTo("(less than '2' or greater than '5' or equals '4')"));
+            Assert.That(Expect.To.BeAnyTrue(x => x.BeLessThan(2), x => x.BeGreaterThan(5), x => x.Equal(4)).ToString(), Is.EqualTo("any true (less than '2' or greater than '5' or equals '4')"));
         }
     }
 }


### PR DESCRIPTION
<!-- Add breif description here -->

#### Details

Issue reference: #148

List of changes:
* Expect.To.BeAnyTrue<T>() with no sub-expectations should fail
* Rendered `BeAnyTrue(...)` as `any true (...)`
* Rendered `BeAllTrue(...)` as `all true (...)`

#### Checklist
- [ ] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
