### PR TITLE
#187 Updated LightBDD.Extensions.DependencyInjection and LightBDD.Autofac to require specifying takeOwnership flag for containers

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,11 @@
 LightBDD
 ===========================================
 
+Version 3.2.0
+----------------------------------------
++ #187 (Autofac) Updated UseAutofac() to require specifying takeOwnership flag for passed container
++ #187 (LightBDD.Extensions.DependencyInjection) Updated UseContainer() to require specifying takeOwnership flag for passed provider
+
 Version 3.1.0
 ----------------------------------------
 + #191 (Core)(Change) Expanded IScenarioInfo, IStepInfo with Parent property

--- a/src/LightBDD.Autofac/AutofacContainerExtensions.cs
+++ b/src/LightBDD.Autofac/AutofacContainerExtensions.cs
@@ -19,7 +19,7 @@ namespace LightBDD.Autofac
         /// <param name="configuration">Configuration.</param>
         /// <param name="container">Container to use.</param>
 
-        [Obsolete("Use other methods instead", true)]
+        [Obsolete("Use overload with takeOwnership flag instead", true)]
         public static DependencyContainerConfiguration UseAutofac(
             this DependencyContainerConfiguration configuration,
             ILifetimeScope container)

--- a/src/LightBDD.Autofac/Implementation/AutofacContainer.cs
+++ b/src/LightBDD.Autofac/Implementation/AutofacContainer.cs
@@ -7,6 +7,7 @@ namespace LightBDD.Autofac.Implementation
     internal class AutofacContainer : IDependencyContainer
     {
         public ILifetimeScope AutofacScope { get; set; }
+        public ILifetimeScope ParentScope { get; set; }
 
         public object Resolve(Type type)
         {
@@ -16,6 +17,7 @@ namespace LightBDD.Autofac.Implementation
         public void Dispose()
         {
             AutofacScope.Dispose();
+            ParentScope?.Dispose();
         }
 
         public IDependencyContainer BeginScope(Action<ContainerConfigurator> configuration = null)

--- a/src/LightBDD.Extensions.DependencyInjection/DiContainerExtensions.cs
+++ b/src/LightBDD.Extensions.DependencyInjection/DiContainerExtensions.cs
@@ -18,7 +18,7 @@ namespace LightBDD.Extensions.DependencyInjection
         /// </summary>
         /// <param name="configuration">Configuration.</param>
         /// <param name="serviceProvider">Service provider to use.</param>
-        [Obsolete("Use other methods instead", true)]
+        [Obsolete("Use overload with takeOwnership flag instead", true)]
         public static DependencyContainerConfiguration UseContainer(
             this DependencyContainerConfiguration configuration, IServiceProvider serviceProvider)
         {

--- a/src/LightBDD.Extensions.DependencyInjection/DiContainerExtensions.cs
+++ b/src/LightBDD.Extensions.DependencyInjection/DiContainerExtensions.cs
@@ -12,14 +12,40 @@ namespace LightBDD.Extensions.DependencyInjection
     {
         /// <summary>
         /// Configures LightBDD to use DI container described by <paramref name="serviceProvider"/>.
-        /// Please note that the new scope will be created to handle injections for LightBDD.
+        /// Please note that the new scope will be created to handle injections for LightBDD.<br/>
+        /// Please note that <paramref name="serviceProvider"/> will not be disposed by LightBDD after test run, as it is treated as externally owned instance
+        /// - use <see cref="UseContainer(DependencyContainerConfiguration,IServiceProvider,bool)"/> if container should be fully managed by LightBDD.
         /// </summary>
         /// <param name="configuration">Configuration.</param>
-        /// <param name="serviceProvider">Service provider instance.</param>
+        /// <param name="serviceProvider">Service provider to use.</param>
+        [Obsolete("Use other methods instead", true)]
         public static DependencyContainerConfiguration UseContainer(
             this DependencyContainerConfiguration configuration, IServiceProvider serviceProvider)
         {
-            return configuration.UseContainer(new DiContainer(serviceProvider.CreateScope(), new ContainerOverrides()));
+            return UseContainer(configuration, serviceProvider, false);
+        }
+
+        /// <summary>
+        /// Configures LightBDD to use provided <paramref name="serviceProvider"/> provider, where <paramref name="takeOwnership"/> specifies if LightBDD should control provider disposal or not.<br/>
+        /// Please note that the new scope will be created to handle injections for LightBDD.<br/>
+        /// </summary>
+        /// <param name="configuration">Configuration.</param>
+        /// <param name="serviceProvider">Service provider to use.</param>
+        /// <param name="takeOwnership">If true, the provider will be disposed by LightBDD after tests are finished.</param>
+        public static DependencyContainerConfiguration UseContainer(
+            this DependencyContainerConfiguration configuration, IServiceProvider serviceProvider, bool takeOwnership)
+        {
+            var container = new DiContainer(serviceProvider.CreateScope(), new ContainerOverrides());
+
+            if (takeOwnership)
+            {
+                if (serviceProvider is IDisposable disposableParent)
+                    container.AddDisposable(disposableParent);
+                else
+                    throw new ArgumentException($"The provided {serviceProvider.GetType().FullName} is not {nameof(IDisposable)} and LightBDD cannot take proper ownership of the provider. Please consider specifying {nameof(takeOwnership)} parameter to be false and manual disposal of the provider.", nameof(serviceProvider));
+            }
+
+            return configuration.UseContainer(container);
         }
     }
 }

--- a/test/LightBDD.Autofac.UnitTests/AutofacContainer_with_builder_tests.cs
+++ b/test/LightBDD.Autofac.UnitTests/AutofacContainer_with_builder_tests.cs
@@ -8,24 +8,14 @@ using NUnit.Framework;
 namespace LightBDD.Autofac.UnitTests
 {
     [TestFixture]
-    public class AutofacContainer_tests : ContainerBaseTests
+    public class AutofacContainer_with_builder_tests : ContainerBaseTests
     {
         protected override IDependencyContainer CreateContainer()
         {
             var builder = new ContainerBuilder();
             builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
+            builder.Register(_ => new DisposableSingleton()).SingleInstance();
             return new DependencyContainerConfiguration().UseAutofac(builder).DependencyContainer;
-        }
-    }
-
-    [TestFixture]
-    public class AutofacContainer_inner_scope_tests : ContainerBaseTests
-    {
-        protected override IDependencyContainer CreateContainer()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
-            return new DependencyContainerConfiguration().UseAutofac(builder.Build()).DependencyContainer;
         }
     }
 }

--- a/test/LightBDD.Autofac.UnitTests/AutofacContainer_with_explicit_container_tests.cs
+++ b/test/LightBDD.Autofac.UnitTests/AutofacContainer_with_explicit_container_tests.cs
@@ -1,0 +1,30 @@
+﻿using Autofac;
+using Autofac.Features.ResolveAnything;
+using LightBDD.Core.Configuration;
+using LightBDD.Core.Dependencies;
+using LightBDD.UnitTests.Helpers;
+using NUnit.Framework;
+
+namespace LightBDD.Autofac.UnitTests
+{
+    [TestFixture(true)]
+    [TestFixture(false)]
+    public class AutofacContainer_with_explicit_container_tests : ContainerBaseTests
+    {
+        public AutofacContainer_with_explicit_container_tests(bool shouldTakeOwnership)
+            : base(shouldTakeOwnership)
+        {
+        }
+
+        protected override IDependencyContainer CreateContainer()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
+            builder.Register(_ => new DisposableSingleton()).SingleInstance();
+
+            return new DependencyContainerConfiguration()
+                .UseAutofac(builder.Build(), ShouldTakeOwnership)
+                .DependencyContainer;
+        }
+    }
+}

