### PR TITLE
#255 Added support for file attachments on scenario steps

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -7,6 +7,12 @@ Version [next]
 + #260 (LightBDD.NUnit3)(Change) Updated NUnit dependency to 3.13.3
 + #260 (LightBDD.Fixie2)(Change) Dropped netcoreapp2.0 support
 + #260 (Examples) Removed Example.LightBDD.MsTest2.UWP project as UWP is deprecated
++ #255 (LightBDD.Core) Added IStep.AttachFile() method allowing to add file attachments to steps and fired StepFileAttached progress notification event when attachment is made
++ #255 (LightBDD.Core) Added ReportWritersConfiguration.UpdateFileAttachmentsManager() to allow re-configuring file attachments storage
++ #255 (LightBDD.Framework) Added support to attach files to steps with StepExecution.Current.AttachFile()
++ #255 (LightBDD.Framework) Added FileAttachmentManager implementation and registered it with ReportWritersConfiguration.RegisterDefaultFileAttachmentManager() extension method to create attachments in ~/Reports folder
++ #255 (LightBDD.Framework) Updated DefaultProgressNotifier to notify on StepFileAttached event
++ #255 (LightBDD.Framework) Updated HtmlResultTextWriter / PlainTextReportFormatter / XmlReportFormatter to include file attachments
 + #225 (Core)(New) Introduced IProgressNotifier and processing events: FeatureStarting, FeatureFinished, ScenarioStarting, ScenarioFinished, StepStarting, StepFinished, StepCommented
 + #225 (Core)(New) Extended ScenarioExecutionContext with GetCurrentScenarioFixtureIfPresent to return fixture object executing given scenario
 + #225 (Framework)(New) Introduced ProgressNotifierConfiguration to configure IProgressNotifier instances and updated DefaultProgressNotifier, NoProgressNotifier to implement IProgressNotifier and added ParallelProgressNotifierProvider.CreateProgressNotifier() method

--- a/examples/Example.LightBDD.Fixie2/Features/Customer_journey.Steps.cs
+++ b/examples/Example.LightBDD.Fixie2/Features/Customer_journey.Steps.cs
@@ -1,7 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text;
+using System.Threading.Tasks;
 using Example.Domain.Helpers;
 using LightBDD.Fixie2;
 using LightBDD.Framework;
+using LightBDD.Framework.Reporting;
 
 #pragma warning disable 1998
 
