### PR TITLE
#182 Updated basic and extended step parsing to make parsing issues easily discoverable

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,7 @@ LightBDD
 Version 3.2.0
 ----------------------------------------
 Summary:
++ #182 (Framework)(Change) Updated basic and extended step parsing to make parsing issues easily discoverable
 + #185 (LightBDD.XUnit2)(Fix) Using skip feature with XUnit InlineData attribute throws InvalidOperationException
 + #187 (Autofac) Updated UseAutofac() to require specifying takeOwnership flag for passed container
 + #187 (LightBDD.Extensions.DependencyInjection) Updated UseContainer() to require specifying takeOwnership flag for passed provider

--- a/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
@@ -136,8 +136,8 @@ namespace LightBDD.Core.Execution.Implementation
             _scenarioContext.ProgressNotifier.NotifyScenarioStart(Info);
             _scope = CreateContainerScope();
             Context = CreateExecutionContext();
-            _preparedSteps = PrepareSteps();
             ScenarioExecutionContext.Current = CreateCurrentContext();
+            PrepareSteps();
         }
 
         private ScenarioExecutionContext CreateCurrentContext()
@@ -155,7 +155,7 @@ namespace LightBDD.Core.Execution.Implementation
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Container scope initialization failed: {e.Message}", e);
+                throw new InvalidOperationException($"Scenario container scope initialization failed: {e.Message}", e);
             }
         }
 
@@ -167,20 +167,22 @@ namespace LightBDD.Core.Execution.Implementation
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Context initialization failed: {e.Message}", e);
+                throw new InvalidOperationException($"Scenario context initialization failed: {e.Message}", e);
             }
         }
 
-        private RunnableStep[] PrepareSteps()
+        private void PrepareSteps()
         {
             try
             {
-                return _scenarioContext.StepsProvider(_result.Info,_stepDescriptors, Context, _scope, string.Empty, ShouldAbortSubStepExecution);
+                _preparedSteps = _scenarioContext.StepsProvider(_result.Info, _stepDescriptors, Context, _scope, string.Empty, ShouldAbortSubStepExecution);
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Step initialization failed: {e.Message}", e);
+                throw new InvalidOperationException($"Scenario steps initialization failed: {e.Message}", e);
             }
+            if (_preparedSteps.Any(x => x.Result.ExecutionException != null))
+                throw new InvalidOperationException("Scenario steps initialization failed.");
         }
 
         private bool ShouldAbortSubStepExecution(Exception ex) => _shouldAbortSubStepExecutionFn(ex);

--- a/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
@@ -144,7 +144,7 @@ namespace LightBDD.Core.Extensibility.Implementation
                 var stepInfo = new StepInfo(parent, metadataProvider.GetStepName(descriptor, previousStepTypeName), stepIndex + 1, totalSteps, groupPrefix);
                 var arguments = descriptor.Parameters.Select(p => new MethodArgument(p, metadataProvider.GetValueFormattingServiceFor(p.ParameterInfo))).ToArray();
 
-                steps[stepIndex] = new RunnableStep(stepContext, stepInfo, descriptor.StepInvocation, arguments, extensions.StepDecorators.Concat(metadataProvider.GetStepDecorators(descriptor)));
+                steps[stepIndex] = new RunnableStep(stepContext, stepInfo, descriptor, arguments, extensions.StepDecorators.Concat(metadataProvider.GetStepDecorators(descriptor)));
                 previousStepTypeName = stepInfo.Name.StepTypeName?.OriginalName;
             }
 

