### PR TITLE
#206 Add explicit netstandard2.0 for packages to decrease dependency graph

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ LightBDD
 
 Version 3.2.0
 ----------------------------------------
++ #206 (all)(New) Added explicit netstandard2.0 support to simplify dependency resolution
 + #210 (LightBDD.Fixie2)(Change) Updated Fixie version to 2.2.1
 + #210 (LightBDD.MsTest2)(Change) Updated MSTest.TestFramework version to 2.1.1
 + #210 (LightBDD.NUnit3)(Change) Updated NUnit version to 3.12.0

--- a/src/LightBDD.Autofac/LightBDD.Autofac.csproj
+++ b/src/LightBDD.Autofac/LightBDD.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <Description>Provides LightBDD integration with Autofac, allowing to use Autofac as DI container for LightBDD scenarios.
     </Description>
   </PropertyGroup>

--- a/src/LightBDD.Core/LightBDD.Core.csproj
+++ b/src/LightBDD.Core/LightBDD.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>LightBDD Test Framework Core</Summary>
     <Description>Provides LightBDD core features, including asynchronous scenario execution with execution tracking and time measurement, metadata discovery and formatting, reporting, in-code configuration, progress notification and framework extensibility.</Description>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
+++ b/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>$(PackageTags);fixie</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/LightBDD.Framework/LightBDD.Framework.csproj
+++ b/src/LightBDD.Framework/LightBDD.Framework.csproj
@@ -13,7 +13,7 @@ High level features:
 * Xml/Html/Plain text report generation;
 * DI support;
 * inline and tabular parameters.</Description>
-    <TargetFrameworks>netstandard1.3;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LightBDD.MsTest2/LightBDD.MsTest2.csproj
+++ b/src/LightBDD.MsTest2/LightBDD.MsTest2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard1.3;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <PackageTags>$(PackageTags);mstest;mstest2</PackageTags>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dotnet</PackageTargetFallback>
   </PropertyGroup>

--- a/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
+++ b/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard1.6;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net46</TargetFrameworks>
     <PackageTags>$(PackageTags);nunit;nunit3</PackageTags>
   </PropertyGroup>
 

--- a/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
+++ b/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard1.3;net452;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net452;net46</TargetFrameworks>
     <PackageTags>$(PackageTags);xunit;xunit2</PackageTags>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dotnet;portable-net45+win8+wp8+wpa81</PackageTargetFallback>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #206

List of changes:
* Added netstandard2.0 to all LightBdd packages

#### Checklist
- [x] Changes are backward compatible with previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
