### PR TITLE
#185 Updated LightBDD.XUnit2 to recognize Skip property on Scenario and InlineData attributes 

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,8 +3,15 @@ LightBDD
 
 Version 3.2.0
 ----------------------------------------
+Summary:
++ #185 (LightBDD.XUnit2)(Fix) Using skip feature with XUnit InlineData attribute throws InvalidOperationException
 + #187 (Autofac) Updated UseAutofac() to require specifying takeOwnership flag for passed container
 + #187 (LightBDD.Extensions.DependencyInjection) Updated UseContainer() to require specifying takeOwnership flag for passed provider
+Details:
++ #185 (LightBDD.XUnit2)(Fix) Updated LightBDD.XUnit2 to allow running scenarios with InlineDataAttribute having specified Skip property value
++ #185 (LightBDD.XUnit2)(New) Updated LightBDD.XUnit2 to recognize Skip property on Scenario and InlineData attributes and include those scenarios in reports
++ #185 (LightBDD.XUnit2)(New) Added UseXUnitSkipBehaviorAttribute to enforce default xunit behavior for skipped scenarios.
+
 
 Version 3.1.0
 ----------------------------------------

--- a/LightBDD.sln
+++ b/LightBDD.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B3AFFD69-36B4-43D6-A6AA-72914D15055C}"
 	ProjectSection(SolutionItems) = preProject