@@ -14,6 +16,7 @@ namespace Example.LightBDD.Fixie2.Features
         {
             public async Task Then_customer_should_receive_invoice()
             {
+                await StepExecution.Current.AttachFile(m => m.CreateFromText("invoice-content", "txt", "Example invoice content", Encoding.UTF8));
                 StepExecution.Current.IgnoreScenario("Not implemented yet");
             }
 

--- a/examples/Example.LightBDD.MsTest2/Features/Customer_journey.Steps.cs
+++ b/examples/Example.LightBDD.MsTest2/Features/Customer_journey.Steps.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text;
+using System.Threading.Tasks;
 using Example.Domain.Helpers;
 using LightBDD.Framework;
+using LightBDD.Framework.Reporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #pragma warning disable 1998
@@ -14,6 +16,7 @@ namespace Example.LightBDD.MsTest2.Features
         {
             public async Task Then_customer_should_receive_invoice()
             {
+                await StepExecution.Current.AttachFile(m => m.CreateFromText("invoice-content", "txt", "Example invoice content", Encoding.UTF8));
                 Assert.Inconclusive("Not implemented yet");
             }
 

--- a/examples/Example.LightBDD.NUnit3/Features/Customer_journey.Steps.cs
+++ b/examples/Example.LightBDD.NUnit3/Features/Customer_journey.Steps.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text;
+using System.Threading.Tasks;
 using Example.Domain.Helpers;
 using LightBDD.Framework;
+using LightBDD.Framework.Reporting;
 using NUnit.Framework;
 
 #pragma warning disable 1998
@@ -14,6 +16,7 @@ namespace Example.LightBDD.NUnit3.Features
         {
             public async Task Then_customer_should_receive_invoice()
             {
+                await StepExecution.Current.AttachFile(m => m.CreateFromText("invoice-content", "txt", "Example invoice content", Encoding.UTF8));
                 Assert.Ignore("Not implemented yet");
             }
 

--- a/examples/Example.LightBDD.XUnit2/Features/Customer_journey.Steps.cs
+++ b/examples/Example.LightBDD.XUnit2/Features/Customer_journey.Steps.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text;
+using System.Threading.Tasks;
 using Example.Domain.Helpers;
 using LightBDD.Framework;
+using LightBDD.Framework.Reporting;
 using LightBDD.XUnit2;
 
 #pragma warning disable 1998
@@ -14,6 +16,7 @@ namespace Example.LightBDD.XUnit2.Features
         {
             public async Task Then_customer_should_receive_invoice()
             {
+                await StepExecution.Current.AttachFile(m => m.CreateFromText("invoice-content", "txt", "Example invoice content", Encoding.UTF8));
                 StepExecution.Current.IgnoreScenario("Not implemented yet");
             }
 

--- a/schemas/XmlReportFormatterSchema.xsd
+++ b/schemas/XmlReportFormatterSchema.xsd
@@ -182,6 +182,12 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="Comment" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="FileAttachment" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+                <xs:attribute name="Name" type="xs:string" use="required"/>
+                <xs:attribute name="Path" type="xs:string" use="required"/>
+            </xs:complexType>
+        </xs:element>
       <xs:element name="SubStep" type="Step" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="Status" type="ResultStatus" use="required"/>

--- a/src/LightBDD.Core/Configuration/ReportWritersConfiguration.cs
+++ b/src/LightBDD.Core/Configuration/ReportWritersConfiguration.cs
@@ -10,7 +10,13 @@ namespace LightBDD.Core.Configuration
     /// </summary>
     public class ReportWritersConfiguration : FeatureConfiguration, IEnumerable<IReportWriter>
     {
-        private readonly List<IReportWriter> _writers = new List<IReportWriter>();
+        private readonly List<IReportWriter> _writers = new();
+        private IFileAttachmentsManager _fileAttachmentsManager = NoFileAttachmentsManager.Instance;
+
+        /// <summary>
+        /// File Attachments Manager
+        /// </summary>
+        public IFileAttachmentsManager GetFileAttachmentsManager() => _fileAttachmentsManager;
 
         /// <summary>
         /// Adds <paramref name="writer"/> to report writers collection.
@@ -47,6 +53,20 @@ namespace LightBDD.Core.Configuration
         {
             ThrowIfSealed();
             _writers.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <paramref name="manager"/> as a default file attachments manager to be used by LightBDD. The manager can be retrieved by <see cref="GetFileAttachmentsManager"/> method call.
+        /// </summary>
+        /// <param name="manager">Manager to set</param>
+        /// <returns></returns>
+        public ReportWritersConfiguration UpdateFileAttachmentsManager(IFileAttachmentsManager manager)
+        {
+            ThrowIfSealed();
+
+            _fileAttachmentsManager = manager ?? throw new ArgumentNullException(nameof(manager));
+
             return this;
         }
 

--- a/src/LightBDD.Core/Execution/IStep.cs
+++ b/src/LightBDD.Core/Execution/IStep.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Threading.Tasks;
 using LightBDD.Core.Dependencies;
 using LightBDD.Core.Metadata;
+using LightBDD.Core.Reporting;
+using LightBDD.Core.Results;
 
 namespace LightBDD.Core.Execution
 {
@@ -26,5 +30,12 @@ namespace LightBDD.Core.Execution
         /// Returns the context used by this step (or null if none were provided).
         /// </summary>
         object Context { get; }
+
+        /// <summary>
+        /// Adds the file attachment to the step.
+        /// </summary>
+        /// <param name="createAttachmentFn">Function creating file attachment by using provided attachments manager.</param>
+        /// <returns></returns>
+        Task AttachFile(Func<IFileAttachmentsManager, Task<FileAttachment>> createAttachmentFn);
     }
 }

--- a/src/LightBDD.Core/Execution/Implementation/RunnableScenarioContext.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableScenarioContext.cs
@@ -4,6 +4,7 @@ using LightBDD.Core.Dependencies;
 using LightBDD.Core.Extensibility;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Notification;
+using LightBDD.Core.Reporting;
 using LightBDD.Core.Results;
 
 namespace LightBDD.Core.Execution.Implementation
@@ -18,6 +19,7 @@ namespace LightBDD.Core.Execution.Implementation
         public ProvideStepsFunc StepsProvider { get; }
         public IProgressNotifier ProgressNotifier => IntegrationContext.ProgressNotifier;
         public IExecutionTimer ExecutionTimer => IntegrationContext.ExecutionTimer;
+        public IFileAttachmentsManager FileAttachmentsManager => IntegrationContext.FileAttachmentsManager;
 
         public RunnableScenarioContext(IntegrationContext integrationContext,
             ExceptionProcessor exceptionProcessor,

--- a/src/LightBDD.Core/Execution/Implementation/RunnableStep.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableStep.cs
@@ -12,6 +12,7 @@ using LightBDD.Core.Internals;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Metadata.Implementation;
 using LightBDD.Core.Notification.Events;
+using LightBDD.Core.Reporting;
 using LightBDD.Core.Results;
 using LightBDD.Core.Results.Implementation;
 using LightBDD.Core.Results.Parameters;
@@ -25,7 +26,7 @@ namespace LightBDD.Core.Execution.Implementation
         private readonly Func<Task> _decoratedStepMethod;
         private readonly StepResult _result;
         private readonly StepFunc _invocation;
-        private readonly ExceptionCollector _exceptionCollector = new ExceptionCollector();
+        private readonly ExceptionCollector _exceptionCollector = new();
         private Func<Exception, bool> _shouldAbortSubStepExecutionFn = _ => true;
         private IDependencyContainer _subStepScope;
         public IStepResult Result => _result;
@@ -97,7 +98,7 @@ namespace LightBDD.Core.Execution.Implementation
 
         private RunnableStep[] InitializeComposite(IStepResultDescriptor result)
         {
-            if (!(result is CompositeStepResultDescriptor compositeDescriptor))
+            if (result is not CompositeStepResultDescriptor compositeDescriptor)
                 return Array.Empty<RunnableStep>();
 
             _subStepScope = _stepContext.Container.BeginScope(LifetimeScope.Local, compositeDescriptor.SubStepsContext.ScopeConfigurator);
@@ -252,7 +253,7 @@ namespace LightBDD.Core.Execution.Implementation
                 case StepExecutionException e:
                     _result.SetStatus(e.StepStatus);
                     break;
-                case ScenarioExecutionException e when e.InnerException is StepBypassException:
+                case ScenarioExecutionException { InnerException: StepBypassException }:
                     _result.SetStatus(ExecutionStatus.Bypassed, exception.InnerException.Message);
                     break;
                 case ScenarioExecutionException e:
@@ -307,6 +308,13 @@ namespace LightBDD.Core.Execution.Implementation
         public override string ToString()
         {
             return _result.ToString();
+        }
+
+        public async Task AttachFile(Func<IFileAttachmentsManager, Task<FileAttachment>> createAttachmentFn)
+        {
+            var attachment = await createAttachmentFn(_stepContext.FileAttachmentsManager);
+            _result.AddAttachment(attachment);
+            _stepContext.ProgressNotifier.Notify(new StepFileAttached(_stepContext.ExecutionTimer.GetTime(), _result.Info, attachment));
         }
     }
 }

--- a/src/LightBDD.Core/Execution/Implementation/RunnableStepContext.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableStepContext.cs
@@ -1,6 +1,7 @@
 using System;
 using LightBDD.Core.Dependencies;
 using LightBDD.Core.Notification;
+using LightBDD.Core.Reporting;
 
 namespace LightBDD.Core.Execution.Implementation
 {
@@ -8,7 +9,7 @@ namespace LightBDD.Core.Execution.Implementation
     {
         public RunnableStepContext(ExceptionProcessor exceptionProcessor, IProgressNotifier progressNotifier,
             IDependencyContainer container, object context, ProvideStepsFunc provideSteps,
-            Func<Exception, bool> shouldAbortSubStepExecution, IExecutionTimer executionTimer)
+            Func<Exception, bool> shouldAbortSubStepExecution, IExecutionTimer executionTimer, IFileAttachmentsManager fileAttachmentsManager)
         {
             ExceptionProcessor = exceptionProcessor;
             ProgressNotifier = progressNotifier;
@@ -17,6 +18,7 @@ namespace LightBDD.Core.Execution.Implementation
             ProvideSteps = provideSteps;
             ShouldAbortSubStepExecution = shouldAbortSubStepExecution;
             ExecutionTimer = executionTimer;
+            FileAttachmentsManager = fileAttachmentsManager;
         }
 
         public ExceptionProcessor ExceptionProcessor { get; }
@@ -26,5 +28,6 @@ namespace LightBDD.Core.Execution.Implementation
         public ProvideStepsFunc ProvideSteps { get; }
         public Func<Exception, bool> ShouldAbortSubStepExecution { get; }
         public IExecutionTimer ExecutionTimer { get; }
+        public IFileAttachmentsManager FileAttachmentsManager { get; }
     }
 }

--- a/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
@@ -136,7 +136,7 @@ namespace LightBDD.Core.Extensibility.Implementation
             string previousStepTypeName = null;
 
             var extensions = _context.IntegrationContext.ExecutionExtensions;
-            var stepContext = new RunnableStepContext(_context.ExceptionProcessor, _context.ProgressNotifier, container, context, ProvideSteps, shouldAbortSubStepExecutionFn, _context.ExecutionTimer);
+            var stepContext = new RunnableStepContext(_context.ExceptionProcessor, _context.ProgressNotifier, container, context, ProvideSteps, shouldAbortSubStepExecutionFn, _context.ExecutionTimer,_context.FileAttachmentsManager);
             for (var stepIndex = 0; stepIndex < totalSteps; ++stepIndex)
             {
                 var descriptor = descriptors[stepIndex];

--- a/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/ScenarioBuilder.cs
@@ -136,7 +136,7 @@ namespace LightBDD.Core.Extensibility.Implementation
             string previousStepTypeName = null;
 
             var extensions = _context.IntegrationContext.ExecutionExtensions;
-            var stepContext = new RunnableStepContext(_context.ExceptionProcessor, _context.ProgressNotifier, container, context, ProvideSteps, shouldAbortSubStepExecutionFn, _context.ExecutionTimer,_context.FileAttachmentsManager);
+            var stepContext = new RunnableStepContext(_context.ExceptionProcessor, _context.ProgressNotifier, container, context, ProvideSteps, shouldAbortSubStepExecutionFn, _context.ExecutionTimer, _context.FileAttachmentsManager);
             for (var stepIndex = 0; stepIndex < totalSteps; ++stepIndex)
             {
                 var descriptor = descriptors[stepIndex];

--- a/src/LightBDD.Core/Extensibility/IntegrationContext.cs
+++ b/src/LightBDD.Core/Extensibility/IntegrationContext.cs
@@ -9,6 +9,7 @@ using LightBDD.Core.Execution;
 using LightBDD.Core.Execution.Implementation;
 using LightBDD.Core.Formatting.Values;
 using LightBDD.Core.Notification.Implementation;
+using LightBDD.Core.Reporting;
 
 namespace LightBDD.Core.Extensibility
 {
@@ -77,6 +78,11 @@ namespace LightBDD.Core.Extensibility
         /// Returns execution timer.
         /// </summary>
         public IExecutionTimer ExecutionTimer { get; } = DefaultExecutionTimer.StartNew();
+
+        /// <summary>
+        /// Returns File Attachments Manager
+        /// </summary>
+        public virtual IFileAttachmentsManager FileAttachmentsManager => Configuration.ReportWritersConfiguration().GetFileAttachmentsManager();
 
         /// <summary>
         /// Creates progress notifier.

--- a/src/LightBDD.Core/Notification/Events/StepFileAttached.cs
+++ b/src/LightBDD.Core/Notification/Events/StepFileAttached.cs
@@ -1,0 +1,30 @@
+﻿using LightBDD.Core.Execution;
+using LightBDD.Core.Metadata;
+using LightBDD.Core.Results;
+
+namespace LightBDD.Core.Notification.Events;
+
+/// <summary>
+/// Event raised when step gets file attached
+/// </summary>
+public class StepFileAttached : ProgressEvent
+{
+    /// <summary>
+    /// Step.
+    /// </summary>
+    public IStepInfo Step { get; }
+        
+    /// <summary>
+    /// Attachment.
+    /// </summary>
+    public FileAttachment Attachment { get; }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public StepFileAttached(EventTime time, IStepInfo step, FileAttachment attachment) : base(time)
+    {
+        Step = step;
+        Attachment = attachment;
+    }
+}

--- a/src/LightBDD.Core/Reporting/IFileAttachmentsManager.cs
+++ b/src/LightBDD.Core/Reporting/IFileAttachmentsManager.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using LightBDD.Core.Results;
+
+namespace LightBDD.Core.Reporting;
+
+/// <summary>
+/// Manager responsible for creating File Attachments that can be associated with scenario steps.
+/// </summary>
+public interface IFileAttachmentsManager
+{
+    /// <summary>
+    /// Creates attachment from existing file.<br/>
+    /// The attachment is stored in the pre-configured location.<br/>
+    /// Caller can choose if the original file should be removed after (default option) or preserved.
+    /// </summary>
+    /// <param name="name">Attachment name</param>
+    /// <param name="filePath">Attachment file location</param>
+    /// <param name="removeOriginalFile">Shall the original file be removed after attachment creation?</param>
+    /// <returns>File attachment</returns>
+    Task<FileAttachment> CreateFromFile(string name, string filePath, bool removeOriginalFile = true);
+
+    /// <summary>
+    /// Creates attachment by using write stream.<br/>
+    /// The attachment is stored in the pre-configured location.<br/>
+    /// </summary>
+    /// <param name="name">Attachment name</param>
+    /// <param name="fileExtension">File extension</param>
+    /// <param name="writeStreamFn">Function providing write stream to the attachment</param>
+    /// <returns>File attachment</returns>
+    Task<FileAttachment> CreateFromStream(string name, string fileExtension, Func<Stream, Task> writeStreamFn);
+
+    /// <summary>
+    /// Creates attachment from in memory content.<br/>
+    /// The attachment is stored in the pre-configured location.<br/>
+    /// </summary>
+    /// <param name="name">Attachment name</param>
+    /// <param name="fileExtension">File extension</param>
+    /// <param name="content">Attachment content</param>
+    /// <returns>File attachment</returns>
+    Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content);
+}

--- a/src/LightBDD.Core/Reporting/IFileAttachmentsManager.cs
+++ b/src/LightBDD.Core/Reporting/IFileAttachmentsManager.cs
@@ -30,14 +30,4 @@ public interface IFileAttachmentsManager
     /// <param name="writeStreamFn">Function providing write stream to the attachment</param>
     /// <returns>File attachment</returns>
     Task<FileAttachment> CreateFromStream(string name, string fileExtension, Func<Stream, Task> writeStreamFn);
-
-    /// <summary>
-    /// Creates attachment from in memory content.<br/>
-    /// The attachment is stored in the pre-configured location.<br/>
-    /// </summary>
-    /// <param name="name">Attachment name</param>
-    /// <param name="fileExtension">File extension</param>
-    /// <param name="content">Attachment content</param>
-    /// <returns>File attachment</returns>
-    Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content);
 }

--- a/src/LightBDD.Core/Reporting/NoFileAttachmentsManager.cs
+++ b/src/LightBDD.Core/Reporting/NoFileAttachmentsManager.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using LightBDD.Core.Results;
+
+namespace LightBDD.Core.Reporting;
+
+/// <summary>
+/// File attachments manager that is used when file attachments are disabled.
+/// </summary>
+public class NoFileAttachmentsManager : IFileAttachmentsManager
+{
+    private const string FileAttachmentsAreDisabled = "File Attachments are disabled";
+
+    /// <summary>
+    /// Default instance
+    /// </summary>
+    public static readonly NoFileAttachmentsManager Instance = new();
+
+    /// <inheritdoc />
+    public Task<FileAttachment> CreateFromFile(string name, string filePath, bool removeOriginalFile = true)
+    {
+        throw new NotSupportedException(FileAttachmentsAreDisabled);
+    }
+
+    /// <inheritdoc />
+    public Task<FileAttachment> CreateFromStream(string name, string fileExtension, Func<Stream, Task> writeStreamFn)
+    {
+        throw new NotSupportedException(FileAttachmentsAreDisabled);
+    }
+
+    /// <inheritdoc />
+    public Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content)
+    {
+        throw new NotSupportedException(FileAttachmentsAreDisabled);
+    }
+}

--- a/src/LightBDD.Core/Reporting/NoFileAttachmentsManager.cs
+++ b/src/LightBDD.Core/Reporting/NoFileAttachmentsManager.cs
@@ -28,10 +28,4 @@ public class NoFileAttachmentsManager : IFileAttachmentsManager
     {
         throw new NotSupportedException(FileAttachmentsAreDisabled);
     }
-
-    /// <inheritdoc />
-    public Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content)
-    {
-        throw new NotSupportedException(FileAttachmentsAreDisabled);
-    }
 }

--- a/src/LightBDD.Core/Results/FileAttachment.cs
+++ b/src/LightBDD.Core/Results/FileAttachment.cs
@@ -8,18 +8,25 @@ public class FileAttachment
     /// <summary>
     /// Default constructor
     /// </summary>
-    public FileAttachment(string name, string filePath)
+    public FileAttachment(string name, string filePath, string relativePath)
     {
         Name = name;
         FilePath = filePath;
+        RelativePath = relativePath;
     }
 
     /// <summary>
     /// Attachment name
     /// </summary>
     public string Name { get; }
+
     /// <summary>
-    /// Attachment path
+    /// Attachment file path
     /// </summary>
     public string FilePath { get; }
+
+    /// <summary>
+    /// Attachment relative path
+    /// </summary>
+    public string RelativePath { get; }
 }

