### PR TITLE
#265 Fixed InputTable and VerifiableTable to include Item column if no other columns are present and fail if provided object count and instances do not match

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,10 @@ Version [next]
 ----------------------------------------
 + #241 (LightBDD.Framework)(New) Added WithInferredColumns(InferredColumnsOrder columnsOrder) method to IInputTableBuilder and IVerifiableDataTableBuilder with option to add inferred columns in name or declaration order
 + #264 (LightBDD.Framework)(Fix) Corrected Html Report to expand feature background with the content
++ #265 (LightBDD.Framework)(Fix) Fixed InputTable and VerifiableTable to include Item column if no other columns are present and fail if provided object count and instances do not match
++ #265 (LightBDD.Core)(New) Added IFormatSymbols.EmptyValue property
++ #265 (LightBDD.Core)(New) Added IValueFormattingService.Symbols property
++ #265 (LightBDD.Framework)(Change) Updated CollectionFormatter and DictionaryFormatter to format empty collections
 + #268 (LightBDD.Framework)(New) Added InputTree<T> to provide detailed insights into the object structure upon progress and results rendering.
 + #268 (LightBDD.Framework)(New) Added VerifiableTree<T> to provide detailed structural verification of actual versus expected object hierarchies
 + #268 (LightBDD.Framework)(New) Added Tree class with a set of methods to create InputTree<T> and VerifiableTree<T> parameters

--- a/src/LightBDD.Core/Formatting/Parameters/IFormatSymbols.cs
+++ b/src/LightBDD.Core/Formatting/Parameters/IFormatSymbols.cs
@@ -9,5 +9,10 @@ namespace LightBDD.Core.Formatting.Parameters
         /// Null value text representation.
         /// </summary>
         string NullValue { get; }
+
+        /// <summary>
+        /// Empty value text representation.
+        /// </summary>
+        string EmptyValue { get; }
     }
 }

--- a/src/LightBDD.Core/Formatting/Parameters/Implementation/FormatSymbols.cs
+++ b/src/LightBDD.Core/Formatting/Parameters/Implementation/FormatSymbols.cs
@@ -9,5 +9,6 @@
         }
 
         public string NullValue => "<null>";
+        public string EmptyValue => "<empty>";
     }
 }

--- a/src/LightBDD.Core/Formatting/Values/IValueFormattingService.cs
+++ b/src/LightBDD.Core/Formatting/Values/IValueFormattingService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using LightBDD.Core.Formatting.Parameters;
 
 namespace LightBDD.Core.Formatting.Values
 {
@@ -19,5 +20,10 @@ namespace LightBDD.Core.Formatting.Values
         /// </summary>
         /// <returns>Current <see cref="CultureInfo"/> instance.</returns>
         CultureInfo GetCultureInfo();
+
+        /// <summary>
+        /// Returns associated <seealso cref="IFormatSymbols"/> instance.
+        /// </summary>
+        IFormatSymbols Symbols { get; }
     }
 }

--- a/src/LightBDD.Core/Formatting/Values/ValueFormattingService.cs
+++ b/src/LightBDD.Core/Formatting/Values/ValueFormattingService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using LightBDD.Core.Configuration;
 using LightBDD.Core.Extensibility;
+using LightBDD.Core.Formatting.Parameters;
 using LightBDD.Core.Formatting.Parameters.Implementation;
 using LightBDD.Core.Formatting.Values.Implementation;
 
@@ -23,7 +24,7 @@ namespace LightBDD.Core.Formatting.Values
         /// </summary>
         /// <param name="configuration">Configuration.</param>
         public ValueFormattingService(LightBddConfiguration configuration) : this(
-            configuration.Get<ValueFormattingConfiguration>(), 
+            configuration.Get<ValueFormattingConfiguration>(),
             configuration.CultureInfoProviderConfiguration().CultureInfoProvider)
         { }
 
@@ -66,6 +67,9 @@ namespace LightBDD.Core.Formatting.Values
         {
             return _cultureInfoProvider.GetCultureInfo();
         }
+
+        /// <inheritdoc />
+        public IFormatSymbols Symbols => FormatSymbols.Instance;
 
         private IValueFormatter LookupFormatter(Type type)
         {
@@ -110,10 +114,9 @@ namespace LightBDD.Core.Formatting.Values
                     : _parent.FormatValue(value, this);
             }
 
-            public CultureInfo GetCultureInfo()
-            {
-                return _parent.GetCultureInfo();
-            }
+            public CultureInfo GetCultureInfo() => _parent.GetCultureInfo();
+
+            public IFormatSymbols Symbols => _parent.Symbols;
         }
     }
 }

