### PR TITLE
#181 Improved compact steps parsing and rendering

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,11 +4,13 @@ LightBDD
 Version 3.2.0
 ----------------------------------------
 Summary:
++ #181 (Framework)(Change) Improved compact steps formatting to exclude control characters, don't perform additional formatting and render properly in HTML reports
 + #182 (Framework)(Change) Updated basic and extended step parsing to make parsing issues easily discoverable
 + #185 (LightBDD.XUnit2)(Fix) Using skip feature with XUnit InlineData attribute throws InvalidOperationException
 + #187 (Autofac) Updated UseAutofac() to require specifying takeOwnership flag for passed container
 + #187 (LightBDD.Extensions.DependencyInjection) Updated UseContainer() to require specifying takeOwnership flag for passed provider
 Details:
++ #181 (Core)(Change) Updated StepDescriptor with configurable IsNameFormattingRequired property, controlling if RawName should be formatted or not
 + #185 (LightBDD.XUnit2)(Fix) Updated LightBDD.XUnit2 to allow running scenarios with InlineDataAttribute having specified Skip property value
 + #185 (LightBDD.XUnit2)(New) Updated LightBDD.XUnit2 to recognize Skip property on Scenario and InlineData attributes and include those scenarios in reports
 + #185 (LightBDD.XUnit2)(New) Added UseXUnitSkipBehaviorAttribute to enforce default xunit behavior for skipped scenarios.