--- a/src/LightBDD.Core/Results/FileAttachment.cs
+++ b/src/LightBDD.Core/Results/FileAttachment.cs
@@ -1,0 +1,25 @@
+namespace LightBDD.Core.Results;
+
+/// <summary>
+/// File attachment
+/// </summary>
+public class FileAttachment
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public FileAttachment(string name, string filePath)
+    {
+        Name = name;
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Attachment name
+    /// </summary>
+    public string Name { get; }
+    /// <summary>
+    /// Attachment path
+    /// </summary>
+    public string FilePath { get; }
+}

--- a/src/LightBDD.Core/Results/IStepResult.cs
+++ b/src/LightBDD.Core/Results/IStepResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LightBDD.Core.Metadata;
+using LightBDD.Core.Results.Implementation;
 using LightBDD.Core.Results.Parameters;
 
 namespace LightBDD.Core.Results
@@ -43,5 +44,9 @@ namespace LightBDD.Core.Results
         /// Returns sub-steps if given step consists of any, or empty collection.
         /// </summary>
         IEnumerable<IStepResult> GetSubSteps();
+        /// <summary>
+        /// Returns step file attachments.
+        /// </summary>
+        IEnumerable<FileAttachment> FileAttachments { get; }
     }
 }

--- a/src/LightBDD.Core/Results/Implementation/StepResult.cs
+++ b/src/LightBDD.Core/Results/Implementation/StepResult.cs
@@ -12,7 +12,8 @@ namespace LightBDD.Core.Results.Implementation
     internal class StepResult : IStepResult
     {
         private readonly StepInfo _info;
-        private readonly ConcurrentQueue<string> _comments = new ConcurrentQueue<string>();
+        private readonly ConcurrentQueue<string> _comments = new();
+        private readonly ConcurrentQueue<FileAttachment> _attachments = new();
         private IEnumerable<IStepResult> _subSteps = Array.Empty<IStepResult>();
 
         public StepResult(StepInfo info)
@@ -27,10 +28,8 @@ namespace LightBDD.Core.Results.Implementation
         public IReadOnlyList<IParameterResult> Parameters { get; private set; } = Array.Empty<IParameterResult>();
         public ExecutionTime ExecutionTime { get; private set; }
         public IEnumerable<string> Comments => _comments;
-        public IEnumerable<IStepResult> GetSubSteps()
-        {
-            return _subSteps;
-        }
+        public IEnumerable<IStepResult> GetSubSteps() => _subSteps;
+        public IEnumerable<FileAttachment> FileAttachments => _attachments;
 
         public void SetStatus(ExecutionStatus status, string details = null)
         {
@@ -82,6 +81,11 @@ namespace LightBDD.Core.Results.Implementation
         public void SetParameters(IEnumerable<IParameterResult> parameters)
         {
             Parameters = parameters.ToArray();
+        }
+
+        public void AddAttachment(FileAttachment attachment)
+        {
+            _attachments.Enqueue(attachment);
         }
     }
 }

--- a/src/LightBDD.Framework/Configuration/FrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.Framework/Configuration/FrameworkConfigurationExtensions.cs
@@ -26,7 +26,8 @@ namespace LightBDD.Framework.Configuration
 
             configuration
                 .ReportWritersConfiguration()
-                .RegisterFrameworkDefaultReportWriters();
+                .RegisterFrameworkDefaultReportWriters()
+                .RegisterDefaultFileAttachmentManager();
 
             configuration
                 .NameFormatterConfiguration()
@@ -52,7 +53,17 @@ namespace LightBDD.Framework.Configuration
         /// </summary>
         public static ReportWritersConfiguration RegisterFrameworkDefaultReportWriters(this ReportWritersConfiguration configuration)
         {
-            return configuration.Add(new ReportFileWriter(new HtmlReportFormatter(), "~" + Path.DirectorySeparatorChar + "Reports" + Path.DirectorySeparatorChar + "FeaturesReport.html"));
+            return configuration
+                .Add(new ReportFileWriter(new HtmlReportFormatter(), $"~{Path.DirectorySeparatorChar}Reports{Path.DirectorySeparatorChar}FeaturesReport.html"));
+        }
+
+        /// <summary>
+        /// Applies default file attachment manager configuration to generate attachments in <c>~\\Reports\</c>(Win) <c>~/Reports/</c>(Unix) directory.
+        /// </summary>
+        public static ReportWritersConfiguration RegisterDefaultFileAttachmentManager(this ReportWritersConfiguration configuration)
+        {
+            return configuration
+                .UpdateFileAttachmentsManager(new FileAttachmentsManager($"~{Path.DirectorySeparatorChar}Reports"));
         }
 
         /// <summary>

--- a/src/LightBDD.Framework/Extensibility/DefaultIntegrationContext.cs
+++ b/src/LightBDD.Framework/Extensibility/DefaultIntegrationContext.cs
@@ -7,6 +7,7 @@ using LightBDD.Core.Formatting.Values;
 using LightBDD.Core.Notification;
 using LightBDD.Core.Results;
 using System;
+using LightBDD.Core.Reporting;
 using LightBDD.Framework.Configuration;
 using LightBDD.Framework.Notification;
 using LightBDD.Framework.Notification.Implementation;
@@ -48,6 +49,9 @@ namespace LightBDD.Framework.Extensibility
         /// <inheritdoc />
         public override ValueFormattingService ValueFormattingService => MetadataProvider.ValueFormattingService;
 
+        /// <inheritdoc />
+        public override IFileAttachmentsManager FileAttachmentsManager { get; }
+
         /// <summary>
         /// Default constructor sealing provided <paramref name="configuration"/> and initializing all properties.
         /// </summary>
@@ -64,6 +68,7 @@ namespace LightBDD.Framework.Extensibility
             ScenarioProgressNotifierProvider = configuration.ScenarioProgressNotifierConfiguration().NotifierProvider;
             ExecutionExtensions = configuration.ExecutionExtensionsConfiguration();
             DependencyContainer = configuration.DependencyContainerConfiguration().DependencyContainer;
+            FileAttachmentsManager = configuration.ReportWritersConfiguration().GetFileAttachmentsManager();
         }
 
         /// <inheritdoc />

--- a/src/LightBDD.Framework/Notification/DefaultProgressNotifier.cs
+++ b/src/LightBDD.Framework/Notification/DefaultProgressNotifier.cs
@@ -138,7 +138,15 @@ namespace LightBDD.Framework.Notification
                 case StepStarting stepStarting:
                     NotifyStepStart(stepStarting.Step);
                     break;
+                case StepFileAttached stepFileAttached:
+                    NotifyStepAttached(stepFileAttached.Step, stepFileAttached.Attachment);
+                    break;
             }
+        }
+
+        private void NotifyStepAttached(IStepInfo step, FileAttachment attachment)
+        {
+            _onNotify($"  STEP {step.GroupPrefix}{step.Number}/{step.GroupPrefix}{step.Total}: File Attached - {attachment.Name}: {attachment.FilePath}");
         }
 
         private static string FormatDescription(string description)

