### PR TITLE
#241 Added WithInferredColumns(InferredColumnsOrder columnsOrder) method to IInputTableBuilder and IVerifiableDataTableBuilder with option to add inferred columns in name or declaration order

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ LightBDD
 
 Version [next]
 ----------------------------------------
++ #241 (LightBDD.Framework)(New) Added WithInferredColumns(InferredColumnsOrder columnsOrder) method to IInputTableBuilder and IVerifiableDataTableBuilder with option to add inferred columns in name or declaration order
 + #264 (LightBDD.Framework)(Fix) Corrected Html Report to expand feature background with the content
 + #268 (LightBDD.Framework)(New) Added InputTree<T> to provide detailed insights into the object structure upon progress and results rendering.
 + #268 (LightBDD.Framework)(New) Added VerifiableTree<T> to provide detailed structural verification of actual versus expected object hierarchies

--- a/src/LightBDD.Framework/Parameters/IInputTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/IInputTableBuilder.cs
@@ -37,5 +37,13 @@ namespace LightBDD.Framework.Parameters
         /// </summary>
         /// <returns>Self.</returns>
         IInputTableBuilder<TRow> WithInferredColumns();
+
+        /// <summary>
+        /// Instructs <see cref="IInputTableBuilder{TRow}"/> to infer columns basing on the <typeparamref name="TRow"/> type.
+        /// It is possible to use this methods together with <c>WithColumn()</c> methods, where manually specified columns will override inferred columns of the same name.
+        /// </summary>
+        /// <param name="columnsOrder">Order of the columns</param>
+        /// <returns>Self.</returns>
+        IInputTableBuilder<TRow> WithInferredColumns(InferredColumnsOrder columnsOrder);
     }
 }

--- a/src/LightBDD.Framework/Parameters/IVerifiableDataTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/IVerifiableDataTableBuilder.cs
@@ -170,5 +170,14 @@ namespace LightBDD.Framework.Parameters
         /// </summary>
         /// <returns>Self.</returns>
         IVerifiableDataTableBuilder<TRow> WithInferredColumns();
+
+        /// <summary>
+        /// Instructs <see cref="IInputTableBuilder{TRow}"/> to infer columns basing on the <typeparamref name="TRow"/> type.
+        /// It is possible to use this methods together with <c>WithColumn() / WithKey()</c> methods, where manually specified columns will override inferred columns of the same name.
+        /// The inferred columns will always use <c>Expect.To.Equal(value)</c> expression for verifying column values.
+        /// </summary>
+        /// <param name="columnsOrder">Order of the columns</param>
+        /// <returns>Self.</returns>
+        IVerifiableDataTableBuilder<TRow> WithInferredColumns(InferredColumnsOrder columnsOrder);
     }
 }

--- a/src/LightBDD.Framework/Parameters/Implementation/AbstractTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/AbstractTableBuilder.cs
@@ -7,6 +7,7 @@ namespace LightBDD.Framework.Parameters.Implementation
     {
         private readonly List<TColumn> _customColumns = new List<TColumn>();
         protected bool InferColumns { get; set; }
+        protected InferredColumnsOrder InferredColumnsOrder { get; set; } = InferredColumnsOrder.Name;
 
         protected IEnumerable<TColumn> BuildColumns(TRow[] rows)
         {
@@ -25,7 +26,7 @@ namespace LightBDD.Framework.Parameters.Implementation
                 return column;
             }
 
-            var results = TableColumnProvider.InferColumns(rows, true)
+            var results = TableColumnProvider.InferColumns(rows, true, InferredColumnsOrder)
                 .Select(CreateColumn)
                 .Select(column => FindCustom(column.Name) ?? column)
                 .ToList();

--- a/src/LightBDD.Framework/Parameters/Implementation/InputTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/InputTableBuilder.cs
@@ -24,9 +24,12 @@ namespace LightBDD.Framework.Parameters.Implementation
             return Add(columnName, columnExpression);
         }
 
-        public IInputTableBuilder<TRow> WithInferredColumns()
+        public IInputTableBuilder<TRow> WithInferredColumns() => WithInferredColumns(InferredColumnsOrder.Name);
+
+        public IInputTableBuilder<TRow> WithInferredColumns(InferredColumnsOrder columnsOrder)
         {
             InferColumns = true;
+            InferredColumnsOrder = columnsOrder;
             return this;
         }
 

--- a/src/LightBDD.Framework/Parameters/Implementation/VerifiableDataTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/VerifiableDataTableBuilder.cs
@@ -50,9 +50,12 @@ namespace LightBDD.Framework.Parameters.Implementation
             return Add(columnName, true, columnExpression, x => Expect.To.Equal(x));
         }
 
