### PR TITLE
#248 Improved MessageListener.EnsureReceived() to return friendly message dumps for common types

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ LightBDD
 
 Version [next]
 ----------------------------------------
++ #248 (Framework)(Change) Improved MessageListener.EnsureReceived() to return friendly message dumps for common types
 
 Version 3.4.0 (VSIX)
 ----------------------------------------

--- a/src/LightBDD.Core/Formatting/Diagnostics/ObjectFormatter.cs
+++ b/src/LightBDD.Core/Formatting/Diagnostics/ObjectFormatter.cs
@@ -68,6 +68,9 @@ namespace LightBDD.Core.Formatting.Diagnostics
                 return builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", obj);
             if (type.IsEnum)
                 return builder.Append(Enum.GetName(type, obj));
+            var basic = TryFormatBasic(obj);
+            if (basic != null)
+                return builder.Append('\"').Append(basic).Append('\"');
 
             if (level == 0)
                 return builder.Append("{...}");
@@ -88,6 +91,17 @@ namespace LightBDD.Core.Formatting.Diagnostics
                 builder.Append(member.Name).Append("=").DumpProperty(member, obj, level).Append(" ");
 
             return builder.Append("}");
+        }
+
+        private static string TryFormatBasic(object value)
+        {
+            return value switch
+            {
+                DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("O", CultureInfo.InvariantCulture),
+                DateTime dateTime => dateTime.ToString("O", CultureInfo.InvariantCulture),
+                IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+                _ => null
+            };
         }
 
         private static StringBuilder DumpProperty(this StringBuilder builder, PropertyInfo member, object obj, int level)

--- a/test/LightBDD.Core.UnitTests/Formatting/Diagnostics/ObjectFormatter_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Formatting/Diagnostics/ObjectFormatter_tests.cs
@@ -28,6 +28,16 @@ namespace LightBDD.Core.UnitTests.Formatting.Diagnostics
             public string Prop => throw new InvalidOperationException("foo");
         }
 
+        class BasicTypes
+        {
+            public TimeSpan? Span { get; set; }
+            public DateTime? DateTime { get; set; }
+            public DateTimeOffset? DateTimeOffset { get; set; }
+            public Guid? Guid { get; set; }
+            public decimal Decimal { get; set; }
+            public long? NullableLong { get; set; }
+        }
+
         [Test]
         public void It_should_format_object()
         {
@@ -41,7 +51,7 @@ namespace LightBDD.Core.UnitTests.Formatting.Diagnostics
             };
 
             var actual = ObjectFormatter.Dump(obj);
-            Assert.That(actual, Is.EqualTo("ComplexType: { StringField=\"test!\" Int=5 Flag=True ReadonlyFloat=3.14 Array=[ Local Unspecified Utc ] Dictionary=[ { Key=\"abc\" Value={ StringField=null Int=0 Flag=False ReadonlyFloat=3.14 Array={...} Dictionary={...} Span=null } } ] Span={ Ticks=864000000000 Days=1 Hours=0 Milliseconds=0 Minutes=0 Seconds=0 TotalDays=1 TotalHours=24 TotalMilliseconds=86400000 TotalMinutes=1440 TotalSeconds=86400 } }"));
+            Assert.That(actual, Is.EqualTo("ComplexType: { StringField=\"test!\" Int=5 Flag=True ReadonlyFloat=3.14 Array=[ Local Unspecified Utc ] Dictionary=[ { Key=\"abc\" Value={ StringField=null Int=0 Flag=False ReadonlyFloat=3.14 Array={...} Dictionary={...} Span=null } } ] Span=\"1.00:00:00\" }"));
         }
 
         [Test]
@@ -63,7 +73,7 @@ namespace LightBDD.Core.UnitTests.Formatting.Diagnostics
             };
 
             var actual = ObjectFormatter.DumpMany(items);
-            Assert.That(actual.Replace("\r", ""), Is.EqualTo(@"ComplexType: { StringField=""test!"" Int=5 Flag=True ReadonlyFloat=3.14 Array=[ Local Unspecified Utc ] Dictionary=[ {...} ] Span={ Ticks=432000000000 Days=0 Hours=12 Milliseconds=0 Minutes=0 Seconds=0 TotalDays=0.5 TotalHours=12 TotalMilliseconds=43200000 TotalMinutes=720 TotalSeconds=43200 } }
+            Assert.That(actual.Replace("\r", ""), Is.EqualTo(@"ComplexType: { StringField=""test!"" Int=5 Flag=True ReadonlyFloat=3.14 Array=[ Local Unspecified Utc ] Dictionary=[ {...} ] Span=""12:00:00"" }
 BaseType: { StringField=""123"" }
 Double: 3.14
 Boolean: False".Replace("\r", "")));
@@ -74,6 +84,22 @@ Boolean: False".Replace("\r", "")));
         {
             var actual = ObjectFormatter.Dump(new Problematic());
             Assert.That(actual, Is.EqualTo("Problematic: { Prop=!InvalidOperationException:\"foo\" }"));
+        }
+
+        [Test]
+        public void It_should_format_basic_types_properly()
+        {
+            var obj = new BasicTypes
+            {
+                DateTimeOffset = new DateTimeOffset(2022,01,02,03,04,05,TimeSpan.FromHours(3)),
+                DateTime = new DateTime(2022,01,02,03,04,05,DateTimeKind.Utc),
+                Decimal = (decimal)3.14,
+                Guid = Guid.Parse("8bdcb730-6d08-409d-8170-12da52cb71e1"),
+                NullableLong = 34,
+                Span = TimeSpan.FromTicks(101427461000),
+            };
+            var actual = ObjectFormatter.Dump(obj);
+            Assert.That(actual.Replace("\r", ""), Is.EqualTo("BasicTypes: { Span=\"02:49:02.7461000\" DateTime=\"2022-01-02T03:04:05.0000000Z\" DateTimeOffset=\"2022-01-02T03:04:05.0000000+03:00\" Guid=\"8bdcb730-6d08-409d-8170-12da52cb71e1\" Decimal=\"3.14\" NullableLong=34 }".Replace("\r", "")));
         }
     }
 }


### PR DESCRIPTION
…

<!-- Add brief description here -->

#### Details

Issue reference: <!-- #248 -->

List of changes:
* Updated `ObjectFormatter` to format `DateTime`, `DateTimeOffset` types with `O` format,
* Updated `ObjectFormatter` to format `IFormattable` types with invariant culture

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