@@ -63,6 +63,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Src", "Src", "{795CD637-D3F
 	ProjectSection(SolutionItems) = preProject
 		src\Common.props = src\Common.props
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightBDD.XUnit2.IntegrationTests", "test\LightBDD.XUnit2.IntegrationTests\LightBDD.XUnit2.IntegrationTests.csproj", "{B958A138-9556-4AB4-9B63-D113F0309454}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -380,6 +382,22 @@ Global
 		{C1B0A7BC-AF9F-4039-8540-231ECDD30AAF}.Release|x64.Build.0 = Release|Any CPU
 		{C1B0A7BC-AF9F-4039-8540-231ECDD30AAF}.Release|x86.ActiveCfg = Release|Any CPU
 		{C1B0A7BC-AF9F-4039-8540-231ECDD30AAF}.Release|x86.Build.0 = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|x64.Build.0 = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Debug|x86.Build.0 = Debug|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|ARM.Build.0 = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|x64.ActiveCfg = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|x64.Build.0 = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|x86.ActiveCfg = Release|Any CPU
+		{B958A138-9556-4AB4-9B63-D113F0309454}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -406,6 +424,7 @@ Global
 		{C1B0A7BC-AF9F-4039-8540-231ECDD30AAF} = {A7491D1D-7E5B-4021-8105-4098683807EB}
 		{82B10F43-3A68-401C-99AB-515D409F6CD3} = {795CD637-D3F6-44AB-A408-AA89B7C18356}
 		{527D4497-4F9D-474C-93C7-773D6D48FCF3} = {795CD637-D3F6-44AB-A408-AA89B7C18356}
+		{B958A138-9556-4AB4-9B63-D113F0309454} = {A7491D1D-7E5B-4021-8105-4098683807EB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0768D221-78A3-4008-968F-3A4D4E43A7D8}

--- a/src/LightBDD.XUnit2/IgnoreScenarioAttribute.cs
+++ b/src/LightBDD.XUnit2/IgnoreScenarioAttribute.cs
@@ -10,7 +10,6 @@ namespace LightBDD.XUnit2
     /// Attribute allowing to ignore scenario in declarative way. It can be applied on scenario method or step method as well as feature class.
     /// If applied on scenario, no steps will be executed, but scenario will be included in reports.
     /// If applied on class level, all scenarios in this class will get ignored.
-    /// It is recommended to use this attribute in favor of <see cref="ScenarioAttribute.Skip"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public class IgnoreScenarioAttribute : Attribute, IScenarioDecoratorAttribute, IStepDecoratorAttribute

--- a/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
@@ -10,5 +10,6 @@ namespace LightBDD.XUnit2.Implementation.Customization
         public static void SetSettings(AssemblySettings settings) => AsyncLocal.Value = settings;
 
         public bool EnableInterClassParallelization { get; set; }
+        public bool UseXUnitSkipBehavior { get; set; }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseDiscoverer.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseDiscoverer.cs
@@ -13,10 +13,6 @@ namespace LightBDD.XUnit2.Implementation.Customization
 
         public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
-            // skipped
-            if (factAttribute.GetNamedArgument<string>("Skip") != null)
-                return new[] { new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
-
             // fact
             if (!testMethod.Method.GetCustomAttributes(typeof(DataAttribute)).Any())
                 return new XunitTestCase[] { new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
@@ -33,7 +29,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
             IAttributeInfo theoryAttribute, string skipReason)
         {
-            return new[] { new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+            return CreateTestCasesForTheory(discoveryOptions, testMethod, theoryAttribute);
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseDiscoverer.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestCaseDiscoverer.cs
@@ -15,7 +15,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
         {
             // skipped
             if (factAttribute.GetNamedArgument<string>("Skip") != null)
-                return new[] { new XunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+                return new[] { new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
 
             // fact
             if (!testMethod.Method.GetCustomAttributes(typeof(DataAttribute)).Any())
@@ -24,15 +24,27 @@ namespace LightBDD.XUnit2.Implementation.Customization
             return base.Discover(discoveryOptions, testMethod, factAttribute);
         }
 
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,IAttributeInfo theoryAttribute, object[] dataRow)
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
+            IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
+        {
+            return new[] { new SkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, skipReason, dataRow) };
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
+            IAttributeInfo theoryAttribute, string skipReason)
+        {
+            return new[] { new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
             return new XunitTestCase[]
             {
-                new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod,dataRow)
+                new ScenarioTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow)
             };
         }
 
-        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,IAttributeInfo theoryAttribute)
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
             return new XunitTestCase[]
             {

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioTestRunner.cs
@@ -31,7 +31,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
             {
                 AfterTestStarting();
 
-                if (!string.IsNullOrEmpty(SkipReason))
+                if (!string.IsNullOrEmpty(SkipReason) && AssemblySettings.Current.UseXUnitSkipBehavior)
                 {
                     runSummary.Skipped++;
 
@@ -95,7 +95,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
             testOutputHelper.Initialize(MessageBus, Test);
             try
             {
-                TestContextProvider.Initialize(TestMethod, TestMethodArguments, testOutputHelper);
+                TestContextProvider.Initialize(TestMethod, TestMethodArguments, testOutputHelper, SkipReason);
                 var totalTime = await InvokeTestMethodAsync(aggregator);
                 return Tuple.Create(totalTime, testOutputHelper.Output);
             }

--- a/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.Implementation.Customization
+{
+    internal class SkippedDataRowTestCase : XunitSkippedDataRowTestCase
+    {
+        [Obsolete("serialization only")]
+        public SkippedDataRowTestCase()
+        {
+        }
+
+        public SkippedDataRowTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            ITestMethod testMethod,
+            string skipReason,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, skipReason, testMethodArguments) { }
+        public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new ScenarioTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
@@ -6,7 +6,8 @@ using Xunit.Sdk;
 
 namespace LightBDD.XUnit2.Implementation.Customization
 {
-    internal class SkippedDataRowTestCase : XunitSkippedDataRowTestCase
+    //The SkipReason looks strange but it is a workaround for https://github.com/xunit/xunit/issues/1782
+    internal class SkippedDataRowTestCase : XunitTestCase
     {
         [Obsolete("serialization only")]
         public SkippedDataRowTestCase()
@@ -19,10 +20,33 @@ namespace LightBDD.XUnit2.Implementation.Customization
             ITestMethod testMethod,
             string skipReason,
             object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, skipReason, testMethodArguments) { }
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        {
+            SkipReason = skipReason;
+        }
+
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
             return new ScenarioTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+            SkipReason = data.GetValue<string>("SkipReason");
+        }
+
+        /// <inheritdoc />
+        protected override string GetSkipReason(IAttributeInfo factAttribute)
+        {
+            return SkipReason;
+        }
+
+        /// <inheritdoc />
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+            data.AddValue("SkipReason", (object)SkipReason, (Type)null);
         }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
@@ -22,7 +22,11 @@ namespace LightBDD.XUnit2.Implementation.Customization
             var bddScopeAttribute = GetLightBddScopeAttribute(assembly);
 
             var enableInterClassParallelization = ShallEnableInterClassParallelization(assembly, executionOptions);
-            AssemblySettings.SetSettings(new AssemblySettings { EnableInterClassParallelization = enableInterClassParallelization });
+            AssemblySettings.SetSettings(new AssemblySettings
+            {
+                EnableInterClassParallelization = enableInterClassParallelization,
+                UseXUnitSkipBehavior = ShallUseXUnitSkipBehavior(assembly)
+            });
 
             bddScopeAttribute?.SetUp();
             try
@@ -51,6 +55,11 @@ namespace LightBDD.XUnit2.Implementation.Customization
             if (executionOptions.DisableParallelization() ?? attribute?.DisableTestParallelization ?? false)
                 return false;
             return assembly.GetCustomAttribute<ClassCollectionBehaviorAttribute>()?.AllowTestParallelization ?? false;
+        }
+
+        private bool ShallUseXUnitSkipBehavior(Assembly assembly)
+        {
+            return assembly.GetCustomAttribute<UseXUnitSkipBehaviorAttribute>() != null;
         }
 
         private Assembly GetAssembly()

--- a/src/LightBDD.XUnit2/Implementation/TestContextProvider.cs
+++ b/src/LightBDD.XUnit2/Implementation/TestContextProvider.cs
@@ -10,12 +10,14 @@ namespace LightBDD.XUnit2.Implementation
         public MethodInfo TestMethod { get; }
         public object[] TestMethodArguments { get; }
         public ITestOutputHelper OutputHelper { get; }
+        public string SkipReason { get; }
 
         public static TestContextProvider Current => Provider.Value;
 
-        public static void Initialize(MethodInfo testMethod, object[] arguments, ITestOutputHelper testOutputHelper)
+        public static void Initialize(MethodInfo testMethod, object[] arguments, ITestOutputHelper testOutputHelper,
+            string skipReason)
         {
-            Provider.Value = new TestContextProvider(testMethod, arguments, testOutputHelper);
+            Provider.Value = new TestContextProvider(testMethod, arguments, testOutputHelper,skipReason);
         }
 
         public static void Clear()
@@ -23,11 +25,13 @@ namespace LightBDD.XUnit2.Implementation
             Provider.Value = null;
         }
 
-        private TestContextProvider(MethodInfo testMethod, object[] arguments, ITestOutputHelper outputHelper)
+        private TestContextProvider(MethodInfo testMethod, object[] arguments, ITestOutputHelper outputHelper,
+            string skipReason)
         {
             TestMethod = testMethod;
             TestMethodArguments = arguments;
             OutputHelper = outputHelper;
+            SkipReason = skipReason;
         }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/TestSkippedDecorator.cs
+++ b/src/LightBDD.XUnit2/Implementation/TestSkippedDecorator.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.XUnit2.Implementation.Customization;
+
+namespace LightBDD.XUnit2.Implementation
+{
+    internal class TestSkippedDecorator : IScenarioDecorator
+    {
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var skipReason = TestContextProvider.Current.SkipReason;
+            if (!string.IsNullOrWhiteSpace(skipReason))
+                throw new IgnoreException(skipReason);
+
+            return scenarioInvocation.Invoke();
+        }
+    }
+}

--- a/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
+++ b/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
@@ -70,6 +70,9 @@ namespace LightBDD.XUnit2
             configuration.ExceptionHandlingConfiguration()
                 .UpdateExceptionDetailsFormatter(new DefaultExceptionFormatter().WithTestFrameworkDefaults().Format);
 
+            configuration.ExecutionExtensionsConfiguration()
+                .EnableScenarioDecorator<TestSkippedDecorator>();
+
             OnConfigure(configuration);
             return configuration;
         }

--- a/src/LightBDD.XUnit2/ScenarioAttribute.cs
+++ b/src/LightBDD.XUnit2/ScenarioAttribute.cs
@@ -15,14 +15,5 @@ namespace LightBDD.XUnit2
     [XunitTestCaseDiscoverer("LightBDD.XUnit2.Implementation.Customization." + nameof(ScenarioTestCaseDiscoverer), "LightBDD.XUnit2")]
     public class ScenarioAttribute : FactAttribute
     {
-        /// <summary>
-        /// Marks the test so that it will not be run, and gets or sets the skip reason
-        /// </summary>
-        [Obsolete("Please use IgnoreScenarioAttribute on scenario or step method instead, as it will make test appearing in the reports.")]
-        public override string Skip
-        {
-            get => base.Skip;
-            set => base.Skip = value;
-        }
     }
 }