--- a/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
+++ b/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
@@ -31,38 +31,41 @@ public class FileAttachmentsManager : IFileAttachmentsManager
     public Task<FileAttachment> CreateFromFile(string name, string filePath, bool removeOriginalFile = true)
     {
         var fileExtension = SanitizeExtension(Path.GetExtension(filePath));
-        var destinationFilePath = GetAttachmentPath(fileExtension);
+        var destinationFile = GetAttachmentFile(fileExtension);
+        var destinationFilePath = Path.Combine(AttachmentsDirectory, destinationFile);
 
         if (removeOriginalFile)
             File.Move(filePath, destinationFilePath);
         else
             File.Copy(filePath, destinationFilePath);
 
-        return Task.FromResult(new FileAttachment(name, destinationFilePath));
+        return Task.FromResult(new FileAttachment(name, destinationFilePath, destinationFile));
     }
 
     /// <inheritdoc />
     public async Task<FileAttachment> CreateFromStream(string name, string fileExtension, Func<Stream, Task> writeStreamFn)
     {
         fileExtension = SanitizeExtension(fileExtension);
-        var destinationFilePath = GetAttachmentPath(fileExtension);
+        var destinationFile = GetAttachmentFile(fileExtension);
+        var destinationFilePath = Path.Combine(AttachmentsDirectory, destinationFile);
 
         using var stream = File.OpenWrite(destinationFilePath);
         await writeStreamFn(stream);
 
-        return new(name, destinationFilePath);
+        return new(name, destinationFilePath, destinationFile);
     }
 
     /// <inheritdoc />
     public async Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content)
     {
         fileExtension = SanitizeExtension(fileExtension);
-        var destinationFilePath = GetAttachmentPath(fileExtension);
+        var destinationFile = GetAttachmentFile(fileExtension);
+        var destinationFilePath = Path.Combine(AttachmentsDirectory, destinationFile);
 
         using var stream = File.OpenWrite(destinationFilePath);
         await stream.WriteAsync(content, 0, content.Length);
 
-        return new(name, destinationFilePath);
+        return new(name, destinationFilePath, destinationFile);
     }
 
     private string SanitizeExtension(string fileExtension)
@@ -77,5 +80,5 @@ public class FileAttachmentsManager : IFileAttachmentsManager
             : $".{fileExtension}";
     }
 
-    private string GetAttachmentPath(string extension) => Path.Combine(AttachmentsDirectory, $"{Guid.NewGuid()}{extension}");
+    private string GetAttachmentFile(string extension) => $"{Guid.NewGuid()}{extension}";
 }

--- a/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
+++ b/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using LightBDD.Core.Reporting;
+using LightBDD.Core.Results;
+using LightBDD.Framework.Reporting.Implementation;
+
+namespace LightBDD.Framework.Reporting;
+
+/// <summary>
+/// File Attachments Manager
+/// </summary>
+public class FileAttachmentsManager : IFileAttachmentsManager
+{
+    /// <summary>
+    /// Directory where attachments are stored
+    /// </summary>
+    public string AttachmentsDirectory { get; }
+
+    /// <summary>
+    /// Initializes the File Attachments Manager with <paramref name="attachmentsDirectory"/>
+    /// </summary>
+    /// <param name="attachmentsDirectory">Attachments directory. If starts with <c>~</c>, it would be resolved to <c>AppContext.BaseDirectory</c>.</param>
+    public FileAttachmentsManager(string attachmentsDirectory)
+    {
+        AttachmentsDirectory = FilePathHelper.ResolveAbsolutePath(attachmentsDirectory);
+        Directory.CreateDirectory(AttachmentsDirectory);
+    }
+
+    /// <inheritdoc />
+    public Task<FileAttachment> CreateFromFile(string name, string filePath, bool removeOriginalFile = true)
+    {
+        var fileExtension = SanitizeExtension(Path.GetExtension(filePath));
+        var destinationFilePath = GetAttachmentPath(fileExtension);
+
+        if (removeOriginalFile)
+            File.Move(filePath, destinationFilePath);
+        else
+            File.Copy(filePath, destinationFilePath);
+
+        return Task.FromResult(new FileAttachment(name, destinationFilePath));
+    }
+
+    /// <inheritdoc />
+    public async Task<FileAttachment> CreateFromStream(string name, string fileExtension, Func<Stream, Task> writeStreamFn)
+    {
+        fileExtension = SanitizeExtension(fileExtension);
+        var destinationFilePath = GetAttachmentPath(fileExtension);
+
+        using var stream = File.OpenWrite(destinationFilePath);
+        await writeStreamFn(stream);
+
+        return new(name, destinationFilePath);
+    }
+
+    /// <inheritdoc />
+    public async Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content)
+    {
+        fileExtension = SanitizeExtension(fileExtension);
+        var destinationFilePath = GetAttachmentPath(fileExtension);
+
+        using var stream = File.OpenWrite(destinationFilePath);
+        await stream.WriteAsync(content, 0, content.Length);
+
+        return new(name, destinationFilePath);
+    }
+
+    private string SanitizeExtension(string fileExtension)
+    {
+        if (string.IsNullOrWhiteSpace(fileExtension))
+            return ".dat";
+
+        fileExtension = fileExtension.Trim().ToLowerInvariant();
+
+        return fileExtension[0] == '.'
+            ? fileExtension
+            : $".{fileExtension}";
+    }
+
+    private string GetAttachmentPath(string extension) => Path.Combine(AttachmentsDirectory, $"{Guid.NewGuid()}{extension}");
+}

--- a/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
+++ b/src/LightBDD.Framework/Reporting/FileAttachmentsManager.cs
@@ -55,19 +55,6 @@ public class FileAttachmentsManager : IFileAttachmentsManager
         return new(name, destinationFilePath, destinationFile);
     }
 
-    /// <inheritdoc />
-    public async Task<FileAttachment> CreateFromData(string name, string fileExtension, byte[] content)
-    {
-        fileExtension = SanitizeExtension(fileExtension);
-        var destinationFile = GetAttachmentFile(fileExtension);
-        var destinationFilePath = Path.Combine(AttachmentsDirectory, destinationFile);
-
-        using var stream = File.OpenWrite(destinationFilePath);
-        await stream.WriteAsync(content, 0, content.Length);
-
-        return new(name, destinationFilePath, destinationFile);
-    }
-
     private string SanitizeExtension(string fileExtension)
     {
         if (string.IsNullOrWhiteSpace(fileExtension))

--- a/src/LightBDD.Framework/Reporting/FileAttachmentsManagerExtensions.cs
+++ b/src/LightBDD.Framework/Reporting/FileAttachmentsManagerExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using LightBDD.Core.Reporting;
+using LightBDD.Core.Results;
+
+namespace LightBDD.Framework.Reporting
+{
+    /// <summary>
+    /// Extension methods for <see cref="IFileAttachmentsManager"/>
+    /// </summary>
+    public static class FileAttachmentsManagerExtensions
+    {
+        /// <summary>
+        /// Creates attachment from in-memory content.<br/>
+        /// The attachment is stored in the pre-configured location.<br/>
+        /// </summary>
+        /// <param name="manager">File attachments manager</param>
+        /// <param name="name">Attachment name</param>
+        /// <param name="fileExtension">File extension</param>
+        /// <param name="content">Attachment content</param>
+        /// <returns>File attachment</returns>
+        public static async Task<FileAttachment> CreateFromData(this IFileAttachmentsManager manager, string name, string fileExtension, byte[] content)
+        {
+            Task WriteContent(Stream stream) => stream.WriteAsync(content, 0, content.Length);
+
+            return await manager.CreateFromStream(name, fileExtension, WriteContent);
+        }
+
+        /// <summary>
+        /// Creates attachment from text content.<br/>
+        /// The attachment is stored in the pre-configured location.<br/>
+        /// </summary>
+        /// <param name="manager">File attachments manager</param>
+        /// <param name="name">Attachment name</param>
+        /// <param name="fileExtension">File extension</param>
+        /// <param name="content">Attachment content</param>
+        /// <param name="encoding">Text encoding</param>
+        /// <returns>File attachment</returns>
+        public static async Task<FileAttachment> CreateFromText(this IFileAttachmentsManager manager, string name, string fileExtension, string content, Encoding encoding)
+        {
+            async Task WriteContent(Stream stream)
+            {
+                using var writer = new StreamWriter(stream, encoding);
+                await writer.WriteAsync(content);
+            }
+            return await manager.CreateFromStream(name, fileExtension, WriteContent);
+        }
+    }
+}

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -1,10 +1,12 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using LightBDD.Core.Configuration;
+using LightBDD.Core.Extensibility;
 using LightBDD.Core.Formatting;
 using LightBDD.Core.Formatting.NameDecorators;
 using LightBDD.Core.Metadata;
@@ -358,7 +360,28 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                 Html.Tag(Html5Tag.Div).Content(scenario.GetSteps().Select(GetStep)),
                 GetStatusDetails(scenario.StatusDetails),
                 GetComments(scenario.GetAllSteps()),
+                GetAttachments(scenario.GetAllSteps()),
                 Html.Br());