--- a/test/LightBDD.Core.UnitTests/Dependencies/BasicDependencyContainer_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Dependencies/BasicDependencyContainer_tests.cs
@@ -165,7 +165,9 @@ namespace LightBDD.Core.UnitTests.Dependencies
 
         protected override IDependencyContainer CreateContainer()
         {
-            return new DependencyContainerConfiguration().UseDefaultContainer().DependencyContainer;
+            return new DependencyContainerConfiguration()
+                .UseDefaultContainer(x => x.RegisterInstance(new DisposableSingleton(), new RegistrationOptions()))
+                .DependencyContainer;
         }
 
         class Holder<T>

--- a/test/LightBDD.Extensions.DependencyInjection.UnitTests/MicrosoftDiContainer_custom_containers.cs
+++ b/test/LightBDD.Extensions.DependencyInjection.UnitTests/MicrosoftDiContainer_custom_containers.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using LightBDD.Core.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+
+namespace LightBDD.Extensions.DependencyInjection.UnitTests
+{
+    [TestFixture]
+    public class MicrosoftDiContainer_custom_containers
+    {
+        [Test]
+        public void UseContainer_requires_disposable_providers_if_ownership_is_expected()
+        {
+            var serviceProvider = new FakeNonDisposableProvider();
+
+            var ex = Assert.Throws<ArgumentException>(() => new DependencyContainerConfiguration().UseContainer(serviceProvider, true));
+            Assert.That(ex.Message,
+                Does.Contain($"The provided {typeof(FakeNonDisposableProvider).FullName} is not IDisposable and LightBDD cannot take proper ownership of the provider. Please consider specifying takeOwnership parameter to be false and manual disposal of the provider."));
+        }
+
+        [Test]
+        public void UseContainer_allows_non_disposable_providers_as_long_as_LightBDD_does_not_take_ownership()
+        {
+            var serviceProvider = new FakeNonDisposableProvider();
+            Assert.DoesNotThrow(() => new DependencyContainerConfiguration().UseContainer(serviceProvider, false));
+        }
+
+        class FakeNonDisposableProvider : IServiceProvider
+        {
+            public object GetService(Type serviceType)
+            {
+                if (serviceType == typeof(IServiceScopeFactory))
+                    return Mock.Of<IServiceScopeFactory>();
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/LightBDD.Extensions.DependencyInjection.UnitTests/MicrosoftDiContainer_with_explicit_container_tests.cs
+++ b/test/LightBDD.Extensions.DependencyInjection.UnitTests/MicrosoftDiContainer_with_explicit_container_tests.cs
@@ -6,16 +6,22 @@ using NUnit.Framework;
 
 namespace LightBDD.Extensions.DependencyInjection.UnitTests
 {
-    [TestFixture]
-    public class MicrosoftDiContainer_tests : ContainerBaseTests
+    [TestFixture(true)]
+    [TestFixture(false)]
+    public class MicrosoftDiContainer_with_explicit_container_tests : ContainerBaseTests
     {
+        public MicrosoftDiContainer_with_explicit_container_tests(bool shouldTakeOwnership)
+            : base(shouldTakeOwnership)
+        {
+        }
         protected override IDependencyContainer CreateContainer()
         {
             var serviceCollection = new ServiceCollection()
-                .AddTransient<Disposable>();
+                .AddTransient<Disposable>()
+                .AddSingleton<DisposableSingleton>();
 
             return new DependencyContainerConfiguration()
-                .UseContainer(serviceCollection.BuildServiceProvider())
+                .UseContainer(serviceCollection.BuildServiceProvider(), ShouldTakeOwnership)
                 .DependencyContainer;
         }
     }


### PR DESCRIPTION
Updated LightBDD.Extensions.DependencyInjection and LightBDD.Autofac to require specifying takeOwnership flag for containers

#### Details

Issue reference: #187 

List of changes:
* LightBDD.Autofac
  * Added `DependencyContainerConfiguration UseAutofac(this DependencyContainerConfiguration configuration, ILifetimeScope container, bool takeOwnership)`
  * Obsoleted `DependencyContainerConfiguration UseAutofac(this DependencyContainerConfiguration configuration, ILifetimeScope container)`
* LightBDD.Extensions.DependencyInjection
  * Added `DependencyContainerConfiguration UseContainer(this DependencyContainerConfiguration configuration, IServiceProvider serviceProvider, bool takeOwnership)`
  * Obsoleted `DependencyContainerConfiguration UseContainer(this DependencyContainerConfiguration configuration, IServiceProvider serviceProvider)`

#### Checklist
- [x] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [x] Examples have been updated to present new feature (if applicable),
- [x] Example reports have been updated in examples\ExampleReports directory (if applicable)