--- a/src/LightBDD.Framework/Formatting/Values/CollectionFormatter.cs
+++ b/src/LightBDD.Framework/Formatting/Values/CollectionFormatter.cs
@@ -30,7 +30,11 @@ namespace LightBDD.Framework.Formatting.Values
         /// </summary>
         public string FormatValue(object value, IValueFormattingService formattingService)
         {
-            return string.Format(_containerFormat, string.Join(_separator, ((IEnumerable)value).Cast<object>().Select(formattingService.FormatValue)));
+            var items = ((IEnumerable)value)
+                .Cast<object>()
+                .Select(formattingService.FormatValue)
+                .DefaultIfEmpty(formattingService.Symbols.EmptyValue);
+            return string.Format(_containerFormat, string.Join(_separator, items));
         }
 
         /// <summary>

--- a/src/LightBDD.Framework/Formatting/Values/DictionaryFormatter.cs
+++ b/src/LightBDD.Framework/Formatting/Values/DictionaryFormatter.cs
@@ -41,7 +41,8 @@ namespace LightBDD.Framework.Formatting.Values
                 .Select(key => string.Format(
                     _pairFormat,
                     formattingService.FormatValue(key),
-                    formattingService.FormatValue(dictionary[key])));
+                    formattingService.FormatValue(dictionary[key])))
+                .DefaultIfEmpty(formattingService.Symbols.EmptyValue);
 
             return string.Format(_containerFormat, string.Join(_separator, keyValues));
         }

