### PR TITLE
#160 Updated Fixie dependency to v2.0.2 to detect tests in VS 15.8 and higher

### DIFF
--- a/examples/Example.LightBDD.Fixie2/Example.LightBDD.Fixie2.csproj
+++ b/examples/Example.LightBDD.Fixie2/Example.LightBDD.Fixie2.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="Fixie" Version="2.0.0" />
+    <PackageReference Include="Fixie" Version="2.0.2" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
+++ b/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
@@ -24,7 +24,7 @@ High level features:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fixie" Version="2.0.0" />
+    <PackageReference Include="Fixie" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LightBDD.Fixie2.UnitTests/LightBDD.Fixie2.UnitTests.csproj
+++ b/test/LightBDD.Fixie2.UnitTests/LightBDD.Fixie2.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="Fixie" Version="2.0.0" />
+    <PackageReference Include="Fixie" Version="2.0.2" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
#### Details

Issue reference: #160

List of changes:
* Updated Fixie dependency to v2.0.2 to detect tests in VS 15.8 and higher

#### Checklist
- [ ] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