+        }
+
+        private IHtmlNode GetAttachments(IEnumerable<IStepResult> steps)
+        {
+            return Html.Tag(Html5Tag.Div).Class("attachments")
+                .SkipEmpty()
+                .Content(from s in steps
+                    from a in s.FileAttachments
+                    select
+                        Html.Tag(Html5Tag.Div).Content(
+                            Html.Text($"Step {s.Info.GroupPrefix}{s.Info.Number}: "),
+                            Html.Tag(Html5Tag.A)
+                                .Href(ResolveLink(a))
+                                .Attribute("target", "_blank")
+                                .Content($"🔗{a.Name} ({Path.GetExtension(a.FilePath).TrimStart('.')})")));
+        }
+
+        private string ResolveLink(FileAttachment fileAttachment)
+        {
+            return fileAttachment.RelativePath.Replace(Path.DirectorySeparatorChar, '/');
         }
 
         private IHtmlNode GetComments(IEnumerable<IStepResult> steps)

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -372,11 +372,10 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                     from a in s.FileAttachments
                     select
                         Html.Tag(Html5Tag.Div).Content(
-                            Html.Text($"Step {s.Info.GroupPrefix}{s.Info.Number}: "),
                             Html.Tag(Html5Tag.A)
                                 .Href(ResolveLink(a))
                                 .Attribute("target", "_blank")
-                                .Content($"🔗{a.Name} ({Path.GetExtension(a.FilePath).TrimStart('.')})")));
+                                .Content($"🔗Step {s.Info.GroupPrefix}{s.Info.Number}: {a.Name} ({Path.GetExtension(a.FilePath).TrimStart('.')})")));
         }
 
         private string ResolveLink(FileAttachment fileAttachment)

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
@@ -29,6 +29,7 @@ h3{ font-size: 1.00em;}
 .status.notrun{background-color: #aaaaaa;}
 .details{margin-top: 0.5em;font-style: italic;color: #ff5555;white-space: pre-wrap;font-size: x-small;}
 .comments{margin-top: 0.5em;font-style: italic;white-space: pre-wrap;font-size: x-small;}
+.attachments{margin-top: 0.5em;}
 .comments div{color: #0000cd;}
 .step, .categories{margin: 0.2em;margin-left: 2.5em;}
 .smallLink,.duration{color: #0000cd;font-size: 0.8em;font-family: monospace;}
@@ -53,7 +54,7 @@ article{ margin-left: 1em;}
 .feature[data-filtered="false"],.scenario[data-filtered="false"] { display: none;}
 a{ text-decoration: none;}
 a:hover{ text-decoration: underline;}
-#optionsLink, .smallLink, a:hover,label:hover,.sortable:hover{ color: #662266;}
+#optionsLink, .smallLink, a:hover,label:hover,.sortable:hover, .attachments a{ color: #662266;}
 .smallLink{ display: none;}
 *:hover > .smallLink { display: inline;}
 input[type="checkbox"],input[type="radio"]{ display: none;}

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
@@ -29,7 +29,9 @@ h3{ font-size: 1.00em;}
 .status.notrun{background-color: #aaaaaa;}
 .details{margin-top: 0.5em;font-style: italic;color: #ff5555;white-space: pre-wrap;font-size: x-small;}
 .comments{margin-top: 0.5em;font-style: italic;white-space: pre-wrap;font-size: x-small;}
-.attachments{margin-top: 0.5em;}
+.attachments{margin-top: 0.5em;font-size: x-small;}
+.attachments::before{content:"Attachments:"}
+.attachments div{ display: inline-block; margin-right: 0.5em;}
 .comments div{color: #0000cd;}
 .step, .categories{margin: 0.2em;margin-left: 2.5em;}
 .smallLink,.duration{color: #0000cd;font-size: 0.8em;font-family: monospace;}

--- a/src/LightBDD.Framework/Reporting/Formatters/PlainTextReportFormatter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/PlainTextReportFormatter.cs
@@ -106,10 +106,12 @@ namespace LightBDD.Framework.Reporting.Formatters
             }
 
             var commentBuilder = new StringBuilder();
+            var attachmentBuilder = new StringBuilder();
             foreach (var step in scenario.GetSteps())
-                FormatStep(writer, step, commentBuilder);
+                FormatStep(writer, step, commentBuilder, attachmentBuilder);
             FormatDetails(writer, scenario);
             FormatComments(writer, commentBuilder);
+            FormatAttachments(writer, attachmentBuilder);
         }
 
         private static void CollectComments(IStepResult step, StringBuilder commentBuilder)
@@ -122,6 +124,18 @@ namespace LightBDD.Framework.Reporting.Formatters
             }
         }
 
+        private static void CollectAttachments(IStepResult step, StringBuilder attachmentBuilder)
+        {
+            foreach (var attachment in step.FileAttachments)
+            {
+                attachmentBuilder.Append("\t\t\tStep ").Append(step.Info.GroupPrefix).Append(step.Info.Number)
+                    .Append(": ")
+                    .Append(attachment.Name)
+                    .Append(" - ")
+                    .AppendLine(attachment.RelativePath);
+            }
+        }
+
         private static void FormatComments(TextWriter writer, StringBuilder commentBuilder)
         {
             if (commentBuilder.Length == 0)
@@ -130,7 +144,15 @@ namespace LightBDD.Framework.Reporting.Formatters
             writer.Write(commentBuilder);
         }
 
-        private static void FormatStep(TextWriter writer, IStepResult step, StringBuilder commentBuilder, int indent = 0)
+        private static void FormatAttachments(TextWriter writer, StringBuilder attachmentBuilder)
+        {
+            if (attachmentBuilder.Length == 0)
+                return;
+            writer.WriteLine("\t\tAttachments:");
+            writer.Write(attachmentBuilder);
+        }
+
+        private static void FormatStep(TextWriter writer, IStepResult step, StringBuilder commentBuilder, StringBuilder attachmentBuilder, int indent = 0)
         {
             var stepIndent = new string('\t', indent + 2);
             writer.Write(stepIndent);
@@ -151,8 +173,9 @@ namespace LightBDD.Framework.Reporting.Formatters
             foreach (var parameterResult in step.Parameters)
                 FormatParameter(writer, parameterResult, stepIndent);
             CollectComments(step, commentBuilder);
+            CollectAttachments(step, attachmentBuilder);
             foreach (var subStep in step.GetSubSteps())
-                FormatStep(writer, subStep, commentBuilder, indent + 1);
+                FormatStep(writer, subStep, commentBuilder, attachmentBuilder, indent + 1);
         }
 
         private static void FormatParameter(TextWriter writer, IParameterResult parameterResult, string stepIndent)

--- a/src/LightBDD.Framework/Reporting/Formatters/XmlReportFormatter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/XmlReportFormatter.cs
@@ -96,9 +96,15 @@ namespace LightBDD.Framework.Reporting.Formatters
             objects.Add(ToXElement(step.Info.Name));
             objects.AddRange(step.Parameters.Select(ToXElement));
             objects.AddRange(step.Comments.Select(c => new XElement("Comment", c)));
+            objects.AddRange(step.FileAttachments.Select(ToXElement));
             objects.AddRange(step.GetSubSteps().Select(s => ToXElement(s, "SubStep")));
             objects.Add(new XAttribute("RuntimeId", step.Info.RuntimeId.ToString("D")));
             return new XElement(elementName, objects);
+        }
+
+        private static XElement ToXElement(FileAttachment attachment)
+        {
+            return new XElement("FileAttachment", new XAttribute("Name", attachment.Name), new XAttribute("Path", attachment.RelativePath));
         }
 
         private static XElement ToXElement(IParameterResult parameterResult)

--- a/src/LightBDD.Framework/StepExecution.cs
+++ b/src/LightBDD.Framework/StepExecution.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Threading.Tasks;
 using LightBDD.Core.Dependencies;
 using LightBDD.Core.Execution;
 using LightBDD.Core.ExecutionContext;
+using LightBDD.Core.Reporting;
 using LightBDD.Core.Results;
 
 namespace LightBDD.Framework
@@ -14,7 +17,7 @@ namespace LightBDD.Framework
         /// Returns current step execution instance.
         /// Reference by <see cref="Current"/> property enables LightBDD extension packages to add functionality to <see cref="StepExecution"/> with extension methods.
         /// </summary>
-        public static StepExecution Current { get; } = new StepExecution();
+        public static StepExecution Current { get; } = new();
 
         private StepExecution() { }
 
@@ -38,10 +41,7 @@ namespace LightBDD.Framework
         /// </summary>
         /// <param name="reason">Bypass reason.</param>
         /// <exception cref="StepBypassException">Bypass exception used to control scenario execution.</exception>
-        public void Bypass(string reason)
-        {
-            throw new StepBypassException(reason);
-        }
+        public void Bypass(string reason) => throw new StepBypassException(reason);
 
         /// <summary>
         /// Comments currently executed step with a <paramref name="comment"/> text.
@@ -58,9 +58,14 @@ namespace LightBDD.Framework
         /// Retrieves <see cref="IDependencyResolver"/> for currently executed scenario.
         /// Please note that for contextual scenarios or composite steps, it is better to specify <see cref="IDependencyResolver"/> in context constructor.
         /// </summary>
-        public IDependencyResolver GetScenarioDependencyResolver()
-        {
-            return ScenarioExecutionContext.CurrentScenario.DependencyResolver;
-        }
+        public IDependencyResolver GetScenarioDependencyResolver() => ScenarioExecutionContext.CurrentScenario.DependencyResolver;
+
+        /// <summary>
+        /// Adds the file attachment to the step.
+        /// </summary>
+        /// <param name="createAttachmentFn">Function creating file attachment by using provided attachments manager.</param>
+        /// <returns></returns>
+        public Task AttachFile(Func<IFileAttachmentsManager, Task<FileAttachment>> createAttachmentFn)
+            => ScenarioExecutionContext.CurrentStep.AttachFile(createAttachmentFn);
     }
 }

--- a/test/LightBDD.AcceptanceTests/ConfiguredLightBddScopeAttribute.cs
+++ b/test/LightBDD.AcceptanceTests/ConfiguredLightBddScopeAttribute.cs
@@ -26,6 +26,7 @@ namespace LightBDD.AcceptanceTests
                 .Add(new ReportFileWriter(new PlainTextReportFormatter(), "~" + Path.DirectorySeparatorChar + "Reports" + Path.DirectorySeparatorChar + "FeaturesReport.txt"));
 
             configuration.DependencyContainerConfiguration().UseDefault(ConfigureContainer);
+            configuration.ExecutionExtensionsConfiguration().EnableStepDecorator<ScreenshotCaptureOnFailure>();
         }
 
         private void ConfigureContainer(IDefaultContainerConfigurator config)

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -19,7 +19,7 @@ using OpenQA.Selenium.Chrome;
 
 namespace LightBDD.AcceptanceTests.Features
 {
-    public class HtmlReportContext
+    public class HtmlReportContext : IChromeDriverContext
     {
         private readonly ResourceHandle<ChromeDriver> _driverHandle;
         private static string BaseDirectory => AppContext.BaseDirectory;
@@ -27,7 +27,7 @@ namespace LightBDD.AcceptanceTests.Features
         private State<IFeatureResult[]> _features;
 
         private string HtmlFileName { get; }
-        private ChromeDriver Driver => _driver.GetValue(nameof(Driver));
+        public ChromeDriver Driver => _driver.GetValue(nameof(Driver));
         private ResultBuilder ResultBuilder { get; }
         private IFeatureResult[] Features => _features.GetValue(nameof(Features));
 
@@ -76,7 +76,6 @@ namespace LightBDD.AcceptanceTests.Features
             _driver = await _driverHandle.ObtainAsync();
             Driver.Navigate().GoToUrl(HtmlFileName);
             Driver.EnsurePageIsLoaded();
-            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromData("message", "txt", Encoding.UTF8.GetBytes("some text")));
         }
 
         public async Task Then_all_features_should_be_VISIBLE([VisibleFormat] bool visible)