--- a/src/LightBDD.Framework/Parameters/Implementation/TableColumnProvider.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/TableColumnProvider.cs
@@ -8,6 +8,8 @@ namespace LightBDD.Framework.Parameters.Implementation
 {
     internal static class TableColumnProvider
     {
+        public static readonly ColumnInfo ItemColumn = new("Item", ColumnValue.From);
+
         public static IEnumerable<ColumnInfo> InferColumns<TRow>(TRow[] rows, bool addLengthToCollections = false, InferredColumnsOrder inferredColumnsOrder = InferredColumnsOrder.Name)
         {
             var typeInfo = typeof(TRow).GetTypeInfo();
@@ -89,7 +91,7 @@ namespace LightBDD.Framework.Parameters.Implementation
 
         private static IEnumerable<ColumnInfo> AsSimpleColumn()
         {
-            return new[] { new ColumnInfo("Item", ColumnValue.From) };
+            return new[] { ItemColumn };
         }
 
         private static bool IsExpando(TypeInfo typeInfo)

--- a/src/LightBDD.Framework/Parameters/InputTable.cs
+++ b/src/LightBDD.Framework/Parameters/InputTable.cs
@@ -6,6 +6,7 @@ using LightBDD.Core.Formatting.Values;
 using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Framework.Formatting.Values;
+using LightBDD.Framework.Parameters.Implementation;
 using LightBDD.Framework.Results.Implementation;
 
 namespace LightBDD.Framework.Parameters
@@ -33,7 +34,9 @@ namespace LightBDD.Framework.Parameters
         public InputTable(IEnumerable<InputTableColumn> columns, IReadOnlyList<TRow> rows)
         {
             _rows = rows;
-            _columns = columns.ToArray();
+            _columns = columns
+                .DefaultIfEmpty(InputTableColumn.FromColumnInfo(TableColumnProvider.ItemColumn))
+                .ToArray();
         }
 
         void IComplexParameter.SetValueFormattingService(IValueFormattingService formattingService)

--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -7,7 +7,9 @@ using LightBDD.Core.Formatting.Values;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
+using LightBDD.Framework.Expectations;
 using LightBDD.Framework.Formatting.Values;
+using LightBDD.Framework.Parameters.Implementation;
 using LightBDD.Framework.Results.Implementation;
 
 namespace LightBDD.Framework.Parameters
@@ -49,7 +51,9 @@ namespace LightBDD.Framework.Parameters
         /// <param name="columns">Table columns.</param>
         protected VerifiableTable(IEnumerable<VerifiableTableColumn> columns)
         {
-            Columns = columns.OrderByDescending(x => x.IsKey).ToArray();
+            Columns = columns.OrderByDescending(x => x.IsKey)
+                .DefaultIfEmpty(VerifiableTableColumn.FromColumnInfo(TableColumnProvider.ItemColumn))
+                .ToArray();
         }
 
         /// <summary>

--- a/src/LightBDD.Framework/Results/Implementation/TabularParameterDetails.cs
+++ b/src/LightBDD.Framework/Results/Implementation/TabularParameterDetails.cs
@@ -18,7 +18,7 @@ namespace LightBDD.Framework.Results.Implementation
         {
             Columns = columns.ToArray();
             Rows = rows.ToArray();
-            VerificationStatus = Rows.Any() ? Rows.Max(x => x.VerificationStatus) : ParameterVerificationStatus.NotApplicable;
+            VerificationStatus = Rows.Any() ? Rows.Max(x => x.VerificationStatus) : ParameterVerificationStatus.Success;
             VerificationMessage = CollectMessages(tableException);
         }
 

--- a/test/LightBDD.Framework.UnitTests/Expectations/AnyItemExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/AnyItemExpectation_tests.cs
@@ -16,7 +16,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
                     x => x.AnyItem(item => item.Contain('a')))
                 .WithMatchingValues(new[] { "apple", "banana" })
                 .WithNotMatchingValue(null, "expected: any item contains 'a', but got: '<null>'")
-                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: any item contains 'a', but got: ''")
+                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: any item contains 'a', but got: '<empty>'")
                 .WithNotMatchingValue(new[] { "cherry", "melon" }, "expected: any item contains 'a', but got: 'cherry, melon'\n\t[0]: expected: contains 'a', but got: 'cherry'\n\t[1]: expected: contains 'a', but got: 'melon'");
 
             yield return new ExpectationScenario<string[]>(

--- a/test/LightBDD.Framework.UnitTests/Expectations/ContainsExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/ContainsExpectation_tests.cs
@@ -16,7 +16,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
                     x => x.Contain("banana"))
                 .WithMatchingValues(new[] { "apple", "banana" })
                 .WithNotMatchingValue(null, "expected: contains 'banana', but got: '<null>'")
-                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: contains 'banana', but got: ''")
+                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: contains 'banana', but got: '<empty>'")
                 .WithNotMatchingValue(new[] { "apple", "orange" }, "expected: contains 'banana', but got: 'apple, orange'");
 
             yield return new ExpectationScenario<string>(

--- a/test/LightBDD.Framework.UnitTests/Expectations/EqualCollectionExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/EqualCollectionExpectation_tests.cs
@@ -18,7 +18,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
                 .WithNotMatchingValue(null, "expected: equals collection 'banana, apple', but got: '<null>'")
                 .WithNotMatchingValue(new[] { "banana", "Apple" }, "expected: equals collection 'banana, apple', but got: 'banana, Apple'\n\t[1]: expected: 'apple', but got: 'Apple'")
                 .WithNotMatchingValue(new[] { "apple", "banana" }, "expected: equals collection 'banana, apple', but got: 'apple, banana'\n\t[0]: expected: 'banana', but got: 'apple'\n\t[1]: expected: 'apple', but got: 'banana'")
-                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: equals collection 'banana, apple', but got: ''\n\texpected collection of 2 item(s), but got one of 0 item(s)\n\t[0]: missing: 'banana'\n\t[1]: missing: 'apple'")
+                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: equals collection 'banana, apple', but got: '<empty>'\n\texpected collection of 2 item(s), but got one of 0 item(s)\n\t[0]: missing: 'banana'\n\t[1]: missing: 'apple'")
                 .WithNotMatchingValue(new[] { "banana", "pear", "orange" }, "expected: equals collection 'banana, apple', but got: 'banana, pear, orange'\n\texpected collection of 2 item(s), but got one of 3 item(s)\n\t[1]: expected: 'apple', but got: 'pear'\n\t[2]: surplus: 'orange'");
 
             yield return new ExpectationScenario<IEnumerable<int>>(

--- a/test/LightBDD.Framework.UnitTests/Expectations/EquivalentCollectionExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/EquivalentCollectionExpectation_tests.cs
@@ -17,7 +17,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
                 .WithMatchingValues(new[] { "banana", "apple" }, new[] { "apple", "banana" })
                 .WithNotMatchingValue(null, "expected: equivalent collection 'banana, apple', but got: '<null>'")
                 .WithNotMatchingValue(new[] { "Apple", "banana" }, "expected: equivalent collection 'banana, apple', but got: 'Apple, banana'\n\tmissing: 'apple'\n\tsurplus: 'Apple'")
-                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: equivalent collection 'banana, apple', but got: ''\n\texpected collection of 2 item(s), but got one of 0 item(s)\n\tmissing: 'banana'\n\tmissing: 'apple'")
+                .WithNotMatchingValue(Enumerable.Empty<string>(), "expected: equivalent collection 'banana, apple', but got: '<empty>'\n\texpected collection of 2 item(s), but got one of 0 item(s)\n\tmissing: 'banana'\n\tmissing: 'apple'")
                 .WithNotMatchingValue(new[] { "pear", "orange", "banana" }, "expected: equivalent collection 'banana, apple', but got: 'pear, orange, banana'\n\texpected collection of 2 item(s), but got one of 3 item(s)\n\tmissing: 'apple'\n\tsurplus: 'pear'\n\tsurplus: 'orange'")
                 .WithNotMatchingValue(new[] { "banana", "banana" }, "expected: equivalent collection 'banana, apple', but got: 'banana, banana'\n\tmissing: 'apple'\n\tsurplus: 'banana'");
 

--- a/test/LightBDD.Framework.UnitTests/Formatting/FormatSymbolsStub.cs
+++ b/test/LightBDD.Framework.UnitTests/Formatting/FormatSymbolsStub.cs
@@ -1,0 +1,9 @@
+using LightBDD.Core.Formatting.Parameters;
+
+namespace LightBDD.Framework.UnitTests.Formatting;
+
+internal class FormatSymbolsStub : IFormatSymbols
+{
+    public string NullValue => "<null>";
+    public string EmptyValue => "<empty>";
+}

--- a/test/LightBDD.Framework.UnitTests/Formatting/ValueFormattingServiceStub.cs
+++ b/test/LightBDD.Framework.UnitTests/Formatting/ValueFormattingServiceStub.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using LightBDD.Core.Formatting.Parameters;
 using LightBDD.Core.Formatting.Values;
 
 namespace LightBDD.Framework.UnitTests.Formatting
@@ -16,6 +17,8 @@ namespace LightBDD.Framework.UnitTests.Formatting
 
         public string FormatValue(object value)
         {
+            if (value is ISelfFormattable f)
+                return f.Format(this);
             return string.Format(GetCultureInfo(), _itemFormat, value);
         }
 
@@ -23,5 +26,7 @@ namespace LightBDD.Framework.UnitTests.Formatting
         {
             return _cultureInfo;
         }
+
+        public IFormatSymbols Symbols { get; } = new FormatSymbolsStub();
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Formatting/Values/CollectionFormatter_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Formatting/Values/CollectionFormatter_tests.cs
@@ -30,6 +30,15 @@ namespace LightBDD.Framework.UnitTests.Formatting.Values
         }
 
         [Test]
+        public void CollectionFormatter_should_format_empty_collections()
+        {
+            var stub = new ValueFormattingServiceStub(CultureInfo.InvariantCulture);
+            var formatter = new CollectionFormatter();
+            var actual = formatter.FormatValue(Enumerable.Empty<int>(), stub);
+            Assert.That(actual, Is.EqualTo("<empty>"));
+        }
+
+        [Test]
         public void CanFormat_should_accept_any_type_implementing_IEnumerable()
         {
             var formatter = new CollectionFormatter();

--- a/test/LightBDD.Framework.UnitTests/Formatting/Values/DictionaryFormatter_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Formatting/Values/DictionaryFormatter_tests.cs
@@ -30,6 +30,18 @@ namespace LightBDD.Framework.UnitTests.Formatting.Values
         }
 
         [Test]
+        public void FormatValue_should_format_empty_dictionaries()
+        {
+            var stub = new ValueFormattingServiceStub(CultureInfo.InvariantCulture);
+            var formatter = new DictionaryFormatter();
+
+            var dictionary = new Dictionary<float, string>();
+
+            var actual = formatter.FormatValue(dictionary, stub);
+            Assert.That(actual, Is.EqualTo("<empty>"));
+        }
+
+        [Test]
         public void DictionaryFormatter_should_use_service_to_format_items()
         {
             var stub = new ValueFormattingServiceStub(CultureInfo.InvariantCulture, ">{0}");

--- a/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
@@ -290,7 +290,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_has_item_for_collection_of_empty_expando_objects(int count)
+        public void Table_should_have_item_for_collection_of_empty_expando_objects(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
             var table = input.ToTable();
@@ -303,7 +303,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_has_item_column_for_collection_of_empty_objects(int count)
+        public void Table_should_have_item_column_for_collection_of_empty_objects(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
             var table = input.ToTable();
@@ -316,7 +316,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_has_item_column_for_collection_of_empty_collections(int count)
+        public void Table_should_have_item_column_for_collection_of_empty_collections(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => Array.Empty<int>()).ToArray();
             var table = input.ToTable();

--- a/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
@@ -7,6 +7,7 @@ using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Framework.Parameters;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Shouldly;
 
 namespace LightBDD.Framework.UnitTests.Parameters
 {
@@ -39,6 +40,8 @@ namespace LightBDD.Framework.UnitTests.Parameters
             public int X { get; }
             public int Y { get; }
         }
+
+        class EmptyObject{}
 
         [Test]
         public void ToTable_should_infer_columns_from_class_collection()
@@ -282,6 +285,45 @@ namespace LightBDD.Framework.UnitTests.Parameters
             var table = input.ToTable();
             Assert.That(table[0], Is.EqualTo(input[0]));
             Assert.That(table[1], Is.EqualTo(input[1]));
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        public void Table_should_have_type_column_for_collection_of_empty_expando_objects(int count)
+        {
+            var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
+            var table = input.ToTable();
+            AssertColumnNames(table, "Item");
+            table.Count.ShouldBe(count);
+            for (int i = 0; i < count; ++i)
+                AssertValues(table, input[i], ColumnValue.From(input[i]));
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        public void Table_should_have_type_column_for_collection_of_empty_objects(int count)
+        {
+            var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
+            var table = input.ToTable();
+            AssertColumnNames(table, "Item");
+            table.Count.ShouldBe(count);
+            for (int i = 0; i < count; ++i)
+                AssertValues(table, input[i], ColumnValue.From(input[i]));
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        public void Table_should_have_type_column_for_collection_of_empty_collections(int count)
+        {
+            var input = Enumerable.Range(0, count).Select(_ => Array.Empty<int>()).ToArray();
+            var table = input.ToTable();
+            AssertColumnNames(table, "Item");
+            table.Count.ShouldBe(count);
+            for (int i = 0; i < count; ++i)
+                AssertValues(table, input[i], ColumnValue.From(input[i]));
         }
 
         private static void TestCollectionToTable<T>(T[] input, string[] expectedColumns, int index, ColumnValue[] expectedValues)

--- a/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Table_tests.cs
@@ -290,7 +290,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_have_type_column_for_collection_of_empty_expando_objects(int count)
+        public void Table_should_has_item_for_collection_of_empty_expando_objects(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
             var table = input.ToTable();
@@ -303,7 +303,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_have_type_column_for_collection_of_empty_objects(int count)
+        public void Table_should_has_item_column_for_collection_of_empty_objects(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
             var table = input.ToTable();
@@ -316,7 +316,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void Table_should_have_type_column_for_collection_of_empty_collections(int count)
+        public void Table_should_has_item_column_for_collection_of_empty_collections(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => Array.Empty<int>()).ToArray();
             var table = input.ToTable();

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -701,7 +701,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void It_should_has_item_column_for_collection_of_empty_expando_objects_and_verify_them(int count)
+        public void It_should_have_item_column_for_collection_of_empty_expando_objects_and_verify_them(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
             var table = input.ToVerifiableDataTable();
@@ -718,7 +718,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void It_should_has_item_column_for_collection_of_empty_objects_and_verify_them(int count)
+        public void It_should_have_item_column_for_collection_of_empty_objects_and_verify_them(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
             var table = input.ToVerifiableDataTable();

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -2,14 +2,18 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using LightBDD.Core.Execution;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Framework.Expectations;
 using LightBDD.Framework.Parameters;
+using LightBDD.Framework.UnitTests.Formatting;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Shouldly;
 
 #pragma warning disable 1998
 
@@ -18,6 +22,8 @@ namespace LightBDD.Framework.UnitTests.Parameters
     [TestFixture]
     public class VerifiableDataTable_tests
     {
+        private static readonly ValueFormattingServiceStub _formatter = new(CultureInfo.InvariantCulture);
+
         class Base
         {
             public string Name { get; set; }
@@ -44,6 +50,8 @@ namespace LightBDD.Framework.UnitTests.Parameters
             public int X { get; }
             public int Y { get; }
         }
+
+        class EmptyObject { }
 
         [Test]
         public void ToVerifiableDataTable_should_infer_columns_from_class_collection()
@@ -690,6 +698,58 @@ namespace LightBDD.Framework.UnitTests.Parameters
             AssertColumnNames(inputTable, "Field", "Name", "Value", "Virtual");
         }
 
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        public void It_should_have_type_column_for_collection_of_empty_expando_objects(int count)
+        {
+            var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
+            var table = input.ToVerifiableDataTable();
+            SetFormatter(table);
+            table.SetActual(input);
+
+            AssertColumnNames(table, "Item");
+            table.ActualRows.Count.ShouldBe(count);
+            for (int i = 0; i < count; ++i)
+                AssertRowValues(table.Details.Rows[i], TableRowType.Matching, ParameterVerificationStatus.Success, $"{_formatter.FormatValue(input[i])}|{_formatter.FormatValue(input[i])}");
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Success));
+        }
+
+        [Test]
+        [TestCase(0)]
+        [TestCase(2)]
+        public void It_should_have_type_column_for_collection_of_empty_objects(int count)
+        {
+            var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
+            var table = input.ToVerifiableDataTable();
+            SetFormatter(table);
+            table.SetActual(input);
+
+            AssertColumnNames(table, "Item");
+            table.ActualRows.Count.ShouldBe(count);
+            for (int i = 0; i < count; ++i)
+                AssertRowValues(table.Details.Rows[i], TableRowType.Matching, ParameterVerificationStatus.Success, $"{_formatter.FormatValue(input[i])}|{_formatter.FormatValue(input[i])}");
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Success));
+        }
+
+        [Test]
+        public void It_should_fail_if_non_empty_collection_is_provided_when_expecting_empty()
+        {
+            var input = Array.Empty<object>();
+            var table = input.ToVerifiableDataTable();
+            SetFormatter(table);
+
+            var actuals = new[] { new object(), new ExpandoObject(), new EmptyObject() };
+            table.SetActual(actuals);
+
+            AssertColumnNames(table, "Item");
+            table.ActualRows.Count.ShouldBe(3);
+            AssertRowValues(table.Details.Rows[0], TableRowType.Surplus, ParameterVerificationStatus.Failure, $"{_formatter.FormatValue(actuals[0])}|<none>");
+            AssertRowValues(table.Details.Rows[1], TableRowType.Surplus, ParameterVerificationStatus.Failure, $"{_formatter.FormatValue(actuals[1])}|<none>");
+            AssertRowValues(table.Details.Rows[2], TableRowType.Surplus, ParameterVerificationStatus.Failure, $"{_formatter.FormatValue(actuals[2])}|<none>");
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Failure));
+        }
+
         private void AssertRow(ITabularParameterRow row, TableRowType rowType, ParameterVerificationStatus rowStatus, params string[] expectedValueDetails)
         {
             Assert.That(row.Type, Is.EqualTo(rowType));
@@ -742,6 +802,11 @@ namespace LightBDD.Framework.UnitTests.Parameters
         private static void AssertVerificationMessage(string actual, string expected)
         {
             Assert.That(actual, Is.EqualTo(expected.Replace("\n", Environment.NewLine)));
+        }
+
+        private void SetFormatter<T>(VerifiableTable<T> t)
+        {
+            (t as IComplexParameter).SetValueFormattingService(_formatter);
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -701,7 +701,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void It_should_have_type_column_for_collection_of_empty_expando_objects(int count)
+        public void It_should_has_item_column_for_collection_of_empty_expando_objects_and_verify_them(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new ExpandoObject()).ToArray();
             var table = input.ToVerifiableDataTable();
@@ -718,7 +718,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         [Test]
         [TestCase(0)]
         [TestCase(2)]
-        public void It_should_have_type_column_for_collection_of_empty_objects(int count)
+        public void It_should_has_item_column_for_collection_of_empty_objects_and_verify_them(int count)
         {
             var input = Enumerable.Range(0, count).Select(_ => new EmptyObject()).ToArray();
             var table = input.ToVerifiableDataTable();
@@ -733,7 +733,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         }
 
         [Test]
-        public void It_should_fail_if_non_empty_collection_is_provided_when_expecting_empty()
+        public void It_should_fail_if_non_empty_collection_is_provided_when_expected_empty()
         {
             var input = Array.Empty<object>();
             var table = input.ToVerifiableDataTable();


### PR DESCRIPTION
#### Details

Issue reference: #265

List of changes:
+ (LightBDD.Framework)(Fix) Fixed InputTable and VerifiableTable to include Item column if no other columns are present and fail if provided object count and instances do not match
+ (LightBDD.Core)(New) Added IFormatSymbols.EmptyValue property
+ (LightBDD.Core)(New) Added IValueFormattingService.Symbols property
+ (LightBDD.Framework)(Change) Updated CollectionFormatter and DictionaryFormatter to format empty collections


#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
