### PR TITLE
#276 Fixed casting null to Nullable for CastExpectation

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 LightBDD
 ===========================================
 
+Version 3.6.1
+----------------------------------------
++ #241 (LightBDD.Framework)(Fix) Fixed casting null to Nullable for CastExpectation
+
 Version 3.6.0
 ----------------------------------------
 + #241 (LightBDD.Framework)(New) Added WithInferredColumns(InferredColumnsOrder columnsOrder) method to IInputTableBuilder and IVerifiableDataTableBuilder with option to add inferred columns in name or declaration order

--- a/src/LightBDD.Framework/Expectations/Implementation/CastExpectation.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/CastExpectation.cs
@@ -14,7 +14,7 @@ namespace LightBDD.Framework.Expectations.Implementation
 
         public override ExpectationResult Verify(TBase value, IValueFormattingService formattingService)
         {
-            if (value is TDerived || value is null && !typeof(TDerived).IsValueType)
+            if (value is TDerived || value is null && CanCastFromNull())
                 return _expectation.Verify((TDerived)value, formattingService);
 
             if (NumericTypeHelper.IsNumeric(typeof(TDerived)) && NumericTypeHelper.IsNumeric(value))
@@ -32,6 +32,12 @@ namespace LightBDD.Framework.Expectations.Implementation
             }
 
             return ExpectationResult.Failure($"value '{formattingService.FormatValue(value)}' of type '{value?.GetType().Name ?? "<null>"}' cannot be cast to '{typeof(TDerived).Name}'");
+        }
+
+        private static bool CanCastFromNull()
+        {
+            return !typeof(TDerived).IsValueType
+                || (typeof(TDerived).IsGenericType && typeof(TDerived).GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
         private static bool TryConvert(TBase value, out TDerived o)

--- a/test/LightBDD.Framework.UnitTests/Expectations/CastFromExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/CastFromExpectation_tests.cs
@@ -57,5 +57,12 @@ namespace LightBDD.Framework.UnitTests.Expectations
             Assert.False(result);
             result.Message.ShouldBe("value '5.14' of type 'Double' cannot be cast to 'Int32' without precision loss");
         }
+
+        [Test]
+        public void Casting_null_to_Nullable()
+        {
+            var result = Expect.To.Equal<int?>(null).CastFrom(Expect.Type<object>()).Verify(null, ValueFormattingServices.Current);
+            Assert.True(result);
+        }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -750,6 +750,23 @@ namespace LightBDD.Framework.UnitTests.Parameters
             Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Failure));
         }
 
+        class WithNullable
+        {
+            public decimal? Value { get; set; }
+        }
+
+        [Test]
+        public void It_should_match_null_against_nullables()
+        {
+            var input = new WithNullable[] { new() { Value = null } };
+
+            var table = input.ToVerifiableDataTable(x => x.WithColumn(v => v.Value));
+            table.SetActual(input);
+
+            table.Details.VerificationMessage.ShouldBeNullOrEmpty();
+            table.Details.VerificationStatus.ShouldBe(ParameterVerificationStatus.Success);
+        }
+
         private void AssertRow(ITabularParameterRow row, TableRowType rowType, ParameterVerificationStatus rowStatus, params string[] expectedValueDetails)
         {
             Assert.That(row.Type, Is.EqualTo(rowType));


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #276 

List of changes:
- Fixed casting null to Nullable for CastExpectation

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