@@ -335,11 +334,6 @@ namespace LightBDD.AcceptanceTests.Features
             var actual = tableRows.Select(row => row.FindElements(By.TagName("td")).Skip(1).Select(x => x.Text).ToArray()).ToArray();
 
             Assert.That(actual, Is.EqualTo(rows.Select(r => new[] { r.id, r.name, r.value }).ToArray()));
-
-            var screenShotPath = $"{Guid.NewGuid()}.PNG";
-            Driver.GetScreenshot().SaveAsFile(screenShotPath, ScreenshotImageFormat.Png);
-            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromFile("screenshot", screenShotPath));
-            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromData("message", "txt", Encoding.UTF8.GetBytes("some text")));
         }
 
         private string FormatResults(params IFeatureResult[] results)

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -76,21 +76,22 @@ namespace LightBDD.AcceptanceTests.Features
             _driver = await _driverHandle.ObtainAsync();
             Driver.Navigate().GoToUrl(HtmlFileName);
             Driver.EnsurePageIsLoaded();
+            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromData("message", "txt", Encoding.UTF8.GetBytes("some text")));
         }
 
-        public async Task Then_all_features_should_be_VISIBLE([VisibleFormat]bool visible)
+        public async Task Then_all_features_should_be_VISIBLE([VisibleFormat] bool visible)
         {
             var actual = Driver.FindFeatures().Count(e => e.Displayed == visible);
             Assert.That(actual, Is.EqualTo(Features.Count()));
         }
 
-        public async Task Then_all_scenarios_should_be_VISIBLE([VisibleFormat]bool visible)
+        public async Task Then_all_scenarios_should_be_VISIBLE([VisibleFormat] bool visible)
         {
             var actual = Driver.FindAllScenarios().Count(e => e.Displayed == visible);
             Assert.That(actual, Is.EqualTo(Features.SelectMany(f => f.GetScenarios()).Count()));
         }
 
-        public async Task Then_all_steps_should_be_VISIBLE([VisibleFormat]bool visible)
+        public async Task Then_all_steps_should_be_VISIBLE([VisibleFormat] bool visible)
         {
             var actual = Driver.FindAllSteps().Count(e => e.Displayed == visible);
             Assert.That(actual, Is.EqualTo(Features.SelectMany(f => f.GetScenarios()).SelectMany(s => s.GetSteps()).Count()));
@@ -124,7 +125,7 @@ namespace LightBDD.AcceptanceTests.Features
             return $"toggle{feature}";
         }
 
-        public async Task Then_the_feature_scenarios_should_be_VISIBLE(int feature, [VisibleFormat]bool visible)
+        public async Task Then_the_feature_scenarios_should_be_VISIBLE(int feature, [VisibleFormat] bool visible)
         {
             var actual = Driver.FindFeature(feature).FindScenarios().Count(e => e.Displayed == visible);
             Assert.That(actual, Is.EqualTo(Features[feature - 1].GetScenarios().Count()));
@@ -140,7 +141,7 @@ namespace LightBDD.AcceptanceTests.Features
             return $"toggle{feature}_{scenario - 1}";
         }
 
-        public async Task Then_the_feature_scenario_steps_should_be_VISIBLE(int feature, int scenario, [VisibleFormat]bool visible)
+        public async Task Then_the_feature_scenario_steps_should_be_VISIBLE(int feature, int scenario, [VisibleFormat] bool visible)
         {
             var actual = Driver.FindFeature(feature).FindScenario(scenario).FindSteps().Count(e => e.Displayed == visible);
             Assert.That(actual, Is.EqualTo(Features[feature - 1].GetScenarios().ElementAt(scenario - 1).GetSteps().Count()));
@@ -156,12 +157,12 @@ namespace LightBDD.AcceptanceTests.Features
             ClickLabeledButtonSync("toggleScenarios");
         }
 
-        public async Task Then_the_scenario_filter_button_should_be_SELECTED([SelectedFormat]bool selected)
+        public async Task Then_the_scenario_filter_button_should_be_SELECTED([SelectedFormat] bool selected)
         {
             Assert.That(Driver.FindElementById("toggleScenarios").Selected, Is.EqualTo(selected));
         }
 
-        public async Task Then_the_feature_filter_button_should_be_SELECTED([SelectedFormat]bool selected)
+        public async Task Then_the_feature_filter_button_should_be_SELECTED([SelectedFormat] bool selected)
         {
             Assert.That(Driver.FindElementById("toggleFeatures").Selected, Is.EqualTo(selected));
         }
@@ -171,26 +172,26 @@ namespace LightBDD.AcceptanceTests.Features
             ClickLabeledButton($"show{status}");
         }
 
-        public async Task Then_the_filter_status_button_should_be_SELECTED(ExecutionStatus status, [SelectedFormat]bool selected)
+        public async Task Then_the_filter_status_button_should_be_SELECTED(ExecutionStatus status, [SelectedFormat] bool selected)
         {
             Assert.That(Driver.FindElementById($"show{status}").Selected, Is.EqualTo(selected));
         }
 
-        public async Task Then_all_scenarios_with_status_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat]bool visible)
+        public async Task Then_all_scenarios_with_status_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat] bool visible)
         {
             var elements = Driver.FindAllScenarios().Where(s => s.HasClassName(status.ToString().ToLower())).ToArray();
             Assert.That(elements, Is.Not.Empty);
             Assert.That(elements.All(s => s.Displayed == visible));
         }
 
-        public async Task Then_all_scenarios_with_status_other_than_STATUS_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat]bool visible)
+        public async Task Then_all_scenarios_with_status_other_than_STATUS_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat] bool visible)
         {
             var elements = Driver.FindAllScenarios().Where(s => !s.HasClassName(status.ToString().ToLower())).ToArray();
             Assert.That(elements, Is.Not.Empty);
             Assert.That(elements.All(s => s.Displayed == visible));
         }
 
-        public async Task Then_all_features_having_all_scenarios_of_status_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat]bool visible)
+        public async Task Then_all_features_having_all_scenarios_of_status_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat] bool visible)
         {
             var expected = new[] { "feature", status.ToString().ToLower() };
             var elements = Driver.FindFeatures().Where(f => f.GetClassNames().SequenceEqual(expected)).ToArray();
@@ -213,18 +214,18 @@ namespace LightBDD.AcceptanceTests.Features
                 .Click();
         }
 
-        public async Task Then_the_category_filter_button_should_be_SELECTED(string category, [SelectedFormat]bool selected)
+        public async Task Then_the_category_filter_button_should_be_SELECTED(string category, [SelectedFormat] bool selected)
         {
             var label = Driver.FindLabelByText(category);
             Assert.That(Driver.FindLabelTarget(label).Selected, Is.EqualTo(selected));
         }
 
-        public async Task Then_the_feature_scenario_should_be_VISIBLE(int feature, int scenario, [VisibleFormat]bool visible)
+        public async Task Then_the_feature_scenario_should_be_VISIBLE(int feature, int scenario, [VisibleFormat] bool visible)
         {
             Assert.That(Driver.FindFeature(feature).FindScenario(scenario).Displayed, Is.EqualTo(visible));
         }
 
-        public async Task Then_the_feature_should_be_VISIBLE(int feature, [VisibleFormat]bool visible)
+        public async Task Then_the_feature_should_be_VISIBLE(int feature, [VisibleFormat] bool visible)
         {
             Assert.That(Driver.FindFeature(feature).Displayed, Is.EqualTo(visible));
         }
@@ -271,7 +272,7 @@ namespace LightBDD.AcceptanceTests.Features
                .WithStepParameters(TestResults.CreateTestParameter(parameter, tabular));
         }
 
-        public async Task Then_the_options_link_should_be_VISIBLE([VisibleFormat]bool visible)
+        public async Task Then_the_options_link_should_be_VISIBLE([VisibleFormat] bool visible)
         {
             Assert.That(Driver.FindElementById("optionsLink").Displayed, Is.EqualTo(visible));
         }
@@ -291,7 +292,7 @@ namespace LightBDD.AcceptanceTests.Features
             Driver.EnsurePageIsLoaded();
         }
 
-        public async Task Then_the_Feature_Summary_table_should_be_sorted_ASCENDING_by_column([OrderFormat]bool ascending, FeatureSummaryColumn column)
+        public async Task Then_the_Feature_Summary_table_should_be_sorted_ASCENDING_by_column([OrderFormat] bool ascending, FeatureSummaryColumn column)
         {
             var values = Driver
                 .FindElementById("featuresSummary")
@@ -334,6 +335,11 @@ namespace LightBDD.AcceptanceTests.Features
             var actual = tableRows.Select(row => row.FindElements(By.TagName("td")).Skip(1).Select(x => x.Text).ToArray()).ToArray();
 
             Assert.That(actual, Is.EqualTo(rows.Select(r => new[] { r.id, r.name, r.value }).ToArray()));
+
+            var screenShotPath = $"{Guid.NewGuid()}.PNG";
+            Driver.GetScreenshot().SaveAsFile(screenShotPath, ScreenshotImageFormat.Png);
+            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromFile("screenshot", screenShotPath));
+            await StepExecution.Current.AttachFile(mgr => mgr.CreateFromData("message", "txt", Encoding.UTF8.GetBytes("some text")));
         }
 
         private string FormatResults(params IFeatureResult[] results)

--- a/test/LightBDD.AcceptanceTests/Helpers/IChromeDriverContext.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/IChromeDriverContext.cs
@@ -1,0 +1,8 @@
+﻿using OpenQA.Selenium.Chrome;
+
+namespace LightBDD.AcceptanceTests.Helpers;
+
+internal interface IChromeDriverContext
+{
+    ChromeDriver Driver { get; }
+}