--- a/src/LightBDD.Core/Formatting/Values/IConditionalValueFormatter.cs
+++ b/src/LightBDD.Core/Formatting/Values/IConditionalValueFormatter.cs
@@ -3,7 +3,7 @@ using System;
 namespace LightBDD.Core.Formatting.Values
 {
     /// <summary>
-    /// Interfce allowing to define a formatting method for objects of types that are accepted by <see cref="CanFormat"/> method.
+    /// Interface allowing to define a formatting method for objects of types that are accepted by <see cref="CanFormat"/> method.
     /// </summary>
     public interface IConditionalValueFormatter : IValueFormatter
     {

--- a/src/LightBDD.Framework/Scenarios/Implementation/BasicStepCompiler.cs
+++ b/src/LightBDD.Framework/Scenarios/Implementation/BasicStepCompiler.cs
@@ -15,21 +15,22 @@ namespace LightBDD.Framework.Scenarios.Implementation
         public static StepDescriptor ToAsynchronousStep(Func<Task> step)
         {
             var methodInfo = step.GetMethodInfo();
-            EnsureNotGenerated(methodInfo);
-            return new StepDescriptor(methodInfo, new AsyncStepExecutor(step).ExecuteAsync);
+            return EnsureNotGenerated(methodInfo)
+                   ?? new StepDescriptor(methodInfo, new AsyncStepExecutor(step).ExecuteAsync);
         }
 
         public static StepDescriptor ToSynchronousStep(Action step)
         {
             var methodInfo = step.GetMethodInfo();
-            EnsureNotGenerated(methodInfo);
-            return new StepDescriptor(methodInfo, new StepExecutor(step).Execute);
+            return EnsureNotGenerated(methodInfo)
+                   ?? new StepDescriptor(methodInfo, new StepExecutor(step).Execute);
         }
 
-        private static void EnsureNotGenerated(MethodInfo methodInfo)
+        private static StepDescriptor EnsureNotGenerated(MethodInfo methodInfo)
         {
-            if(Reflector.IsGenerated(methodInfo))
-                throw new ArgumentException($"The basic step syntax does not support compiler generated methods, such as {methodInfo}, as rendered step name will be unreadable. Please either pass the step method name directly or use other methods for declaring steps.");
+            return Reflector.IsGenerated(methodInfo)
+                ? StepDescriptor.CreateInvalid(new ArgumentException($"The basic step syntax does not support compiler generated methods, such as {methodInfo}, as rendered step name will be unreadable. Please either pass the step method name directly or use other methods for declaring steps."))
+                : null;
         }
 
         private class AsyncStepExecutor

--- a/src/LightBDD.Framework/Scenarios/Implementation/ExtendedStepCompiler.cs
+++ b/src/LightBDD.Framework/Scenarios/Implementation/ExtendedStepCompiler.cs
@@ -22,15 +22,23 @@ namespace LightBDD.Framework.Scenarios.Implementation
 
         public StepDescriptor ToStep<T>(Expression<T> stepExpression)
         {
-            var contextParameter = stepExpression.Parameters[0];
-            var methodExpression = GetMethodExpression(stepExpression);
-
-            var arguments = ProcessArguments(methodExpression, contextParameter);
-
-            return new StepDescriptor(methodExpression.Method, CompileStepAction(methodExpression, contextParameter), arguments)
+            try
             {
-                PredefinedStepType = GetStepTypeName(contextParameter)
-            };
+                var contextParameter = stepExpression.Parameters[0];
+                var methodExpression = GetMethodExpression(stepExpression);
+
+                var arguments = ProcessArguments(methodExpression, contextParameter);
+
+                return new StepDescriptor(methodExpression.Method, CompileStepAction(methodExpression, contextParameter), arguments)
+                {
+                    PredefinedStepType = GetStepTypeName(contextParameter)
+                };
+            }
+            catch (Exception ex)
+            {
+                return StepDescriptor.CreateInvalid(ex);
+                throw;
+            }
         }
 
         private string GetStepTypeName(ParameterExpression contextParameter)

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
@@ -8,6 +8,7 @@ using LightBDD.Framework.Extensibility;
 using LightBDD.UnitTests.Helpers;
 using LightBDD.UnitTests.Helpers.TestableIntegration;
 using NUnit.Framework;
+#pragma warning disable 1998
 
 namespace LightBDD.Core.UnitTests
 {

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using LightBDD.Core.Extensibility;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Extensibility;
+using LightBDD.UnitTests.Helpers;
+using LightBDD.UnitTests.Helpers.TestableIntegration;
+using NUnit.Framework;
+
+namespace LightBDD.Core.UnitTests
+{
+    [TestFixture]
+    public class CoreBddRunner_invalid_step_handling_tests
+    {
+        private IBddRunner _runner;
+        private IFeatureRunner _feature;
+
+        #region Setup/Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            _feature = TestableFeatureRunnerRepository.GetRunner(GetType());
+            _runner = _feature.GetBddRunner(this);
+        }
+
+        #endregion
+
+        [Test]
+        public void Invalid_step_descriptors_should_make_scenario_failing_immediately_without_execution()
+        {
+            var step1 = TestStep.Create(Step_that_should_not_run);
+            var step2 = StepDescriptor.CreateInvalid(new Exception("reason1"));
+            var step3 = StepDescriptor.CreateInvalid(new Exception("reason2"));
+            var ex = Assert.Throws<AggregateException>(() => _runner.Test().TestScenario(step1, step2, step3));
+
+            Assert.That(ex.InnerExceptions.Select(x => x.Message).ToArray(),
+                Is.EqualTo(new[] { "Scenario steps initialization failed.", "reason1", "reason2" }));
+
+            var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
+            StepResultExpectation.AssertEqual(steps,
+                new StepResultExpectation(1, 3, "Step that should not run", ExecutionStatus.NotRun),
+                new StepResultExpectation(2, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 2: reason1"),
+                new StepResultExpectation(3, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 3: reason2"));
+        }
+
+        [Test]
+        public void Invalid_step_descriptors_should_make_composite_failing_immediately_without_execution()
+        {
+            TestCompositeStep Composite_step() => new TestCompositeStep(
+                TestStep.Create(Step_that_should_not_run),
+                StepDescriptor.CreateInvalid(new Exception("reason1")),
+                StepDescriptor.CreateInvalid(new Exception("reason2")));
+
+            var ex = Assert.Throws<AggregateException>(() => _runner.Test()
+                .TestScenario(
+                    TestStep.CreateComposite(Composite_step),
+                    TestStep.Create(Step_that_should_not_run)));
+
+            Assert.That(ex.InnerExceptions.Select(x => x.Message).ToArray(),
+                Is.EqualTo(new[] { "Sub-steps initialization failed.", "reason1", "reason2" }));
+
+            var mainSteps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps().ToArray();
+            StepResultExpectation.AssertEqual(mainSteps[0].GetSubSteps(),
+                new StepResultExpectation("1.",1, 3, "Step that should not run", ExecutionStatus.NotRun),
+                new StepResultExpectation("1.",2, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 1.2: reason1"),
+                new StepResultExpectation("1.",3, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 1.3: reason2"));
+            Assert.That(mainSteps[1].Status,Is.EqualTo(ExecutionStatus.NotRun));
+        }
+
+        private static async Task Step_that_should_not_run()
+        {
+            throw new InvalidOperationException("Step should not run");
+        }
+    }
+}

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_metadata_collection_tests.cs
@@ -154,7 +154,7 @@ namespace LightBDD.Core.UnitTests
             Assert.Throws<InvalidOperationException>(() => _runner.Test().TestScenario(GetFailingStepDescriptors("some reason")));
             var result = _feature.GetFeatureResult().GetScenarios().Single();
             Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Failed));
-            Assert.That(result.StatusDetails, Is.EqualTo("Scenario: Step initialization failed: some reason"));
+            Assert.That(result.StatusDetails, Is.EqualTo("Scenario: Scenario steps initialization failed: some reason"));
         }
 
         [Test]

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_step_execution_with_context_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_step_execution_with_context_tests.cs
@@ -36,7 +36,7 @@ namespace LightBDD.Core.UnitTests
 
             var scenario = _feature.GetFeatureResult().GetScenarios().Single();
             Assert.That(scenario.Status, Is.EqualTo(ExecutionStatus.Failed));
-            Assert.That(scenario.StatusDetails, Is.EqualTo("Scenario: Context initialization failed: abc"));
+            Assert.That(scenario.StatusDetails, Is.EqualTo("Scenario: Scenario context initialization failed: abc"));
         }
 
         [Test]

--- a/test/LightBDD.Core.UnitTests/Extensibility/StepDescriptor_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/StepDescriptor_tests.cs
@@ -29,6 +29,8 @@ namespace LightBDD.Core.UnitTests.Extensibility
             Assert.That(descriptor.RawName, Is.EqualTo(rawName));
             Assert.That(descriptor.Parameters, Is.SameAs(parameters));
             Assert.That(descriptor.StepInvocation, Is.SameAs(SomeStepInvocation));
+            Assert.That(descriptor.IsValid, Is.True);
+            Assert.That(descriptor.CreationException, Is.Null);
         }
 
         [Test]
@@ -53,6 +55,20 @@ namespace LightBDD.Core.UnitTests.Extensibility
         {
             var ex = Assert.Throws<ArgumentNullException>(() => new StepDescriptor("abc", null));
             Assert.That(ex.ParamName, Is.EqualTo("stepInvocation"));
+        }
+
+        [Test]
+        public void It_should_create_descriptor_from_exception()
+        {
+            var ex = new Exception("foo");
+            var descriptor = StepDescriptor.CreateInvalid(ex);
+            Assert.That(descriptor.IsValid, Is.False);
+            Assert.That(descriptor.CreationException, Is.SameAs(ex));
+            Assert.That(descriptor.RawName, Is.EqualTo("--INVALID STEP--"));
+            Assert.That(descriptor.Parameters, Is.Empty);
+
+            var actual = Assert.ThrowsAsync<Exception>(() => descriptor.StepInvocation(null, null));
+            Assert.That(actual, Is.SameAs(ex));
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_runner_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Basic/Basic_scenario_runner_tests.cs
@@ -3,8 +3,10 @@ using LightBDD.Framework.UnitTests.Scenarios.Basic.Helpers;
 using LightBDD.Framework.UnitTests.Scenarios.Helpers;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using LightBDD.Core.Extensibility;
 
 namespace LightBDD.Framework.UnitTests.Scenarios.Basic
 {
@@ -86,8 +88,8 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
         {
             Action lambda = () => { };
             var builder = new TestableScenarioBuilder<NoContext>();
-            var ex = Assert.Throws<ArgumentException>(() => builder.AddSteps(lambda));
-            AssertGeneratedStepNameException(ex, lambda.GetMethodInfo());
+            builder.AddSteps(lambda);
+            AssertGeneratedStepNameException(builder.Steps.Single(), lambda.GetMethodInfo());
         }
 
         [Test]
@@ -96,8 +98,8 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             void LocalFunction() { }
             Action action = LocalFunction;
             var builder = new TestableScenarioBuilder<NoContext>();
-            var ex = Assert.Throws<ArgumentException>(() => builder.AddSteps(LocalFunction));
-            AssertGeneratedStepNameException(ex, action.GetMethodInfo());
+            builder.AddSteps(LocalFunction);
+            AssertGeneratedStepNameException(builder.Steps.Single(), action.GetMethodInfo());
         }
 
         [Test]
@@ -105,8 +107,8 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
         {
             Func<Task> lambda = async () => await Task.Yield();
             var builder = new TestableScenarioBuilder<NoContext>();
-            var ex = Assert.Throws<ArgumentException>(() => builder.AddAsyncSteps(lambda));
-            AssertGeneratedStepNameException(ex, lambda.GetMethodInfo());
+            builder.AddAsyncSteps(lambda);
+            AssertGeneratedStepNameException(builder.Steps.Single(), lambda.GetMethodInfo());
         }
 
         [Test]
@@ -118,13 +120,14 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Basic
             }
             Func<Task> action = LocalFunction;
             var builder = new TestableScenarioBuilder<NoContext>();
-            var ex = Assert.Throws<ArgumentException>(() => builder.AddAsyncSteps(LocalFunction));
-            AssertGeneratedStepNameException(ex, action.GetMethodInfo());
+            builder.AddAsyncSteps(LocalFunction);
+            AssertGeneratedStepNameException(builder.Steps.Single(), action.GetMethodInfo());
         }
 
-        private static void AssertGeneratedStepNameException(ArgumentException ex, MethodInfo methodInfo)
+        private static void AssertGeneratedStepNameException(StepDescriptor descriptor, MethodInfo methodInfo)
         {
-            Assert.That(ex.Message,
+            Assert.That(descriptor.IsValid, Is.False);
+            Assert.That(descriptor.CreationException.Message,
                 Is.EqualTo($"The basic step syntax does not support compiler generated methods, such as {methodInfo}, as rendered step name will be unreadable. Please either pass the step method name directly or use other methods for declaring steps."));
         }
     }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_hierarchical_execution_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_hierarchical_execution_tests.cs
@@ -56,7 +56,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
                 .AddAsyncSteps(_ => null as Task)
                 .Build());
 
