### PR TITLE
#252 Added LightBddScopeAttribute.DiagnosticMessageSink property for LightBDD.XUnit2 project

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ LightBDD
 
 Version [next]
 ----------------------------------------
++ #252 (LightBdd.XUnit2)(Change) Added LightBddScopeAttribute.DiagnosticMessageSink property
 
 Version 3.4.0 (VSIX)
 ----------------------------------------

--- a/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/TestFrameworkExecutor.cs
@@ -28,7 +28,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
                 UseXUnitSkipBehavior = ShallUseXUnitSkipBehavior(assembly)
             });
 
-            bddScopeAttribute?.SetUp();
+            bddScopeAttribute?.SetUp(DiagnosticMessageSink);
             try
             {
                 using (var assemblyRunner = CreateAssemblyRunner(testCases, executionMessageSink, executionOptions, enableInterClassParallelization))

--- a/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
+++ b/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
@@ -4,6 +4,7 @@ using LightBDD.Core.Formatting.ExceptionFormatting;
 using LightBDD.Framework.Configuration;
 using LightBDD.XUnit2.Configuration;
 using LightBDD.XUnit2.Implementation;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace LightBDD.XUnit2
@@ -19,11 +20,20 @@ namespace LightBDD.XUnit2
     [AttributeUsage(AttributeTargets.Assembly)]
     public class LightBddScopeAttribute : Attribute, ITestFrameworkAttribute
     {
-        internal void SetUp()
+        private static readonly NullMessageSink NullDiagnosticMessageSink = new NullMessageSink();
+        internal void SetUp(IMessageSink diagnosticMessageSink)
         {
+            DiagnosticMessageSink = diagnosticMessageSink;
             XUnit2FeatureCoordinator.InstallSelf(Configure());
             OnSetUp();
         }
+
+        /// <summary>
+        /// Returns XUnit diagnostic MessageSink.<br/>
+        /// When accessed within <seealso cref="OnSetUp"/>, <seealso cref="OnConfigure"/>, <seealso cref="OnTearDown"/> or during test execution, the current XUnit diagnostic message sink is returned.<br/>
+        /// When accessed outside of mentioned scopes, the instance of <seealso cref="NullMessageSink"/> is returned.
+        /// </summary>
+        protected IMessageSink DiagnosticMessageSink { get; private set; } = NullDiagnosticMessageSink;
 
         /// <summary>
         /// Allows to execute additional actions after LightBDD scope initialization
@@ -35,6 +45,7 @@ namespace LightBDD.XUnit2
             try
             {
                 OnTearDown();
+                DiagnosticMessageSink = NullDiagnosticMessageSink;
             }
             finally
             {

--- a/test/LightBDD.XUnit2.IntegrationTests/Helpers/ConfiguredLightBDDScope.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Helpers/ConfiguredLightBDDScope.cs
@@ -1,6 +1,7 @@
 ﻿using LightBDD.Core.Configuration;
 using LightBDD.Framework.Configuration;
 using LightBDD.XUnit2.IntegrationTests.Helpers;
+using Xunit.Sdk;
 
 [assembly: ConfiguredLightBDDScope]
 namespace LightBDD.XUnit2.IntegrationTests.Helpers
@@ -16,6 +17,16 @@ namespace LightBDD.XUnit2.IntegrationTests.Helpers
                 .UpdateNotifierProvider(() => ScenarioProgressCapture.Instance);
             configuration.ReportWritersConfiguration()
                 .Clear();
+        }
+
+        protected override void OnSetUp()
+        {
+            DiagnosticMessageSink.OnMessage(new DiagnosticMessage("OnSetUp"));
+        }
+
+        protected override void OnTearDown()
+        {
+            DiagnosticMessageSink.OnMessage(new DiagnosticMessage("OnTearDown"));
         }
     }
 }

--- a/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
+++ b/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
@@ -21,4 +21,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/LightBDD.XUnit2.IntegrationTests/xunit.runner.json
+++ b/test/LightBDD.XUnit2.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+	"diagnosticMessages": true
+}


### PR DESCRIPTION
#### Details

Issue reference: <!-- #252 -->

List of changes:
* Added LightBddScopeAttribute.DiagnosticMessageSink property for LightBDD.XUnit2 project

Example usage: `LightBDD.XUnit2.IntegrationTests` project

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [x] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
