### PR TITLE
Fixed ChromeDriver version mismatch in AcceptanceTests

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -8,6 +8,7 @@ Version [next]
 + #225 (Framework)(New) Introduced ProgressNotifierConfiguration to configure IProgressNotifier instances and updated DefaultProgressNotifier, NoProgressNotifier to implement IProgressNotifier and added ParallelProgressNotifierProvider.CreateProgressNotifier() method
 + #225 (LightBDD.XUnit2/LightBDD.NUnit3/LightBDD.MsTest2/LightBDD.Fixie2)(Change) Updated projects to use IProgressNotifier configuration
 + #225 (Core/Framework)(Change) Obsoleted IScenarioProgressNotifier, IFeatureProgressNotifier, DelegatingScenarioProgressNotifier, DelegatingFeatureProgressNotifier and all methods using them
++ #231 (Framework)(New) Updated ResourcePool with constructor accepting async resource factory method
 
 Version 3.3.0
 ----------------------------------------

--- a/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+
+namespace LightBDD.AcceptanceTests.Helpers
+{
+    /// <summary>
+    /// Based on https://github.com/Swimburger/DownloadChromeDriverSample
+    /// </summary>
+    public class ChromeDriverInstaller : IDisposable
+    {
+        private readonly SemaphoreSlim _sem = new SemaphoreSlim(1);
+        private bool _installed;
+        private readonly HttpClient _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri("https://chromedriver.storage.googleapis.com/")
+        };
+
+        public static ChromeDriverInstaller Instance { get; } = new ChromeDriverInstaller();
+
+        private ChromeDriverInstaller() { }
+
+        public async Task InstallOnce(CancellationToken cancellationToken)
+        {
+            if (_installed)
+                return;
+            await _sem.WaitAsync(cancellationToken);
+
+            try
+            {
+                if (_installed)
+                    return;
+
+                var chromeVersion = GetChromeVersion();
+                var chromeDriverVersion = await GetChromeDriverVersion(chromeVersion, cancellationToken);
+                var (zipName, driverName) = GetDriverLocation();
+                var targetPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                    driverName);
+
+                await using (var zipFileStream = await _httpClient.GetStreamAsync($"{chromeDriverVersion}/{zipName}"))
+                using (var zipArchive = new ZipArchive(zipFileStream, ZipArchiveMode.Read))
+                await using (var chromeDriverWriter = new FileStream(targetPath, FileMode.Create))
+                {
+                    await using var chromeDriverStream = zipArchive.GetEntry(driverName).Open();
+                    await chromeDriverStream.CopyToAsync(chromeDriverWriter, cancellationToken);
+                }
+
+                _installed = true;
+            }
+            finally
+            {
+                _sem.Release();
+            }
+        }
+
+        private static (string zipName, string driverName) GetDriverLocation()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return ("chromedriver_win32.zip", "chromedriver.exe");
+
+            throw new PlatformNotSupportedException("Your operating system is not supported.");
+        }
+
+        private async Task<string> GetChromeDriverVersion(string chromeVersion, CancellationToken cancellationToken)
+        {
+            var chromeDriverVersionResponse = await _httpClient.GetAsync($"LATEST_RELEASE_{chromeVersion}", cancellationToken);
+            if (chromeDriverVersionResponse.IsSuccessStatusCode)
+                return await chromeDriverVersionResponse.Content.ReadAsStringAsync();
+
+            if (chromeDriverVersionResponse.StatusCode == HttpStatusCode.NotFound)
+                throw new Exception($"ChromeDriver version not found for Chrome version {chromeVersion}");
+            throw new Exception($"ChromeDriver version request failed with status code: {chromeDriverVersionResponse.StatusCode}, reason phrase: {chromeDriverVersionResponse.ReasonPhrase}");
+        }
+
+        public string GetChromeVersion()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                throw new PlatformNotSupportedException("Your operating system is not supported.");
+
+            var chromePath = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe", null, null);
+            if (chromePath == null)
+                throw new Exception("Google Chrome not found in registry");
+
+            var chromeVersion = FileVersionInfo.GetVersionInfo(chromePath).FileVersion;
+            return chromeVersion.Substring(0, chromeVersion.LastIndexOf('.'));
+        }
+
+        public void Dispose()
+        {
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/test/LightBDD.AcceptanceTests/LightBDD.AcceptanceTests.csproj
+++ b/test/LightBDD.AcceptanceTests/LightBDD.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.Tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,13 +11,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="87.0.4280.8800" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #231 

List of changes:
- Extended ResourcePool to support async resource factory
- Fixed AcceptanceTests to download proper ChromeDriver
- Fixed AcceptanceTests to dispose ChromeDriver upon creation failure

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
