### PR TITLE
#163 Updated DefaultExceptionFormatter to exclude "End of stack trace" lines and fixed tests

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 LightBDD
 ===========================================
 
+Version vNext
+----------------------------------------
++ #163 (Core)(Change) Updated DefaultExceptionFormatter to exclude "End of stack trace" lines
+
 Version 2.5.0
 ----------------------------------------
 Summary:

--- a/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
+++ b/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
@@ -37,9 +37,20 @@ namespace LightBDD.Core.Formatting.ExceptionFormatting
             var builder = new StringBuilder();
 
             FormatExceptionDetails(exception, builder);
+            string last = null;
+            var added = 0;
+            foreach (var line in exception.StackTrace.Split('\n').Where(ShouldPrintLine))
+            {
+                var current = line.Trim();
+                if (current.StartsWith("--- End of") && current == last)
+                    continue;
 
-            foreach (var line in exception.StackTrace.Split('\n').Where(ShouldPrintLine).Take(_stackTraceLinesLimit))
-                builder.AppendLine(line.Trim());
+                last = current;
+                builder.AppendLine(current);
+
+                if (++added >= _stackTraceLinesLimit)
+                    break;
+            }
 
             return builder.ToString();
         }

--- a/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
+++ b/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
@@ -37,26 +37,16 @@ namespace LightBDD.Core.Formatting.ExceptionFormatting
             var builder = new StringBuilder();
 
             FormatExceptionDetails(exception, builder);
-            string last = null;
-            var added = 0;
-            foreach (var line in exception.StackTrace.Split('\n').Where(ShouldPrintLine))
-            {
-                var current = line.Trim();
-                if (current.StartsWith("--- End of") && current == last)
-                    continue;
-
-                last = current;
-                builder.AppendLine(current);
-
-                if (++added >= _stackTraceLinesLimit)
-                    break;
-            }
+            foreach (var line in exception.StackTrace.Split('\n').Where(ShouldPrintLine).Take(_stackTraceLinesLimit))
+                builder.AppendLine(line.Trim());
 
             return builder.ToString();
         }
 
         private bool ShouldPrintLine(string line)
         {
+            if (line.StartsWith("--- End "))
+                return false;
             foreach (var excludeMember in _excludeMembers)
             {
                 if (excludeMember.IsMatch(line))

--- a/test/LightBDD.Autofac.UnitTests/AssemblyInfo.cs
+++ b/test/LightBDD.Autofac.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/test/LightBDD.Core.UnitTests/AssemblyInfo.cs
+++ b/test/LightBDD.Core.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
@@ -150,8 +150,7 @@ namespace LightBDD.Core.UnitTests
 
             ex.AssertStackTraceMatching(@"^\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ProcessStatus[^\n]*
 \s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ExecuteAsync[^\n]*
-\s*at LightBDD.Core.Extensibility.Execution.Implementation.DecoratingExecutor.RecursiveExecutor`1.<ExecuteAsync>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
+\s*at LightBDD.Core.Extensibility.Execution.Implementation.DecoratingExecutor.RecursiveExecutor[^\n]+ExecuteAsync[^\n]*
 ([^\n]*
 )?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner.TestScenario[^\n]*");
         }
@@ -166,10 +165,9 @@ namespace LightBDD.Core.UnitTests
                 .TestScenarioAsync(My_failed_async_step));
 
             ex.AssertStackTraceMatching(@"^\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ProcessStatus[^\n]*
-\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.<ProcessStatusAsync>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
+\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator[^\n]+ProcessStatusAsync[^\n]*
 ([^\n]*
-)?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner.<TestScenarioAsync>[^\n]*");
+)?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner[^\n]+TestScenarioAsync[^\n]*");
         }
 
         [Test]
@@ -184,8 +182,7 @@ namespace LightBDD.Core.UnitTests
 
             ex.AssertStackTraceMatching(@"^\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ProcessStatus[^\n]*
 \s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ExecuteAsync[^\n]*
-\s*at LightBDD.Core.Extensibility.Execution.Implementation.DecoratingExecutor.RecursiveExecutor`1.<ExecuteAsync>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
+\s*at LightBDD.Core.Extensibility.Execution.Implementation.DecoratingExecutor.RecursiveExecutor[^\n]+ExecuteAsync[^\n]*
 ([^\n]*
 )?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner.TestScenario[^\n]*");
         }
@@ -201,10 +198,9 @@ namespace LightBDD.Core.UnitTests
                 .TestScenarioAsync(Some_async_step));
 
             ex.AssertStackTraceMatching(@"^\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.ProcessStatus[^\n]*
-\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator.<ProcessStatusAsync>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
+\s*at LightBDD.Core.UnitTests.CoreBddRunner_execution_extension_tests.MyThrowingDecorator[^\n]+ProcessStatusAsync[^\n]*
 ([^\n]*
-)?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner.<TestScenarioAsync>[^\n]*");
+)?\s*at LightBDD.UnitTests.Helpers.TestableIntegration.TestSyntaxRunner[^\n]+TestScenarioAsync[^\n]*");
         }
 
         [Test]