--- a/test/LightBDD.AcceptanceTests/Helpers/ScreenshotCaptureOnFailure.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/ScreenshotCaptureOnFailure.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using OpenQA.Selenium;
+
+namespace LightBDD.AcceptanceTests.Helpers
+{
+    internal class ScreenshotCaptureOnFailure : IStepDecorator
+    {
+        public async Task ExecuteAsync(IStep step, Func<Task> stepInvocation)
+        {
+            try
+            {
+                await stepInvocation();
+            }
+            catch (Exception)
+            {
+                if (step.Context is IChromeDriverContext context)
+                    await TakeScreenshot(step, context);
+                throw;
+            }
+
+        }
+
+        private static async Task TakeScreenshot(IStep step, IChromeDriverContext context)
+        {
+            var screenShotPath = $"{Guid.NewGuid()}.png";
+            context.Driver.GetScreenshot().SaveAsFile(screenShotPath, ScreenshotImageFormat.Png);
+            await step.AttachFile(mgr => mgr.CreateFromFile("screenshot", screenShotPath));
+        }
+    }
+}

--- a/test/LightBDD.Core.UnitTests/Helpers/Steps.cs
+++ b/test/LightBDD.Core.UnitTests/Helpers/Steps.cs
@@ -11,6 +11,8 @@ namespace LightBDD.Core.UnitTests.Helpers
         public const string IgnoreReason = "ignore reason";
         public const string ParameterExceptionReason = "parameter exception";
         public const string CommentReason = "some comment";
+        public const string AttachmentName = "attachment1";
+        public const string AttachmentFile = "attachment1.txt";
 
         public void Some_step() { }
         public void Given_step_one() { }
@@ -18,6 +20,7 @@ namespace LightBDD.Core.UnitTests.Helpers
         public void When_step_two() { }
 
         public void When_step_two_with_comment() { StepCommentHelper.Comment(CommentReason); }
+        public void When_step_two_with_attachment() { StepCommentHelper.AttachFile(AttachmentName, AttachmentFile); }
         public void When_step_two_is_bypassed() { StepExecution.Current.Bypass(BypassReason); }
         public void When_step_two_throwing_exception() { throw new InvalidOperationException(ExceptionReason); }
         public void Then_step_three() { }

--- a/test/LightBDD.Core.UnitTests/Reporting/StepExecution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Reporting/StepExecution_tests.cs
@@ -32,19 +32,19 @@ namespace LightBDD.Core.UnitTests.Reporting
             await _runner.Test().TestScenarioAsync(Step1_with_attachment, Step2_with_attachment);
             var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps().ToArray();
 
-            Assert.That(steps[0].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}"), Is.EqualTo(new[] { "step1|path1" }));
-            Assert.That(steps[1].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}"), Is.EqualTo(new[] { "step2_1|path2", "step2_2|path3" }));
+            Assert.That(steps[0].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}|{a.RelativePath}"), Is.EqualTo(new[] { "step1|path1|file1" }));
+            Assert.That(steps[1].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}|{a.RelativePath}"), Is.EqualTo(new[] { "step2_1|path2|file2", "step2_2|path3|file3" }));
         }
 
         private async Task Step1_with_attachment()
         {
-            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step1", "path1")));
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step1", "path1","file1")));
         }
 
         private async Task Step2_with_attachment()
         {
-            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_1", "path2")));
-            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_2", "path3")));
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_1", "path2", "file2")));
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_2", "path3", "file3")));
         }
     }
 }

--- a/test/LightBDD.Core.UnitTests/Reporting/StepExecution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Reporting/StepExecution_tests.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LightBDD.Core.Extensibility;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Extensibility;
+using LightBDD.UnitTests.Helpers.TestableIntegration;
+using NUnit.Framework;
+
+namespace LightBDD.Core.UnitTests.Reporting
+{
+    [TestFixture]
+    public class StepExecution_tests
+    {
+        #region Setup/Teardown
+
+        private IFeatureRunner _feature;
+        private IBddRunner _runner;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _feature = TestableFeatureRunnerRepository.GetRunner(GetType());
+            _runner = _feature.GetBddRunner(this);
+        }
+
+        #endregion
+
+        [Test]
+        public async Task AttachFile_should_attach_file_to_step_results()
+        {
+            await _runner.Test().TestScenarioAsync(Step1_with_attachment, Step2_with_attachment);
+            var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps().ToArray();
+
+            Assert.That(steps[0].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}"), Is.EqualTo(new[] { "step1|path1" }));
+            Assert.That(steps[1].FileAttachments.Select(a => $"{a.Name}|{a.FilePath}"), Is.EqualTo(new[] { "step2_1|path2", "step2_2|path3" }));
+        }
+
+        private async Task Step1_with_attachment()
+        {
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step1", "path1")));
+        }
+
+        private async Task Step2_with_attachment()
+        {
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_1", "path2")));
+            await StepExecution.Current.AttachFile(_ => Task.FromResult(new FileAttachment("step2_2", "path3")));
+        }
+    }
+}

--- a/test/LightBDD.Framework.Reporting.UnitTests/Configuration/ReportWritersConfiguration_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Configuration/ReportWritersConfiguration_tests.cs
@@ -34,7 +34,7 @@ namespace LightBDD.Framework.Reporting.UnitTests.Configuration
         }
 
         [Test]
-        public void It_should_allow_clear_add_and_remove_items()
+        public void It_should_allow_clear_add_and_remove_writrs()
         {
             var writer = Mock.Of<IReportWriter>();
             var writer2 = Mock.Of<IReportWriter>();
@@ -45,7 +45,7 @@ namespace LightBDD.Framework.Reporting.UnitTests.Configuration
         }
 
         [Test]
-        public void It_should_not_allow_null_items()
+        public void It_should_not_allow_null_writers()
         {
             var configuration = new ReportWritersConfiguration();
             Assert.Throws<ArgumentNullException>(() => configuration.Add(null));
@@ -76,7 +76,41 @@ namespace LightBDD.Framework.Reporting.UnitTests.Configuration
             Assert.Throws<InvalidOperationException>(() => cfg.Add(Mock.Of<IReportWriter>()));
             Assert.Throws<InvalidOperationException>(() => cfg.Clear());
             Assert.Throws<InvalidOperationException>(() => cfg.Remove(writer));
+            Assert.Throws<InvalidOperationException>(() => cfg.UpdateFileAttachmentsManager(Mock.Of<IFileAttachmentsManager>()));
             Assert.That(cfg.ToArray(), Is.Not.Empty);
+        }
+
+        [Test]
+        public void It_should_return_default_file_attachment_manager()
+        {
+            var configuration = new ReportWritersConfiguration().RegisterDefaultFileAttachmentManager();
+            var fileAttachmentsManager = configuration.GetFileAttachmentsManager();
+            Assert.That(fileAttachmentsManager, Is.TypeOf<FileAttachmentsManager>());
+
+            var expectedPath = Path.Combine(AppContext.BaseDirectory, "Reports");
+            Assert.That(((FileAttachmentsManager)fileAttachmentsManager).AttachmentsDirectory, Is.EqualTo(expectedPath));
+        }
+
+        [Test]
+        public void It_should_allow_updating_FileAttachmentManager()
+        {
+            var manager = Mock.Of<IFileAttachmentsManager>();
+            var actual = new ReportWritersConfiguration().UpdateFileAttachmentsManager(manager)
+                .GetFileAttachmentsManager();
+            Assert.That(actual, Is.EqualTo(manager));
+        }
+
+        [Test]
+        public void It_should_not_allow_updating_FileAttachmentManager_with_null()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new ReportWritersConfiguration().UpdateFileAttachmentsManager(null));
+            Assert.That(ex.ParamName, Is.EqualTo("manager"));
+        }
+
+        [Test]
+        public void GetFileAttachmentsManager_should_return_NoFileAttachmentsManager_by_default()
+        {
+            Assert.That(new ReportWritersConfiguration().GetFileAttachmentsManager(), Is.TypeOf<NoFileAttachmentsManager>());
         }
     }
 }

--- a/test/LightBDD.Framework.Reporting.UnitTests/FileAttachmentsManager_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/FileAttachmentsManager_tests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using LightBDD.Core.Results;
+using LightBDD.UnitTests.Helpers;
+using NUnit.Framework;
+
+namespace LightBDD.Framework.Reporting.UnitTests
+{
+    [TestFixture]
+    [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    public class FileAttachmentsManager_tests : IDisposable
+    {
+        private readonly string _directory = Guid.NewGuid().ToString();
+        private readonly string _fullDirectoryPath;
+
+        public FileAttachmentsManager_tests()
+        {
+            _fullDirectoryPath = Path.Combine(AppContext.BaseDirectory, _directory);
+        }
+
+        [Test]
+        public void Constructor_should_support_tilde_and_create_output_directory()
+        {
+            var manager = new FileAttachmentsManager(Path.Combine("~", _directory));
+            Assert.That(manager.AttachmentsDirectory, Is.EqualTo(_fullDirectoryPath));
+            Assert.That(Directory.Exists(_fullDirectoryPath), Is.True);
+        }
+
+        [Test]
+        public async Task Manager_should_create_attachments_from_byte_content()
+        {
+            var manager = new FileAttachmentsManager(_fullDirectoryPath);
+            var name = Fake.String();
+            var content = Fake.String();
+            var result = await manager.CreateFromData(name, "TXT", Encoding.UTF8.GetBytes(content));
+            AssertAttachment(result, name, content, ".txt");
+        }
+
+        [Test]
+        public async Task Manager_should_create_attachments_from_stream()
+        {
+            var manager = new FileAttachmentsManager(_fullDirectoryPath);
+            var name = Fake.String();
+            var content = Fake.String();
+            var contentBytes = Encoding.UTF8.GetBytes(content);
+            var result = await manager.CreateFromStream(name, ".bin",
+                stream => stream.WriteAsync(contentBytes, 0, contentBytes.Length));
+
+            AssertAttachment(result, name, content, ".bin");
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Manager_should_create_attachments_from_file(bool shouldMove)
+        {
+            var manager = new FileAttachmentsManager(_fullDirectoryPath);
+            var name = Fake.String();
+            var content = Fake.String();
+            var fileName = Path.GetTempFileName();
+            File.WriteAllText(fileName, content);
+
+            var result = await manager.CreateFromFile(name, fileName, shouldMove);
+
+            AssertAttachment(result, name, content, Path.GetExtension(fileName));
+            Assert.That(File.Exists(fileName), Is.EqualTo(!shouldMove));
+        }
+
+        private void AssertAttachment(FileAttachment result, string expectedName, string expectedContent, string expectedExtension)
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo(expectedName));
+            Assert.That(Path.GetExtension(result.FilePath), Is.EqualTo(expectedExtension));
+            Assert.That(Path.GetDirectoryName(result.FilePath), Is.EqualTo(_fullDirectoryPath));
+            Assert.That(File.Exists(result.FilePath), Is.True);
+            Assert.That(File.ReadAllText(result.FilePath), Is.EqualTo(expectedContent));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_fullDirectoryPath))
+                Directory.Delete(_fullDirectoryPath, true);
+        }
+    }
+}