--- a/src/LightBDD.XUnit2/UseXUnitSkipBehaviorAttribute.cs
+++ b/src/LightBDD.XUnit2/UseXUnitSkipBehaviorAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace LightBDD.XUnit2
+{
+    /// <summary>
+    /// Attribute allowing to control the xunit Fact, Theory, Scenario and InlineData skip behavior.<br/>
+    /// When applied on assembly, all Scenarios and InlineData attributes with Skip property set will result with scenario being immediately ignored without running them.<br/>
+    /// When not applied, scenarios will always run but LightBDD will ignore them just before running any steps, which will allow to include those scenarios in the LightBDD results.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class UseXUnitSkipBehaviorAttribute : Attribute
+    {
+    }
+}

--- a/test/LightBDD.XUnit2.IntegrationTests/Helpers/ConfiguredLightBDDScope.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Helpers/ConfiguredLightBDDScope.cs
@@ -1,0 +1,21 @@
+﻿using LightBDD.Core.Configuration;
+using LightBDD.Framework.Configuration;
+using LightBDD.XUnit2.IntegrationTests.Helpers;
+
+[assembly: ConfiguredLightBDDScope]
+namespace LightBDD.XUnit2.IntegrationTests.Helpers
+{
+    public class ConfiguredLightBDDScope : LightBddScopeAttribute
+    {
+        protected override void OnConfigure(LightBddConfiguration configuration)
+        {
+            configuration.FeatureProgressNotifierConfiguration()
+                .ClearNotifiers();
+            configuration.ScenarioProgressNotifierConfiguration()
+                .ClearNotifierProviders()
+                .UpdateNotifierProvider(() => ScenarioProgressCapture.Instance);
+            configuration.ReportWritersConfiguration()
+                .Clear();
+        }
+    }
+}