-        public IVerifiableDataTableBuilder<TRow> WithInferredColumns()
+        public IVerifiableDataTableBuilder<TRow> WithInferredColumns() => WithInferredColumns(InferredColumnsOrder.Name);
+
+        public IVerifiableDataTableBuilder<TRow> WithInferredColumns(InferredColumnsOrder columnsOrder)
         {
             InferColumns = true;
+            InferredColumnsOrder = columnsOrder;
             return this;
         }
 

--- a/src/LightBDD.Framework/Parameters/InferredColumnsOrder.cs
+++ b/src/LightBDD.Framework/Parameters/InferredColumnsOrder.cs
@@ -1,0 +1,16 @@
+﻿namespace LightBDD.Framework.Parameters;
+
+/// <summary>
+/// Order of inferred columns
+/// </summary>
+public enum InferredColumnsOrder
+{
+    /// <summary>
+    /// Order by name
+    /// </summary>
+    Name,
+    /// <summary>
+    /// Maintain declaration order
+    /// </summary>
+    Declaration
+};

--- a/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Framework.Parameters;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -168,7 +170,31 @@ namespace LightBDD.Framework.UnitTests.Parameters
         }
 
         [Test]
-        public void AsVerifiableTable_should_infer_columns_from_dynamic_collection_of_unified_item_types()
+        public void ToTable_should_maintain_declaration_order_of_inferred_columns_for_complex_types_with_fields_being_first()
+        {
+            var data = new[]
+            {
+                new Derived()
+            };
+
+            var inputTable = data.ToTable(x => x.WithInferredColumns(InferredColumnsOrder.Declaration));
+            AssertColumnNames(inputTable, "Field", "Value", "Text", "Virtual", "Name");
+        }
+
+        [Test]
+        public void ToTable_should_maintain_declaration_order_of_inferred_columns_for_poco_types_with_fields_being_first()
+        {
+            var data = new[]
+            {
+                new Base()
+            };
+
+            var inputTable = data.ToTable(x => x.WithInferredColumns(InferredColumnsOrder.Declaration));
+            AssertColumnNames(inputTable, "Field", "Name", "Value", "Virtual");
+        }
+
+        [Test]
+        public void It_should_infer_columns_from_dynamic_collection_of_unified_item_types()
         {
             var values = new[]
                 {
@@ -273,6 +299,9 @@ namespace LightBDD.Framework.UnitTests.Parameters
         private static void AssertColumnNames<T>(InputTable<T> table, params string[] expectedColumns)
         {
             Assert.That(table.Columns.Select(c => c.Name).ToArray(), Is.EqualTo(expectedColumns));
+
+            var details = (ITabularParameterDetails)((IComplexParameter)table).Details;
+            Assert.That(details.Columns.Select(x => x.Name).ToArray(), Is.EqualTo(expectedColumns));
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -666,6 +666,30 @@ namespace LightBDD.Framework.UnitTests.Parameters
             Assert.ThrowsAsync<ArgumentNullException>(() => table.SetActualAsync(null));
         }
 
+        [Test]
+        public void ToVerifiableDataTable_should_maintain_declaration_order_of_inferred_columns_for_complex_types_with_fields_being_first()
+        {
+            var data = new[]
+            {
+                new Derived()
+            };
+
+            var inputTable = data.ToVerifiableDataTable(x => x.WithInferredColumns(InferredColumnsOrder.Declaration));
+            AssertColumnNames(inputTable, "Field", "Value", "Text", "Virtual", "Name");
+        }
+
+        [Test]
+        public void ToVerifiableDataTable_should_maintain_declaration_order_of_inferred_columns_for_poco_types_with_fields_being_first()
+        {
+            var data = new[]
+            {
+                new Base()
+            };
+
+            var inputTable = data.ToVerifiableDataTable(x => x.WithInferredColumns(InferredColumnsOrder.Declaration));
+            AssertColumnNames(inputTable, "Field", "Name", "Value", "Virtual");
+        }
+
         private void AssertRow(ITabularParameterRow row, TableRowType rowType, ParameterVerificationStatus rowStatus, params string[] expectedValueDetails)
         {
             Assert.That(row.Type, Is.EqualTo(rowType));
@@ -705,6 +729,8 @@ namespace LightBDD.Framework.UnitTests.Parameters
         private static void AssertColumnNames<T>(VerifiableTable<T> table, params string[] expectedColumns)
         {
             Assert.That(table.Columns.Select(c => c.Name).ToArray(), Is.EqualTo(expectedColumns));
+
+            Assert.That(table.Details.Columns.Select(x => x.Name).ToArray(), Is.EqualTo(expectedColumns));
         }
 
         private static void AssertResultColumnsMatchingTable<T>(VerifiableTable<T> table)


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #241 

List of changes:
* Added WithInferredColumns(InferredColumnsOrder columnsOrder) method to IInputTableBuilder and IVerifiableDataTableBuilder with option to add inferred columns in name or declaration order

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