--- a/test/LightBDD.Core.UnitTests/Formatting/ExceptionFormatting/DefaultExceptionFormatter_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Formatting/ExceptionFormatting/DefaultExceptionFormatter_tests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using LightBDD.Core.Formatting.ExceptionFormatting;
+using NUnit.Framework;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using LightBDD.Core.Formatting.ExceptionFormatting;
-using NUnit.Framework;
 #pragma warning disable 1998
 
 namespace LightBDD.Core.UnitTests.Formatting.ExceptionFormatting
@@ -25,10 +25,11 @@ namespace LightBDD.Core.UnitTests.Formatting.ExceptionFormatting
             var exception = await MakeSampleException();
 
             var formattedDetails = new DefaultExceptionFormatter().Format(exception);
+            Console.WriteLine(formattedDetails);
             var stackTraceLinesNumber = formattedDetails
                 .Split('\n')
                 .AsEnumerable()
-                .Count(l => l.StartsWith("at ") || l.StartsWith("---"));
+                .Count(l => l.StartsWith("at ") || l.StartsWith("--- "));
 
             Assert.That(stackTraceLinesNumber, Is.EqualTo(8));
         }
@@ -43,23 +44,32 @@ namespace LightBDD.Core.UnitTests.Formatting.ExceptionFormatting
 		---> System.AggregateException : One or more errors occurred.*
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<ThrowSampleExceptionAsync>[^\n]*
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<HandleInnerException>[^\n]*
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<WrapInnerExceptionLevel2>[^\n]*
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<WrapInnerExceptionLevel1>[^\n]*
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<MakeSampleException>[^\n]*$";
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
+--- End of stack trace from previous location where exception was thrown ---
+(\s*at System.Runtime.[^\n]+.Throw[^\n]*
+(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
+--- End of stack trace from previous location where exception was thrown ---
+(\s*at System.Runtime.[^\n]+.Throw[^\n]*
+(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
+)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+MakeSampleException[^\n]*
+$";
 
             var formattedDetails = new DefaultExceptionFormatter().WithAllMembersIncludedOnStackTrace().Format(exception);
             Assert.That(formattedDetails.Replace("\r", ""), Does.Match(expectedExceptionDetails.Replace("\r", "")));
@@ -75,7 +85,7 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
 		---> System.AggregateException : One or more errors occurred\..*
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<ThrowSampleExceptionAsync>[^\n]*
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]*
 --- End of stack trace from previous location where exception was thrown ---$";
 
             var formattedDetails = new DefaultExceptionFormatter().WithStackTraceLinesLimit(2).Format(exception);
@@ -89,20 +99,14 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
 
             var expectedExceptionDetails = @"^System.Exception : ThrowSampleExceptionAsync
 	---> System.InvalidOperationException : ThrowInnerExceptionAsync
-		---> System.AggregateException : One or more errors occurred\..*
+		---> System.AggregateException : One or more errors occurred.*
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<ThrowSampleExceptionAsync>[^\n]*
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]+
 --- End of stack trace from previous location where exception was thrown ---
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<HandleInnerException>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<WrapInnerExceptionLevel2>[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests.<WrapInnerExceptionLevel1>[^\n]*
---- End of stack trace from previous location where exception was thrown ---$";
-
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+MakeSampleException[^\n]+$";
             var formattedDetails = new DefaultExceptionFormatter()
-                .WithMembersExcludedFromStackTrace("System.Runtime.*")
+                .WithMembersExcludedFromStackTrace("System.Runtime.*",".*RecurrentCall.*")
                 .Format(exception);
             Assert.That(formattedDetails.Replace("\r", ""), Does.Match(expectedExceptionDetails.Replace("\r", "")));
         }
@@ -112,7 +116,7 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
             Exception exception = null;
             try
             {
-                await WrapInnerExceptionLevel1();
+                await RecurrentCall(4);
             }
             catch (Exception e)
             {
@@ -122,19 +126,14 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
             return exception;
         }
 
-        private async Task WrapInnerExceptionLevel1()
+        private async Task RecurrentCall(int i)
         {
-            await WrapInnerExceptionLevel2();
-        }
-
-        private async Task WrapInnerExceptionLevel2()
-        {
-            await HandleInnerException();
-        }
-
-        private async Task HandleInnerException()
-        {
-            await ThrowSampleExceptionAsync();
+            if (i > 0)
+                await RecurrentCall(i - 1);
+            else
+            {
+                await ThrowSampleExceptionAsync();
+            }
         }
 
         private async Task ThrowSampleExceptionAsync()

--- a/test/LightBDD.Core.UnitTests/Formatting/ExceptionFormatting/DefaultExceptionFormatter_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Formatting/ExceptionFormatting/DefaultExceptionFormatter_tests.cs
@@ -45,30 +45,12 @@ namespace LightBDD.Core.UnitTests.Formatting.ExceptionFormatting
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
 at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
---- End of stack trace from previous location where exception was thrown ---
+)+)?(at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
 (\s*at System.Runtime.[^\n]+.Throw[^\n]*
 (at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-(\s*at System.Runtime.[^\n]+.Throw[^\n]*
-(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-(\s*at System.Runtime.[^\n]+.Throw[^\n]*
-(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-(\s*at System.Runtime.[^\n]+.Throw[^\n]*
-(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]*
---- End of stack trace from previous location where exception was thrown ---
-(\s*at System.Runtime.[^\n]+.Throw[^\n]*
-(at System.Runtime.CompilerServices.TaskAwaiter.[^\n]*
-)+)?at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+MakeSampleException[^\n]*
+)+)?)+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+MakeSampleException[^\n]*
 $";
 
             var formattedDetails = new DefaultExceptionFormatter().WithAllMembersIncludedOnStackTrace().Format(exception);
@@ -85,8 +67,8 @@ $";
 		---> System.AggregateException : One or more errors occurred\..*
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
-at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]*
---- End of stack trace from previous location where exception was thrown ---$";
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]+
+at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+RecurrentCall[^\n]+$";
 
             var formattedDetails = new DefaultExceptionFormatter().WithStackTraceLinesLimit(2).Format(exception);
             Assert.That(formattedDetails.Replace("\r", ""), Does.Match(expectedExceptionDetails.Replace("\r", "")));
@@ -103,7 +85,6 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
 			---> System.NotImplementedException : Not implemented yet
 			---> System.Exception : other
 at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+ThrowSampleExceptionAsync[^\n]+
---- End of stack trace from previous location where exception was thrown ---
 at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormatter_tests[^\n]+MakeSampleException[^\n]+$";
             var formattedDetails = new DefaultExceptionFormatter()
                 .WithMembersExcludedFromStackTrace("System.Runtime.*",".*RecurrentCall.*")
@@ -116,7 +97,7 @@ at LightBDD.Core.UnitTests.Formatting.ExceptionFormatting.DefaultExceptionFormat
             Exception exception = null;
             try
             {
-                await RecurrentCall(4);
+                await RecurrentCall(7);
             }
             catch (Exception e)
             {

--- a/test/LightBDD.Extensions.DependencyInjection.UnitTests/AssemblyInfo.cs
+++ b/test/LightBDD.Extensions.DependencyInjection.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/test/LightBDD.Framework.Reporting.UnitTests/AssemblyInfo.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/test/LightBDD.Framework.UnitTests/AssemblyInfo.cs
+++ b/test/LightBDD.Framework.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_exception_stack_trace_integration_tests.cs
@@ -27,7 +27,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             ex.AssertStackTraceMatching(
 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests.Step_throwing_exception[^\n]*
 \s*at LightBDD.Framework.Scenarios.Basic.Implementation.BasicStepCompiler.StepExecutor.Execute[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions.RunScenario[^\n]*");
         }
@@ -43,7 +42,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(Async_step_throwing_exception_immediately));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_immediately[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
@@ -59,7 +57,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(Async_step_throwing_exception_after_await));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_after_await[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
@@ -76,10 +73,8 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioActionsAsync(Async_void_step_throwing_exception_after_await));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_void_step_throwing_exception_after_await[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 ){0,2}\s*at LightBDD.Core.Execution.Implementation.AsyncStepSynchronizationContext.RunWithSelf[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioActionsAsync[^\n]*");
         }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_exception_stack_trace_integration_tests.cs
@@ -42,10 +42,10 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(Async_step_throwing_exception_immediately));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests.<Async_step_throwing_exception_immediately>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_immediately[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions.<RunScenarioAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
 
         async Task Async_step_throwing_exception_immediately()
@@ -58,10 +58,10 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(Async_step_throwing_exception_after_await));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests.<Async_step_throwing_exception_after_await>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_after_await[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions.<RunScenarioAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
 
         async Task Async_step_throwing_exception_after_await()
@@ -75,13 +75,13 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioActionsAsync(Async_void_step_throwing_exception_after_await));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests.<Async_void_step_throwing_exception_after_await>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Basic.Basic_scenario_exception_stack_trace_integration_tests[^\n]*Async_void_step_throwing_exception_after_await[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 ){0,2}\s*at LightBDD.Core.Execution.Implementation.AsyncStepSynchronizationContext.RunWithSelf[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions.<RunScenarioActionsAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Basic.BasicScenarioExtensions[^\n]*RunScenarioActionsAsync[^\n]*");
         }
 
         async void Async_void_step_throwing_exception_after_await()

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_exception_stack_trace_integration_tests.cs
@@ -44,10 +44,10 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(_ => Async_step_throwing_exception_immediately()));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests.<Async_step_throwing_exception_immediately>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_immediately[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions.<RunScenarioAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
 
         async Task Async_step_throwing_exception_immediately()
@@ -60,10 +60,10 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(_ => Async_step_throwing_exception_after_await()));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests.<Async_step_throwing_exception_after_await>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_after_await[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions.<RunScenarioAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
 
         async Task Async_step_throwing_exception_after_await()
@@ -77,13 +77,13 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
         {
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioActionsAsync(_ => Async_void_step_throwing_exception_after_await()));
             ex.AssertStackTraceMatching(
-                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests.<Async_void_step_throwing_exception_after_await>[^\n]*
+                @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_void_step_throwing_exception_after_await[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 ){0,2}\s*at LightBDD.Core.Execution.Implementation.AsyncStepSynchronizationContext.RunWithSelf[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions.<RunScenarioActionsAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioActionsAsync[^\n]*");
         }
 
         async void Async_void_step_throwing_exception_after_await()

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_exception_stack_trace_integration_tests.cs
@@ -28,7 +28,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
             ex.AssertStackTraceMatching(
 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests.Step_throwing_exception[^\n]*
 \s*at [^\n]*lambda_method[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions.RunScenario[^\n]*");
         }
@@ -45,7 +44,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(_ => Async_step_throwing_exception_immediately()));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_immediately[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
@@ -61,7 +59,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioAsync(_ => Async_step_throwing_exception_after_await()));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_step_throwing_exception_after_await[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioAsync[^\n]*");
         }
@@ -78,10 +75,8 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => _runner.RunScenarioActionsAsync(_ => Async_void_step_throwing_exception_after_await()));
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Extended.Extended_scenario_exception_stack_trace_integration_tests[^\n]*Async_void_step_throwing_exception_after_await[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 ){0,2}\s*at LightBDD.Core.Execution.Implementation.AsyncStepSynchronizationContext.RunWithSelf[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Extended.ExtendedScenarioExtensions[^\n]*RunScenarioActionsAsync[^\n]*");
         }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_exception_stack_trace_integration_tests.cs
@@ -27,7 +27,6 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Fluent
             ex.AssertStackTraceMatching(
                 @"^\s*at LightBDD.Framework.UnitTests.Scenarios.Fluent.Fluent_scenario_exception_stack_trace_integration_tests.Step_throwing_exception[^\n]*
 \s*at LightBDD.Framework.Scenarios.Basic.Implementation.BasicStepCompiler.StepExecutor.Execute[^\n]*
---- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
 )?\s*at LightBDD.Framework.Scenarios.Fluent.Implementation.ScenarioBuilder[^\n]*RunAsync[^\n]*");
         }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_exception_stack_trace_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_exception_stack_trace_integration_tests.cs
@@ -29,7 +29,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Fluent
 \s*at LightBDD.Framework.Scenarios.Basic.Implementation.BasicStepCompiler.StepExecutor.Execute[^\n]*
 --- End of stack trace from previous location where exception was thrown ---
 ([^\n]*
-)?\s*at LightBDD.Framework.Scenarios.Fluent.Implementation.ScenarioBuilder`1.<RunAsync>[^\n]*");
+)?\s*at LightBDD.Framework.Scenarios.Fluent.Implementation.ScenarioBuilder[^\n]*RunAsync[^\n]*");
         }
 
         void Step_throwing_exception()

--- a/test/LightBDD.UnitTests.Helpers/ExceptionAssertExtensions.cs
+++ b/test/LightBDD.UnitTests.Helpers/ExceptionAssertExtensions.cs
@@ -7,7 +7,8 @@ namespace LightBDD.UnitTests.Helpers
     {
         public static void AssertStackTraceMatching(this Exception ex, string expectedStackTracePattern)
         {
-            Assert.That(ex.StackTrace.Replace("\r", ""), Does.Match(expectedStackTracePattern.Replace("\r", "")));
+            var actual = ex.StackTrace.Replace("\r", "").Replace("--- End of stack trace from previous location where exception was thrown ---\n","");
+            Assert.That(actual, Does.Match(expectedStackTracePattern.Replace("\r", "")));
         }
     }
 }


### PR DESCRIPTION
<!-- Add breif description here -->

#### Details

Issue reference: #163

List of changes:
* Updated DefaultExceptionFormatter to exclude "End of stack trace" lines

#### Checklist
- [x] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