--- a/test/LightBDD.XUnit2.IntegrationTests/Helpers/RunScenariosFirst.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Helpers/RunScenariosFirst.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace LightBDD.XUnit2.IntegrationTests.Helpers
+{
+    class RunScenariosFirst : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        {
+            return testCases.OrderByDescending(x =>
+                x.TestMethod.Method.GetCustomAttributes(typeof(ScenarioAttribute).AssemblyQualifiedName).Any());
+        }
+    }
+}

--- a/test/LightBDD.XUnit2.IntegrationTests/Helpers/ScenarioProgressCapture.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Helpers/ScenarioProgressCapture.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using LightBDD.Core.Metadata;
+using LightBDD.Core.Notification;
+using LightBDD.Core.Results;
+
+namespace LightBDD.XUnit2.IntegrationTests.Helpers
+{
+    public class ScenarioProgressCapture : IScenarioProgressNotifier
+    {
+        private readonly ConcurrentQueue<IScenarioResult> _results = new ConcurrentQueue<IScenarioResult>();
+        public IEnumerable<IScenarioResult> Results => _results;
+        public static ScenarioProgressCapture Instance { get; } = new ScenarioProgressCapture();
+        public void NotifyScenarioStart(IScenarioInfo scenario)
+        {
+        }
+
+        public void NotifyScenarioFinished(IScenarioResult scenario)
+        {
+            _results.Enqueue(scenario);
+        }
+
+        public void NotifyStepStart(IStepInfo step)
+        {
+        }
+
+        public void NotifyStepFinished(IStepResult step)
+        {
+        }
+
+        public void NotifyStepComment(IStepInfo step, string comment)
+        {
+        }
+    }
+}