-            Assert.Throws<ArgumentException>(() => group.SubSteps.ToArray());
+            Assert.That(group.SubSteps.Any(s => !s.IsValid), Is.True);
         }
 
 

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_parameter_capture_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_parameter_capture_tests.cs
@@ -81,19 +81,31 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
         [Test]
         public void It_should_not_allow_ref_parameters_in_sync_mode()
         {
-            ExpectExtendedScenarioRun();
+            var (stepCapture, _) = ExpectExtendedScenarioRun();
             var val = 4;
-            var ex = Assert.Throws<ArgumentException>(() => Runner.RunScenario(_ => Step_with_ref_parameters(ref val)));
-            Assert.That(ex.Message, Does.Match($"Steps accepting ref or out parameters are not supported: _ => .*{nameof(Step_with_ref_parameters)}.*"));
+            Runner.RunScenario(_ => Step_with_ref_parameters(ref val));
+            Assert.That(stepCapture.Single().IsValid, Is.False);
+            Assert.That(stepCapture.Single().CreationException.Message, Does.Match($"Steps accepting ref or out parameters are not supported: _ => .*{nameof(Step_with_ref_parameters)}.*"));
         }
 
         [Test]
         public void It_should_not_allow_out_parameters_in_sync_mode()
         {
-            ExpectExtendedScenarioRun();
+            var (stepCapture, _) = ExpectExtendedScenarioRun();
             int val;
-            var ex = Assert.Throws<ArgumentException>(() => Runner.RunScenario(_ => Step_with_out_parameters(out val)));
-            Assert.That(ex.Message, Does.Match($"Steps accepting ref or out parameters are not supported: _ => .*{nameof(Step_with_out_parameters)}.*"));
+            Runner.RunScenario(_ => Step_with_out_parameters(out val));
+            Assert.That(stepCapture.Single().IsValid, Is.False);
+            Assert.That(stepCapture.Single().CreationException.Message, Does.Match($"Steps accepting ref or out parameters are not supported: _ => .*{nameof(Step_with_out_parameters)}.*"));
+        }
+
+        [Test]
+        public void It_should_not_allow_non_method_call_expressions()
+        {
+            var (stepCapture, _) = ExpectExtendedScenarioRun();
+            var someTask = new Task(() => { });
+            Runner.RunScenarioAsync(_ => someTask);
+            Assert.That(stepCapture.Single().IsValid, Is.False);
+            Assert.That(stepCapture.Single().CreationException.Message, Does.Match($"Unsupported step expression. Expected MethodCallExpression, got: _ => value\\(.*\\)\\.{nameof(someTask)}"));
         }
 
         [Test]