--- a/test/LightBDD.Framework.Reporting.UnitTests/FileAttachmentsManager_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/FileAttachmentsManager_tests.cs
@@ -39,6 +39,16 @@ namespace LightBDD.Framework.Reporting.UnitTests
         }
 
         [Test]
+        public async Task Manager_should_create_attachments_from_text_content()
+        {
+            var manager = new FileAttachmentsManager(_fullDirectoryPath);
+            var name = Fake.String();
+            var content = Fake.String();
+            var result = await manager.CreateFromText(name, "TXT", content, Encoding.UTF8);
+            AssertAttachment(result, name, content, ".txt");
+        }
+
+        [Test]
         public async Task Manager_should_create_attachments_from_stream()
         {
             var manager = new FileAttachmentsManager(_fullDirectoryPath);

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -95,6 +95,7 @@ comment
 // Step 2.3: sub-comment
 // Step 2.3.1: sub-sub-multiline
 comment
+Step 2.3.1: &#128279;attachment1 (png)
 Failed name2 ""arg1"" (2s 157ms)[&#8734;link]
 categoryB, categoryC
 Bypassed 1. step3 (2s 107ms)

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -95,7 +95,7 @@ comment
 // Step 2.3: sub-comment
 // Step 2.3.1: sub-sub-multiline
 comment
-Step 2.3.1: &#128279;attachment1 (png)
+&#128279;Step 2.3.1: attachment1 (png)
 Failed name2 ""arg1"" (2s 157ms)[&#8734;link]
 categoryB, categoryC
 Bypassed 1. step3 (2s 107ms)

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/PlainTextReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/PlainTextReportFormatter_tests.cs
@@ -85,6 +85,8 @@ Feature: My feature [Label 1]
 			Step 2.3: sub-comment
 			Step 2.3.1: sub-sub-multiline
 				comment
+		Attachments:
+			Step 2.3.1: attachment1 - file1.png
 
 	Scenario: name2 ""arg1"" - Failed (2s 157ms)
 		Categories: categoryB, categoryC

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
@@ -26,6 +26,7 @@ namespace LightBDD.Framework.Reporting.UnitTests.Formatters
                             .WithSubSteps(TestResults.CreateStepResult(1, "sub-substep 1", ExecutionStatus.Failed)
                                     .WithGroupPrefix("2.3.")
                                     .WithComments($"sub-sub-multiline{Environment.NewLine}comment")
+                                    .WithAttachment(new FileAttachment("attachment1","/tmp/file1.png","file1.png"))
                                     .WithStepParameters(
                                         TestResults.CreateTestParameter("table1", TestResults.CreateTabularParameterDetails(ParameterVerificationStatus.Failure)
                                             .WithKeyColumns("Key")

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/XmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/XmlReportFormatter_tests.cs
@@ -128,6 +128,7 @@ comment</Comment>
             </Parameter>
             <Comment>sub-sub-multiline
 comment</Comment>
+            <FileAttachment Name=""attachment1"" Path=""file1.png"" />
           </SubStep>
           <SubStep Status=""NotRun"" Number=""2"" Name=""sub-substep 2"" GroupPrefix=""2.3."" RuntimeId=""11111111-1111-1111-1111-111111111111"">
             <StepName Format=""sub-substep 2"" />

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
@@ -74,7 +74,7 @@ namespace LightBDD.Framework.UnitTests.Notification
 
             var featureResult = Fake.Object<TestResults.TestFeatureResult>();
             var comment = Fake.String();
-            var attachment = new FileAttachment(Fake.String(),Fake.String());
+            var attachment = new FileAttachment(Fake.String(), Fake.String(), Fake.String());
 
             var eventTime = new EventTime();
             _notifier.Notify(new FeatureStarting(eventTime, featureInfo));

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using LightBDD.Core.Execution;
 using LightBDD.Core.Formatting;
 using LightBDD.Core.Metadata;
-using LightBDD.Core.Notification;
 using LightBDD.Core.Notification.Events;
 using LightBDD.Core.Results;
 using LightBDD.Core.Results.Parameters;
@@ -75,12 +74,14 @@ namespace LightBDD.Framework.UnitTests.Notification
 
             var featureResult = Fake.Object<TestResults.TestFeatureResult>();
             var comment = Fake.String();
+            var attachment = new FileAttachment(Fake.String(),Fake.String());
 
             var eventTime = new EventTime();
             _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
             _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
             _notifier.Notify(new StepStarting(eventTime, stepInfo));
             _notifier.Notify(new StepCommented(eventTime, stepInfo, comment));
+            _notifier.Notify(new StepFileAttached(eventTime, stepInfo, attachment));
             _notifier.Notify(new StepFinished(eventTime, stepResult));
             _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
             _notifier.Notify(new FeatureFinished(eventTime, featureResult));
@@ -103,6 +104,7 @@ namespace LightBDD.Framework.UnitTests.Notification
                 $"SCENARIO: [{string.Join("][", scenarioInfo.Labels)}] {scenarioInfo.Name}",
                 $"  STEP {stepInfo.GroupPrefix}{stepInfo.Number}/{stepInfo.GroupPrefix}{stepInfo.Total}: {stepInfo.Name}...",
                 $"  STEP {stepInfo.GroupPrefix}{stepInfo.Number}/{stepInfo.GroupPrefix}{stepInfo.Total}: /* {comment} */",
+                $"  STEP {stepInfo.GroupPrefix}{stepInfo.Number}/{stepInfo.GroupPrefix}{stepInfo.Total}: File Attached - {attachment.Name}: {attachment.FilePath}",
                 $"  STEP {stepResult.Info.GroupPrefix}{stepResult.Info.Number}/{stepResult.Info.GroupPrefix}{stepResult.Info.Total}: {stepResult.Info.Name} ({stepResult.Status} after {stepResult.ExecutionTime.Duration.FormatPretty()}){Environment.NewLine}{expectedTable}",
                 $"  SCENARIO RESULT: {scenarioResult.Status} after {scenarioResult.ExecutionTime.Duration.FormatPretty()}{Environment.NewLine}    {scenarioResult.StatusDetails}",
                 $"FEATURE FINISHED: {featureResult.Info.Name}"

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -270,9 +270,12 @@ namespace LightBDD.UnitTests.Helpers
                 return SubSteps;
             }
 
+            IEnumerable<FileAttachment> IStepResult.FileAttachments => FileAttachments;
+
             public IParameterResult[] Parameters { get; set; } = new IParameterResult[0];
             public TestStepResult[] SubSteps { get; set; } = new TestStepResult[0];
             public string[] Comments { get; set; } = new string[0];
+            public FileAttachment[] FileAttachments { get; set; } = new FileAttachment[0];
         }
 
         public class TestStepInfo : IStepInfo

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -36,6 +36,12 @@ namespace LightBDD.UnitTests.Helpers
             return result;
         }
 
+        public static TestStepResult WithAttachment(this TestStepResult result, params FileAttachment[] fileAttachments)
+        {
+            result.FileAttachments = fileAttachments;
+            return result;
+        }
+
         public static TestStepResult WithStepNameDetails(this TestStepResult result, int stepNumber, string stepName, string nameFormat, string stepTypeName = null, params string[] parameters)
         {
             result.Info = new TestStepInfo

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Core.Execution;
 using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Core.Results;
 
 namespace LightBDD.UnitTests.Helpers.TestableIntegration
 {
@@ -13,6 +14,11 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
         public static void Comment(string commentReason)
         {
             CurrentStep.Value.Comment(commentReason);
+        }
+
+        public static void AttachFile(string name, string file)
+        {
+            CurrentStep.Value.AttachFile(_ => Task.FromResult(new FileAttachment(name, file)));
         }
 
         public async Task ExecuteAsync(IStep step, Func<Task> stepInvocation)

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
@@ -18,7 +18,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
 
         public static void AttachFile(string name, string file)
         {
-            CurrentStep.Value.AttachFile(_ => Task.FromResult(new FileAttachment(name, file)));
+            CurrentStep.Value.AttachFile(_ => Task.FromResult(new FileAttachment(name, file, $"base/{file}")));
         }
 
         public async Task ExecuteAsync(IStep step, Func<Task> stepInvocation)


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #255 

List of changes:
+ (LightBDD.Core) Added IStep.AttachFile() method allowing to add file attachments to steps and fired StepFileAttached progress notification event when attachment is made
+ (LightBDD.Core) Added ReportWritersConfiguration.UpdateFileAttachmentsManager() to allow re-configuring file attachments storage
+ (LightBDD.Framework) Added support to attach files to steps with StepExecution.Current.AttachFile()
+ (LightBDD.Framework) Added FileAttachmentManager implementation and registered it with ReportWritersConfiguration.RegisterDefaultFileAttachmentManager() extension method to create attachments in ~/Reports folder
+ (LightBDD.Framework) Updated DefaultProgressNotifier to notify on StepFileAttached event
+ (LightBDD.Framework) Updated HtmlResultTextWriter / PlainTextReportFormatter / XmlReportFormatter to include file attachments

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [x] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