--- a/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
+++ b/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
@@ -36,7 +36,7 @@ namespace LightBDD.Core.Extensibility
         /// </summary>
         protected CoreMetadataProvider(LightBddConfiguration configuration)
         {
-            if (configuration == null) 
+            if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
 
             ValueFormattingService = new ValueFormattingService(configuration);
@@ -96,6 +96,9 @@ namespace LightBDD.Core.Extensibility
         /// The <see cref="IStepNameInfo.StepTypeName"/> is determined from value <see cref="StepDescriptor.PredefinedStepType"/> or parsed from <see cref="StepDescriptor.RawName"/> if former is <c>null</c>.
         /// When determined step type is the same as <paramref name="previousStepTypeName"/>, it is being replaced with <see cref="StepTypeConfiguration.RepeatedStepReplacement"/>.
         /// </para>
+        /// <para>
+        /// For method inferred descriptors (<see cref="StepDescriptor.IsMethodInferred"/>) the step name is formatted with <see cref="NameParser"/>, otherwise the name is used as is from <see cref="StepDescriptor.RawName"/>.
+        /// </para>
         /// See also: <seealso cref="StepTypeConfiguration"/>, <seealso cref="LightBddConfiguration"/>.
         /// </summary>
         /// <param name="stepDescriptor">Step descriptor.</param>
@@ -103,7 +106,9 @@ namespace LightBDD.Core.Extensibility
         /// <returns><see cref="IStepNameInfo"/> object.</returns>
         public IStepNameInfo GetStepName(StepDescriptor stepDescriptor, string previousStepTypeName)
         {
-            var formattedStepName = _nameParser.GetNameFormat(stepDescriptor.MethodInfo, stepDescriptor.RawName, stepDescriptor.Parameters);
+            var formattedStepName = stepDescriptor.IsMethodInferred
+                ? _nameParser.GetNameFormat(stepDescriptor.MethodInfo, stepDescriptor.RawName, stepDescriptor.Parameters)
+                : stepDescriptor.RawName;
             return new StepNameInfo(
                 _stepTypeProcessor.GetStepTypeName(stepDescriptor.PredefinedStepType, ref formattedStepName, previousStepTypeName),
                 formattedStepName,

--- a/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
+++ b/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
@@ -97,7 +97,7 @@ namespace LightBDD.Core.Extensibility
         /// When determined step type is the same as <paramref name="previousStepTypeName"/>, it is being replaced with <see cref="StepTypeConfiguration.RepeatedStepReplacement"/>.
         /// </para>
         /// <para>
-        /// For method inferred descriptors (<see cref="StepDescriptor.IsMethodInferred"/>) the step name is formatted with <see cref="NameParser"/>, otherwise the name is used as is from <see cref="StepDescriptor.RawName"/>.
+        /// For descriptors with <see cref="StepDescriptor.IsNameFormattingRequired"/> set, the step name is formatted with <see cref="NameParser"/>, otherwise the name is used as is from <see cref="StepDescriptor.RawName"/>.
         /// </para>
         /// See also: <seealso cref="StepTypeConfiguration"/>, <seealso cref="LightBddConfiguration"/>.
         /// </summary>

--- a/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
+++ b/src/LightBDD.Core/Extensibility/CoreMetadataProvider.cs
@@ -106,7 +106,7 @@ namespace LightBDD.Core.Extensibility
         /// <returns><see cref="IStepNameInfo"/> object.</returns>
         public IStepNameInfo GetStepName(StepDescriptor stepDescriptor, string previousStepTypeName)
         {
-            var formattedStepName = stepDescriptor.IsMethodInferred
+            var formattedStepName = stepDescriptor.IsNameFormattingRequired
                 ? _nameParser.GetNameFormat(stepDescriptor.MethodInfo, stepDescriptor.RawName, stepDescriptor.Parameters)
                 : stepDescriptor.RawName;
             return new StepNameInfo(

--- a/src/LightBDD.Core/Extensibility/StepDescriptor.cs
+++ b/src/LightBDD.Core/Extensibility/StepDescriptor.cs
@@ -58,7 +58,7 @@ namespace LightBDD.Core.Extensibility
         private StepDescriptor(Exception creationException)
         {
             CreationException = creationException ?? throw new ArgumentNullException(nameof(creationException));
-            RawName = "--INVALID STEP--";
+            RawName = "<INVALID STEP>";
             Parameters = Arrays<ParameterDescriptor>.Empty();
             StepInvocation = RunInvalidDescriptor;
         }

--- a/src/LightBDD.Core/Extensibility/StepDescriptor.cs
+++ b/src/LightBDD.Core/Extensibility/StepDescriptor.cs
@@ -106,5 +106,10 @@ namespace LightBDD.Core.Extensibility
         /// Returns true if descriptor is valid or false if descriptor was created by <see cref="CreateInvalid"/> method.
         /// </summary>
         public bool IsValid => CreationException == null;
+
+        /// <summary>
+        /// Returns true if descriptor is inferred from method or explicitly made without it.
+        /// </summary>
+        public bool IsMethodInferred => MethodInfo != null;
     }
 }

--- a/src/LightBDD.Core/Metadata/Implementation/NameInfo.cs
+++ b/src/LightBDD.Core/Metadata/Implementation/NameInfo.cs
@@ -23,9 +23,9 @@ namespace LightBDD.Core.Metadata.Implementation
 
         public string Format(INameDecorator decorator)
         {
-            if (!Parameters.Any())
-                return decorator.DecorateNameFormat(NameFormat);
-            return string.Format(NameFormat, Parameters.Select(p => (object)decorator.DecorateParameterValue(p)).ToArray());
+            return !Parameters.Any()
+                ? decorator.DecorateNameFormat(NameFormat)
+                : string.Format(decorator.DecorateNameFormat(NameFormat), Parameters.Select(p => (object)decorator.DecorateParameterValue(p)).ToArray());
         }
     }
 }

--- a/src/LightBDD.Core/Metadata/Implementation/StepNameInfo.cs
+++ b/src/LightBDD.Core/Metadata/Implementation/StepNameInfo.cs
@@ -29,8 +29,8 @@ namespace LightBDD.Core.Metadata.Implementation
         public string Format(IStepNameDecorator decorator)
         {
             return StepTypeName != null
-                ? string.Format("{0} {1}", decorator.DecorateStepTypeName(StepTypeName), base.Format(decorator))
-                : base.ToString();
+                ? $"{decorator.DecorateStepTypeName(StepTypeName)} {base.Format(decorator)}"
+                : base.Format(decorator);
         }
     }
 }

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -39,7 +39,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                 .SelectMany(f => f.GetScenarios())
                 .SelectMany(s => s.Info.Categories)
                 .Distinct()
-                .Select((c, i) => new KeyValuePair<string, string>(c, string.Format("_{0}_", i)))
+                .Select((c, i) => new KeyValuePair<string, string>(c, $"_{i}_"))
                 .ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
@@ -203,7 +203,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
         {
             return Html.Tag(Html5Tag.Span)
                 .Class("label")
-                .Content(string.IsNullOrWhiteSpace(label) ? string.Empty : string.Format("[{0}]", label.Trim()))
+                .Content(string.IsNullOrWhiteSpace(label) ? string.Empty : $"[{label.Trim()}]")
                 .SpaceBefore()
                 .SkipEmpty();
         }