### PR DESCRIPTION
Deferred basic and extended step parsing issues escalation to scenario / sub-step run, allowing users to see the the details about other steps and identify problematic steps easier.

#### Details
Issue reference: #182  
List of changes:  
* Implemented `StepDescriptor.CreateInvalid(Exception ex)` for creating step descriptors that failed to initialize,
* Updated basic and extended step compilers to create invalid descriptors instead of throwing upon parsing failure,
* Updated scenarios and composite-steps to fail fast if any of step-descriptor is invalid. 

#### Examples

```c#
[Scenario]
public async Task My_scenario()
{
    await Runner
        .AddSteps(_ => Given_some_step())
        .AddSteps(() => When_some_step())
        .AddSteps(_ => Then_some_step())
        .RunAsync();
}

private void Given_some_step() { }
private void When_some_step() { }
private void Then_some_step() { }
```

Before:
![image](https://user-images.githubusercontent.com/1894621/66275896-48bab200-e885-11e9-8548-9aa797a61156.png)

After:
![image](https://user-images.githubusercontent.com/1894621/66275967-fc23a680-e885-11e9-8c34-b5aa6782f0d4.png)

```c#
[Scenario]
public void My_other_scenario()
{
    Runner.RunScenario(_ => Given_some_step(),
        _ => When_some_composite(),
        _ => Then_some_step());
}

private CompositeStep When_some_composite()
{
    return CompositeStep.DefineNew()
        .AddSteps(_ => When_some_step())
        .AddAsyncSteps(_ => When_some_other_step)
        .AddSteps(() => When_another_step())
        .Build();
}

private void Given_some_step() { }
private void When_some_step() { }
private void Then_some_step() { }
private void When_another_step() { }
// It's a property, which is not supported
private Task When_some_other_step => Task.FromResult(2);
```

Before:
![image](https://user-images.githubusercontent.com/1894621/66275928-a0591d80-e885-11e9-87a9-3d4dfc16afaa.png)

After:
![image](https://user-images.githubusercontent.com/1894621/66275978-0fcf0d00-e886-11e9-84ae-c449bd0fa486.png)


#### Checklist
- [ ] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