--- a/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
+++ b/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Common.Tests.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LightBDD.XUnit2\LightBDD.XUnit2.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/test/LightBDD.XUnit2.IntegrationTests/Skipped_scenarios.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Skipped_scenarios.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using LightBDD.Core.Results;
+using LightBDD.Framework.Scenarios;
+using LightBDD.XUnit2.IntegrationTests.Helpers;
+using Xunit;
+
+namespace LightBDD.XUnit2.IntegrationTests
+{
+    [TestCaseOrderer("LightBDD.XUnit2.IntegrationTests." + nameof(RunScenariosFirst), "LightBDD.XUnit2.IntegrationTests")]
+    public class Skipped_scenarios : FeatureFixture
+
+    {
+        [Fact]
+        public void All_skipped_tests_should_be_included_in_results()
+        {
+            var actual = ScenarioProgressCapture.Instance.Results
+                .Where(x => x.Status == ExecutionStatus.Ignored)
+                .Select(x => $"{x.Info.Name}:{x.StatusDetails}")
+                .OrderBy(x => x)
+                .ToArray();
+
+            var expected = new[]
+            {
+                "Scenario 1:Scenario: normal scenario",
+                "Scenario 2 [param: \"a\"]:Scenario: parameterized 1",
+                "Scenario 2 [param: \"b\"]:Scenario: parameterized 2",
+                "Scenario 3 [param: \"val1\"]:Scenario: skip all",
+                "Scenario 3 [param: \"val2\"]:Scenario: skip all"
+            };
+            Assert.Equal(expected, actual);
+        }
+
+        [Scenario(Skip = "normal scenario")]
+        public async Task Scenario_1()
+        {
+            await Runner.RunScenarioAsync(
+                _ => Given_something(),
+                _ => When_something_happens(),
+                _ => Then_something_else_should_happen());
+        }
+
+        [Scenario]
+        [InlineData("a", Skip = "parameterized 1")]
+        [InlineData("b", Skip = "parameterized 2")]
+        public async Task Scenario_2(string param)
+        {
+            await Runner.RunScenarioAsync(
+                _ => Given_something(),
+                _ => When_something_happens(),
+                _ => Then_something_else_should_happen());
+        }
+
+        [Scenario(Skip = "skip all")]
+        [InlineData("val1")]
+        [InlineData("val2")]
+        public async Task Scenario_3(string param)
+        {
+            await Runner.RunScenarioAsync(
+                _ => Given_something(),
+                _ => When_something_happens(),
+                _ => Then_something_else_should_happen());
+        }
+
+        private Task Given_something()
+        {
+            throw new NotImplementedException();
+        }
+
+        private Task When_something_happens()
+        {
+            throw new NotImplementedException();
+        }
+
+        private Task Then_something_else_should_happen()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/LightBDD.XUnit2.UnitTests/IntegrationTests.cs
+++ b/test/LightBDD.XUnit2.UnitTests/IntegrationTests.cs
@@ -110,6 +110,20 @@ namespace LightBDD.XUnit2.UnitTests
         }
 
         [Scenario]
+        [InlineData("1234", Skip = "Let's skip it as it is too long")]
+        [Label(nameof(Runner_should_skip_scenarios_with_skipped_inline_data))]
+        public void Runner_should_skip_scenarios_with_skipped_inline_data(string param)
+        {
+            var ex = Assert.ThrowsAny<Exception>(() => Runner.RunScenario(_ => Step_with_parameter(param)));
+            Assert.Equal("Let's skip it as it is too long", ex.Message);
+            var result = GetScenarioResult(nameof(Runner_should_skip_scenarios_with_skipped_inline_data));
+
+            Assert.Equal(ExecutionStatus.Ignored, result.Status);
+            Assert.Equal("Scenario: Let's skip it as it is too long", result.StatusDetails);
+            Assert.Equal(ExecutionStatus.NotRun, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
         [IgnoreScenario("scenario reason")]
         [Label(nameof(Runner_should_ignore_scenario_with_IgnoreScenarioAttribute))]
         public void Runner_should_ignore_scenario_with_IgnoreScenarioAttribute()
@@ -117,6 +131,19 @@ namespace LightBDD.XUnit2.UnitTests
             var ex = Assert.ThrowsAny<Exception>(() => Runner.RunScenario(_ => Some_step()));
             Assert.Equal("scenario reason", ex.Message);
             var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_with_IgnoreScenarioAttribute));
+
+            Assert.Equal(ExecutionStatus.Ignored, result.Status);
+            Assert.Equal("Scenario: scenario reason", result.StatusDetails);
+            Assert.Equal(ExecutionStatus.NotRun, result.GetSteps().Single().Status);
+        }
+
+        [Scenario(Skip = "scenario reason")]
+        [Label(nameof(Runner_should_ignore_scenario_with_Skip_parameter))]
+        public void Runner_should_ignore_scenario_with_Skip_parameter()
+        {
+            var ex = Assert.ThrowsAny<Exception>(() => Runner.RunScenario(_ => Some_step()));
+            Assert.Equal("scenario reason", ex.Message);
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_with_Skip_parameter));
 
             Assert.Equal(ExecutionStatus.Ignored, result.Status);
             Assert.Equal("Scenario: scenario reason", result.StatusDetails);


### PR DESCRIPTION
Updated LightBDD.XUnit2 to recognize Skip property on Scenario and InlineData attributes 
Added option to fallback to xunit behavior

#### Details

Issue reference: #185

List of changes:
* Updated LightBDD to support `Skip` property on `ScenarioAttribute` as well as `InlineDataAttribute`, allow the test to run but make it ignored as soon as executed with `Runner`, so that outcome is included in the reports
* Added `UseXUnitSkipBehaviorAttribute` that could enforce default xunit behavior. 

The tests no longer fail when `[InlineData]` is used with `Skip` property.

The feature has been tested in:
* VS Test Explorer (VS 2019 16.3.1)
* Resharper
* dotnet test command

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