@@ -254,7 +254,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
         private static IHtmlNode GetCategoryFilterNode(string categoryId, string categoryName, bool selected = false)
         {
             return GetOptionNode(
-                string.Format("category{0}radio", categoryId),
+                $"category{categoryId}radio",
                 Html.Radio().Name("categoryFilter")
                     .Attribute("data-filter-value", categoryId)
                     .Attribute("data-filter-name", WebUtility.UrlEncode(categoryName))
@@ -341,8 +341,8 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
 
         private IHtmlNode GetScenario(IScenarioResult scenario, int featureIndex, int scenarioIndex)
         {
-            var toggleId = string.Format("toggle{0}_{1}", featureIndex, scenarioIndex);
-            var scenarioId = string.Format("scenario{0}_{1}", featureIndex, scenarioIndex + 1);
+            var toggleId = $"toggle{featureIndex}_{scenarioIndex}";
+            var scenarioId = $"scenario{featureIndex}_{scenarioIndex + 1}";
 
             return Html.Tag(Html5Tag.Div).Class("scenario " + GetStatusClass(scenario.Status)).Attribute("data-categories", GetScenarioCategories(scenario)).Content(
                 Html.Checkbox().Id(toggleId).Class("toggle toggleS").Checked(),
@@ -386,7 +386,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
         {
             return Html.Tag(Html5Tag.Span)
                 .Class("duration")
-                .Content(executionTime != null ? string.Format("({0})", executionTime.Duration.FormatPretty()) : string.Empty)
+                .Content(executionTime != null ? $"({executionTime.Duration.FormatPretty()})" : string.Empty)
                 .SkipEmpty()
                 .SpaceBefore();
         }
@@ -403,7 +403,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
         {
             return Html.Tag(Html5Tag.Div).Class("step").Content(
                 GetStatus(step.Status),
-                Html.Text(string.Format("{0}{1}. {2}", step.Info.GroupPrefix, step.Info.Number, step.Info.Name.Format(StepNameDecorator))).Trim(),
+                Html.Text($"{WebUtility.HtmlEncode(step.Info.GroupPrefix)}{step.Info.Number}. {step.Info.Name.Format(StepNameDecorator)}").Trim(),
                 GetDuration(step.ExecutionTime),
                 Html.Tag(Html5Tag.Div).Class("step-parameters").Content(step.Parameters.Select(GetStepParameter)).SkipEmpty(),
                 Html.Tag(Html5Tag.Div).Class("sub-steps").Content(step.GetSubSteps().Select(GetStep)).SkipEmpty());

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
@@ -43,8 +43,8 @@ namespace LightBDD.Core.UnitTests
             var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
             StepResultExpectation.AssertEqual(steps,
                 new StepResultExpectation(1, 3, "Step that should not run", ExecutionStatus.NotRun),
-                new StepResultExpectation(2, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 2: reason1"),
-                new StepResultExpectation(3, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 3: reason2"));
+                new StepResultExpectation(2, 3, "<INVALID STEP>", ExecutionStatus.Failed, "Step 2: reason1"),
+                new StepResultExpectation(3, 3, "<INVALID STEP>", ExecutionStatus.Failed, "Step 3: reason2"));
         }
 
         [Test]
@@ -66,8 +66,8 @@ namespace LightBDD.Core.UnitTests
             var mainSteps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps().ToArray();
             StepResultExpectation.AssertEqual(mainSteps[0].GetSubSteps(),
                 new StepResultExpectation("1.",1, 3, "Step that should not run", ExecutionStatus.NotRun),
-                new StepResultExpectation("1.",2, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 1.2: reason1"),
-                new StepResultExpectation("1.",3, 3, "--INVALID STEP--", ExecutionStatus.Failed, "Step 1.3: reason2"));
+                new StepResultExpectation("1.",2, 3, "<INVALID STEP>", ExecutionStatus.Failed, "Step 1.2: reason1"),
+                new StepResultExpectation("1.",3, 3, "<INVALID STEP>", ExecutionStatus.Failed, "Step 1.3: reason2"));
             Assert.That(mainSteps[1].Status,Is.EqualTo(ExecutionStatus.NotRun));
         }
 

--- a/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_step_type_interpretation_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_step_type_interpretation_tests.cs
@@ -53,7 +53,10 @@ namespace LightBDD.Core.UnitTests.Extensibility
         {
             var metadataProvider = new TestMetadataProvider();
 
-            var descriptor = new StepDescriptor(methodName, (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance));
+            var descriptor = new StepDescriptor(methodName, (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance))
+            {
+                IsNameFormattingRequired = true
+            };
             var stepName = metadataProvider.GetStepName(descriptor, lastStepType);
             Assert.That(stepName.StepTypeName?.ToString(), Is.EqualTo(expectedStepType));
             Assert.That(stepName.NameFormat, Is.EqualTo(expectedStepNameFormat));
@@ -93,7 +96,10 @@ namespace LightBDD.Core.UnitTests.Extensibility
         {
             var metadataProvider = new TestMetadataProvider(cfg => cfg.StepTypeConfiguration().UpdatePredefinedStepTypes("call", "invoke"));
 
-            var descriptor = new StepDescriptor(formattedName, (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance));
+            var descriptor = new StepDescriptor(formattedName, (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance))
+            {
+                IsNameFormattingRequired = true
+            };
             var step = metadataProvider.GetStepName(descriptor, null);
             Assert.That(step.StepTypeName?.ToString(), Is.EqualTo(expectedType), "type");
             Assert.That(step.NameFormat, Is.EqualTo(expectedNameFormat), "name");

--- a/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
@@ -79,7 +79,7 @@ namespace LightBDD.Core.UnitTests.Extensibility
         public void GetStepName_should_capture_name_from_step_descriptor_but_leave_parameters_unknown()
         {
             var descriptor = new StepDescriptor(
-                nameof(Feature_type.Some_step_with_argument),
+                ParameterInfoHelper.GetMethodInfo<int>(new Feature_type().Some_step_with_argument),
                 (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance),
                 ParameterDescriptor.FromConstant(
                     ParameterInfoHelper.GetMethodParameter<int>(new Feature_type().Some_step_with_argument), 5))
@@ -93,6 +93,13 @@ namespace LightBDD.Core.UnitTests.Extensibility
             Assert.That(stepName.ToString(), Is.EqualTo("GIVEN Some step with argument \"<?>\""));
         }
 
+        [Test]
+        public void GetStepName_should_capture_unmodified_name_for_not_inferred_descriptors()
+        {
+            var descriptor = new StepDescriptor("raw_name", (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance));
+            var stepName = _metadataProvider.GetStepName(descriptor, null);
+            Assert.That(stepName.NameFormat, Is.EqualTo("raw_name"));
+        }
 
         [Test]
         public void GetStepDecorators_should_return_extensions_in_order_if_declaring_type_does_not_have_extensions()

--- a/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
@@ -94,11 +94,17 @@ namespace LightBDD.Core.UnitTests.Extensibility
         }
 
         [Test]
-        public void GetStepName_should_capture_unmodified_name_for_not_inferred_descriptors()
+        [TestCase(true, "raw_name", "raw name")]
+        [TestCase(false, "raw_name", "raw_name")]
+        public void GetStepName_should_honor_IsNameFormattingRequired_flag(bool flag, string rawName, string expectedName)
         {
-            var descriptor = new StepDescriptor("raw_name", (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance));
+            var descriptor =
+                new StepDescriptor(rawName, (o, a) => Task.FromResult(DefaultStepResultDescriptor.Instance))
+                {
+                    IsNameFormattingRequired = flag
+                };
             var stepName = _metadataProvider.GetStepName(descriptor, null);
-            Assert.That(stepName.NameFormat, Is.EqualTo("raw_name"));
+            Assert.That(stepName.NameFormat, Is.EqualTo(expectedName));
         }
 
         [Test]

--- a/test/LightBDD.Core.UnitTests/Extensibility/StepDescriptor_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/StepDescriptor_tests.cs
@@ -106,7 +106,7 @@ namespace LightBDD.Core.UnitTests.Extensibility
             var descriptor = StepDescriptor.CreateInvalid(ex);
             Assert.That(descriptor.IsValid, Is.False);
             Assert.That(descriptor.CreationException, Is.SameAs(ex));
-            Assert.That(descriptor.RawName, Is.EqualTo("--INVALID STEP--"));
+            Assert.That(descriptor.RawName, Is.EqualTo("<INVALID STEP>"));
             Assert.That(descriptor.Parameters, Is.Empty);
 
             var actual = Assert.ThrowsAsync<Exception>(() => descriptor.StepInvocation(null, null));

--- a/test/LightBDD.Core.UnitTests/Helpers/ParameterInfoHelper.cs
+++ b/test/LightBDD.Core.UnitTests/Helpers/ParameterInfoHelper.cs
@@ -9,7 +9,17 @@ namespace LightBDD.Core.UnitTests.Helpers
         public static readonly ParameterInfo IntParameterInfo = GetMethodParameter<int>(SomeMethod);
         public static ParameterInfo GetMethodParameter<T>(Action<T> lambda)
         {
-            return lambda.GetMethodInfo().GetParameters()[0];
+            return GetMethodInfo(lambda).GetParameters()[0];
+        }
+
+        public static MethodInfo GetMethodInfo<T>(Action<T> lambda)
+        {
+            return lambda.GetMethodInfo();
+        }
+
+        public static MethodInfo GetMethodInfo(Action lambda)
+        {
+            return lambda.GetMethodInfo();
         }
     }
 }

--- a/test/LightBDD.Core.UnitTests/Metadata/StepNameInfo_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Metadata/StepNameInfo_tests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using LightBDD.Core.Extensibility;
+using LightBDD.Core.Extensibility.Results;
+using LightBDD.Core.Formatting.NameDecorators;
+using LightBDD.Core.Metadata;
+using LightBDD.UnitTests.Helpers.TestableIntegration;
+using NUnit.Framework;
+
+namespace LightBDD.Core.UnitTests.Metadata
+{
+    [TestFixture]
+    public class StepNameInfo_tests
+    {
+        [Test]
+        public void Format_should_decorate_step_name()
+        {
+            var stepName = CreateStepNameInfo("raw");
+            var format = stepName.Format(new TestDecorator());
+            Assert.That(format, Is.EqualTo("|raw|"));
+        }
+
+        [Test]
+        public void Format_should_decorate_step_name_with_parameter()
+        {
+            var stepName = CreateStepNameInfo("raw {0}, {1}", 2);
+            var format = stepName.Format(new TestDecorator());
+            Assert.That(format, Is.EqualTo("|raw '<?>', '<?>'|"));
+        }
+
+        [Test]
+        public void Format_should_decorate_step_name_with_step_type()
+        {
+            var stepName = CreateStepNameInfo("type", "raw");
+            var format = stepName.Format(new TestDecorator());
+            Assert.That(format, Is.EqualTo("<TYPE> |raw|"));
+        }
+
+        [Test]
+        public void Format_should_decorate_step_name_with_step_type_and_parameters()
+        {
+            var stepName = CreateStepNameInfo("type", "raw {0}", 1);
+            var format = stepName.Format(new TestDecorator());
+            Assert.That(format, Is.EqualTo("<TYPE> |raw '<?>'|"));
+        }
+
+        [Test]
+        public void Format_should_decorate_step_name_using_name_formatter()
+        {
+            var stepName = CreateStepNameInfo("type", "raw {0}", 1);
+            var format = stepName.Format((INameDecorator)new TestDecorator());
+            Assert.That(format, Is.EqualTo("|raw '<?>'|"));
+        }
+
+        private static IStepNameInfo CreateStepNameInfo(string name, int args = 0) => CreateStepNameInfo(null, name, args);
+        private static IStepNameInfo CreateStepNameInfo(string type, string name, int args = 0)
+        {
+            Task<IStepResultDescriptor> Invocation(object ctx, object[] a) => Task.FromResult(DefaultStepResultDescriptor.Instance);
+            void SomeFunction(int x) { }
+
+            Action<int> fn = SomeFunction;
+            var param = fn.GetMethodInfo().GetParameters().Single();
+
+
+            var descriptor = new StepDescriptor(name, Invocation,
+                Enumerable.Range(0, args).Select(a => ParameterDescriptor.FromConstant(param, a)).ToArray())
+            {
+                PredefinedStepType = type
+            };
+            return new TestMetadataProvider().GetStepName(descriptor, "");
+        }
+
+        class TestDecorator : IStepNameDecorator
+        {
+            public string DecorateParameterValue(INameParameterInfo parameter)
+            {
+                return $"'{parameter.FormattedValue}'";
+            }
+
+            public string DecorateNameFormat(string nameFormat)
+            {
+                return $"|{nameFormat}|";
+            }
+
+            public string DecorateStepTypeName(IStepTypeNameInfo stepTypeName)
+            {
+                return $"<{stepTypeName.Name}>";
+            }
+        }
+    }
+}

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -64,7 +64,7 @@ My feature
 long description
 Ignored name [Label 2] (1m 02s)[&#8734;link]
 categoryA
-Passed 1. call step1 ""arg1"" (1m 01s)
+Passed 1. call step1 &quot;arg1&quot; (1m 01s)
 Ignored 2. step2 (1s 100ms)
 Passed 2.1. substep 1 (100ms)
 Passed 2.2. substep 2 (1s)
@@ -192,6 +192,56 @@ Generated with LightBDD v{GetExpectedLightBddVersion()}
 initialize();";
             Assert.That(text.NormalizeNewLine(), Is.EqualTo(expectedText.NormalizeNewLine()));
         }
+
+        [Test]
+        public void Should_escape_html_characters_in_step_name()
+        {
+            var date = new DateTimeOffset(2019, 10, 21, 05, 06, 07, TimeSpan.Zero);
+            var feature = TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("scenario1", null, date, TimeSpan.FromSeconds(5), new string[0],
+                    TestResults.CreateStepResult(ExecutionStatus.Passed)
+                        .WithStepNameDetails(1, "ste<p>", "ste<p>", "ty<p>e")
+                        .WithGroupPrefix("<gr>")
+                        .WithExecutionTime(date, TimeSpan.FromMilliseconds(20)),
+                    TestResults.CreateStepResult(ExecutionStatus.Passed)
+                        .WithStepNameDetails(2, "ste<p>2", "ste<p>2")
+                        .WithExecutionTime(date.AddMilliseconds(50), TimeSpan.FromMilliseconds(20))));
+
+            var text = FormatAndExtractText(feature);
+            TestContext.WriteLine(text);
+            var expectedText = $@"Execution summary
+Test execution start time: 2019-10-21 05:06:07 UTC
+Test execution end time: 2019-10-21 05:06:12 UTC
+Test execution time: 5s
+Test execution time (aggregated): 5s
+Number of features: 1
+Number of scenarios: 1
+Passed scenarios: 1
+Bypassed scenarios: 0
+Failed scenarios: 0
+Ignored scenarios: 0
+Number of steps: 2
+Passed steps: 2
+Bypassed steps: 0
+Failed steps: 0
+Ignored steps: 0
+Not Run steps: 0
+Feature summary
+Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ignored Not Run Duration Aggregated Average
+My feature 1 1 0 0 0 2 2 0 0 0 0 5s 50000000 5s 50000000 5s 50000000
+Feature details[&#8734;link]
+Toggle: Features Scenarios
+Filter: Passed Bypassed Failed Ignored Not Run
+[&#8734;filtered link]
+My feature[&#8734;link]
+Passed scenario1 (5s)[&#8734;link]
+Passed &lt;gr&gt;1. ty&lt;p&gt;e ste&lt;p&gt; (20ms)
+Passed 2. ste&lt;p&gt;2 (20ms)
+Generated with LightBDD v{GetExpectedLightBddVersion()}
+initialize();";
+            Assert.That(text.NormalizeNewLine(), Is.EqualTo(expectedText.NormalizeNewLine()));
+        }
+
 
         private string GetExpectedLightBddVersion()
         {

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -231,15 +231,22 @@ namespace LightBDD.UnitTests.Helpers
             public TestStepTypeNameInfo StepTypeName { get; set; }
             IStepTypeNameInfo IStepNameInfo.StepTypeName => StepTypeName;
 
+            //TODO: rework to make it testing real code
             public string Format(IStepNameDecorator decorator)
             {
-                return FormattedName;
+                return StepTypeName != null
+                    ? $"{decorator.DecorateStepTypeName(StepTypeName)} {Format((INameDecorator)decorator)}"
+                    : Format((INameDecorator)decorator);
             }
 
+            //TODO: rework to make it testing real code
             public string Format(INameDecorator decorator)
             {
-                return FormattedName;
+                return !Parameters.Any()
+                    ? decorator.DecorateNameFormat(NameFormat)
+                    : string.Format(decorator.DecorateNameFormat(NameFormat), Parameters.Select(p => (object)decorator.DecorateParameterValue(p)).ToArray());
             }
+
             public override string ToString()
             {
                 return Format(StepNameDecorators.Default);


### PR DESCRIPTION
<!-- Add breif description here -->

#### Details

Issue reference: #181

List of changes:
* Core changes:
  * Updated `StepDescriptor` with configurable `IsNameFormattingRequired` property defaulting to `true` for descriptors made from `MethodBase` and `false` for pure text-based descriptors,
  * Ensured the `StepDescriptor` cannot be made from text having control characters (`char.IsControl()`),
  * Updated `CoreMetadataProvider.GetStepName()` to honor `StepDescriptor.IsNameFormattingRequired` when formatting names,
* Framework changes:
  * Updated compact steps to trim step names, replace `\t` and `new line` characters with space and remove any other control characters
  * Ensured that compact steps does not formats the step names (no `_` replacements)
  * Corrected HTML reports to properly render compact step name/step type (escaping html codes)

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
