### PR TITLE
#282 Updated Html Report to have collapsible sub-steps being collapsed by default

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,7 @@ Version vNext
 + #281 (LightBDD.Core)(New) Added IScenarioSetUp and IScenarioTearDown execution extension interfaces allowing to run scenario set up / tear down when implemented on fixture class
 + #281 (LightBDD.Core)(Change) Exposed IScenario.Fixture property allowing scenario decorators accessing the fixture object
 + #281 (LightBDD.Core)(New) Added ability to register global set up and tear down for resources and activities by using `ExecutionExtensionsConfiguration`
++ #282 (LightBDD.Framework)(Change) Updated Html Report to have collapsible sub-steps being collapsed by default
 
 Version 3.6.1
 ----------------------------------------

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -290,15 +290,18 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
             return Html.Tag(Html5Tag.Div).Class("options").Content(
                 Html.Tag(Html5Tag.Span).Content("Toggle:"),
                 Html.Tag(Html5Tag.Span).Content(
-                GetOptionNode(
-                    "toggleFeatures",
-                    Html.Checkbox().Checked().SpaceBefore().OnClick("checkAll('toggleF',toggleFeatures.checked)"),
-                    "Features"),
-
-                GetOptionNode(
-                    "toggleScenarios",
-                    Html.Checkbox().Checked().SpaceBefore().OnClick("checkAll('toggleS',toggleScenarios.checked)"),
-                    "Scenarios")));
+                    GetOptionNode(
+                        "toggleFeatures",
+                        Html.Checkbox().Checked().SpaceBefore().OnClick("checkAll('toggleF',toggleFeatures.checked)"),
+                        "Features"),
+                    GetOptionNode(
+                        "toggleScenarios",
+                        Html.Checkbox().Checked().SpaceBefore().OnClick("checkAll('toggleS',toggleScenarios.checked)"),
+                        "Scenarios"),
+                    GetOptionNode(
+                        "toggleSubSteps",
+                        Html.Checkbox().Checked().SpaceBefore().OnClick("checkAll('toggleSS',toggleSubSteps.checked)"),
+                        "Sub Steps")));
         }
 
         private static IHtmlNode GetOptionNode(string elementId, TagBuilder element, string labelContent)
@@ -307,9 +310,10 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                 Html.Tag(Html5Tag.Label).Content(GetCheckBoxTag(), Html.Text(labelContent)).For(elementId));
         }
 
-        private static IHtmlNode GetCheckBoxTag()
+        private static IHtmlNode GetCheckBoxTag(bool isEmpty = false)
         {
-            return Html.Tag(Html5Tag.Span).Class("chbox");
+            var className = isEmpty ? "chbox empty" : "chbox";
+            return Html.Tag(Html5Tag.Span).Class(className);
         }
 
         private IHtmlNode GetFeatureDetails(IFeatureResult feature, int index)
@@ -425,11 +429,16 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
 
         private static IHtmlNode GetStep(IStepResult step)
         {
+            var toggleId = step.Info.RuntimeId.ToString();
             return Html.Tag(Html5Tag.Div).Class("step").Content(
-                GetStatus(step.Status),
-                Html.Text($"{WebUtility.HtmlEncode(step.Info.GroupPrefix)}{step.Info.Number}. {step.Info.Name.Format(StepNameDecorator)}").Trim(),
+                Html.Checkbox().Id(toggleId).Class("toggle toggleSS").Checked(),
+                Html.Tag(Html5Tag.Label).For(toggleId).Content(
+                    GetCheckBoxTag(!step.GetSubSteps().Any()),
+                    GetStatus(step.Status),
+                    Html.Text($"{WebUtility.HtmlEncode(step.Info.GroupPrefix)}{step.Info.Number}. {step.Info.Name.Format(StepNameDecorator)}").Trim()),
                 GetDuration(step.ExecutionTime),
-                Html.Tag(Html5Tag.Div).Class("step-parameters").Content(step.Parameters.Select(GetStepParameter)).SkipEmpty(),
+                Html.Tag(Html5Tag.Div).Class("step-parameters").Content(step.Parameters.Select(GetStepParameter))
+                    .SkipEmpty(),
                 Html.Tag(Html5Tag.Div).Class("sub-steps").Content(step.GetSubSteps().Select(GetStep)).SkipEmpty());
         }
 

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/scripts.js
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/scripts.js
@@ -48,26 +48,26 @@ function sortTable(tableId, columnIdx, numeric, toggle) {
     var parseMethod;
     var checkMethod;
     if (numeric) {
-        sortMethod = direction ? function(x, y) { return x[0] - y[0]; } : function(x, y) { return y[0] - x[0]; };
-        parseMethod = function(x) { return parseFloat(x); };
-        checkMethod = function(x) { return !isNaN(x); };
+        sortMethod = direction ? function (x, y) { return x[0] - y[0]; } : function (x, y) { return y[0] - x[0]; };
+        parseMethod = function (x) { return parseFloat(x); };
+        checkMethod = function (x) { return !isNaN(x); };
     } else {
         sortMethod = direction
-            ? function(x, y) { return (x[0] > y[0]) ? 1 : ((x[0] < y[0]) ? -1 : 0); }
-            : function(x, y) { return (x[0] < y[0]) ? 1 : ((x[0] > y[0]) ? -1 : 0); };
-        parseMethod = function(x) { return x; };
-        checkMethod = function(x) { return true; };
+            ? function (x, y) { return (x[0] > y[0]) ? 1 : ((x[0] < y[0]) ? -1 : 0); }
+            : function (x, y) { return (x[0] < y[0]) ? 1 : ((x[0] > y[0]) ? -1 : 0); };
+        parseMethod = function (x) { return x; };
+        checkMethod = function (x) { return true; };
     }
 
     var tbl = document.getElementById(tableId).tBodies[0];
     var store = [];
     tbl.rows.asQueryable()
-        .do(function(row) {
+        .do(function (row) {
             var sortnr = parseMethod(row.cells[columnIdx].textContent || row.cells[columnIdx].innerText);
             if (checkMethod(sortnr)) store.push([sortnr, row]);
         });
     store.sort(sortMethod);
-    store.asQueryable().do(function(row) { tbl.appendChild(row[1]); });
+    store.asQueryable().do(function (row) { tbl.appendChild(row[1]); });
     ++synchronizationCounter;
 }
 
@@ -138,13 +138,17 @@ function updateOptionsLink() {
 
     var options = [];
 
-    var check = function (element, option) {
-        if (!document.getElementById(element).checked)
+    var check = function (element, option, invert = true) {
+        var value = document.getElementById(element).checked;
+        if (invert && !value)
             options.push(option + '=0');
+        if (!invert && value)
+            options.push(option + '=1');
     };
 
     check('toggleFeatures', 'tf');
     check('toggleScenarios', 'ts');
+    check('toggleSubSteps', 'tss', false);
 
     check('showPassed', 'fp');
     check('showBypassed', 'fb');
@@ -178,14 +182,16 @@ function applyOptionsFromLink() {
         return results === null ? null : decodeURIComponent(results[1]);
     };
 
-    var applyToCheckbox = function (elementId, param) {
+    var applyToCheckbox = function (elementId, param, invert = true) {
         var element = document.getElementById(elementId);
-        element.checked = (getParam(param) === '0'); //set opposite value
+        var value = getParam(param);
+        element.checked = value === null ? !invert : (value==='0'); //set opposite value
         element.click(); //toggle it
     };
 
     applyToCheckbox('toggleFeatures', 'tf');
     applyToCheckbox('toggleScenarios', 'ts');
+    applyToCheckbox('toggleSubSteps', 'tss', false);
     applyToCheckbox('showPassed', 'fp');
     applyToCheckbox('showBypassed', 'fb');
     applyToCheckbox('showFailed', 'ff');
@@ -196,9 +202,9 @@ function applyOptionsFromLink() {
 
     if (cat !== null) {
         document.getElementsByName('categoryFilter')
-        .asQueryable()
-        .where(function (c) { return c.dataset.filterName === cat; })
-        .do(function (c) { c.click(); });
+            .asQueryable()
+            .where(function (c) { return c.dataset.filterName === cat; })
+            .do(function (c) { c.click(); });
     }
 
 }

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/styles.css
@@ -20,6 +20,7 @@ section.features{display: flex;flex-direction: column;}
 .scenario{ margin-bottom: 1px;}
 .toggleF:not(:checked) ~ .scenarios { display: none;}
 .toggleS:not(:checked) + h3 ~ * { display: none;}
+.toggleSS:not(:checked) ~ .sub-steps { display: none;}
 .description{font-style: italic;color: #222222;white-space: pre-wrap;margin-top: 0.5em;}
 .label{color: #222277;}
 .status{font-weight: bold;border: 1px solid #777777;padding: 0.2em;margin-right: 0.2em;width: 5em; display: inline-block;text-align: center;}
@@ -34,7 +35,7 @@ section.features{display: flex;flex-direction: column;}
 .attachments::before{content:"Attachments:"}
 .attachments div{ display: inline-block; margin-right: 0.5em;}
 .comments div{color: #0000cd;}
-.step, .categories{margin: 0.2em;margin-left: 2.5em;}
+.step,.categories,.step-parameters{margin: 0.2em;margin-left: 1.5em;}
 .smallLink,.duration{color: #0000cd;font-size: 0.8em;font-family: monospace;}
 th,td{ white-space: nowrap;}
 th{ text-align: right;}
@@ -62,6 +63,7 @@ a:hover{ text-decoration: underline;}
 *:hover > .smallLink { display: inline;}
 input[type="checkbox"],input[type="radio"]{ display: none;}
 .chbox:before{display: inline-block; border: 1px solid #777777;margin-right: 0.5em;font-weight: bold;text-align: center;width: 1.2em;height: 1.2em;line-height: 1.2em;vertical-align: middle;}
+.chbox.empty:before {visibility: hidden;}
 input[type="checkbox"]:not(:checked) + * .chbox:before{ background-color: #ffeeee;content: "\2715";}
 input[type="checkbox"]:checked + * .chbox:before{ background-color: #eeeeee;content: "\2713";}
 input[type="checkbox"].toggle:not(:checked) + * .chbox:before{ background-color: #ffeeee;content: "v";}

--- a/test/LightBDD.AcceptanceTests/Features/HTML_report_feature.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HTML_report_feature.cs
@@ -60,6 +60,29 @@ I want to have HTML report")]
         }
 
         [Scenario]
+        public async Task Should_expand_scenario_step_sub_steps()
+        {
+            await Runner
+                .WithContext<HtmlReportContext>()
+                .RunScenarioAsync(
+                    x => x.Given_a_various_features_with_scenarios_and_categories(),
+                    x => x.Given_a_html_report_is_created(),
+
+                    x => x.When_a_html_report_is_opened(),
+                    x => x.Then_all_features_should_be_VISIBLE(true),
+                    x => x.Then_all_scenarios_should_be_VISIBLE(true),
+                    x => x.Then_all_steps_should_be_VISIBLE(true),
+                    x => x.Then_all_sub_steps_should_be_VISIBLE(false),
+
+                    x => x.When_a_feature_scenario_step_collapse_button_is_clicked(1, 1, 1),
+                    x => x.Then_the_feature_scenario_step_sub_steps_should_be_VISIBLE(1, 1, 1, true),
+
+                    x => x.When_a_feature_scenario_step_collapse_button_is_clicked(1, 1, 1),
+                    x => x.Then_the_feature_scenario_step_sub_steps_should_be_VISIBLE(1, 1, 1, false));
+
+        }
+
+        [Scenario]
         public async Task Should_collapse_all_features()
         {
             await Runner
@@ -104,6 +127,32 @@ I want to have HTML report")]
                 x => x.When_a_scenario_filter_button_is_clicked(),
                 x => x.Then_all_scenarios_should_be_VISIBLE(true),
                 x => x.Then_all_steps_should_be_VISIBLE(true));
+        }
+
+        [Scenario]
+        public async Task Should_expand_all_sub_steps()
+        {
+            await Runner
+                .WithContext<HtmlReportContext>()
+                .RunScenarioAsync(
+                    x => x.Given_a_various_features_with_scenarios_and_categories(),
+                    x => x.Given_a_html_report_is_created(),
+
+                    x => x.When_a_html_report_is_opened(),
+                    x => x.Then_all_features_should_be_VISIBLE(true),
+                    x => x.Then_all_scenarios_should_be_VISIBLE(true),
+                    x => x.Then_all_steps_should_be_VISIBLE(true),
+                    x => x.Then_all_sub_steps_should_be_VISIBLE(false),
+
+                    x => x.When_a_sub_step_filter_button_is_clicked(),
+                    x => x.Then_all_scenarios_should_be_VISIBLE(true),
+                    x => x.Then_all_steps_should_be_VISIBLE(true),
+                    x => x.Then_all_sub_steps_should_be_VISIBLE(true),
+
+                    x => x.When_a_sub_step_filter_button_is_clicked(),
+                    x => x.Then_all_scenarios_should_be_VISIBLE(true),
+                    x => x.Then_all_steps_should_be_VISIBLE(true),
+                    x => x.Then_all_sub_steps_should_be_VISIBLE(false));
         }
 
         [Scenario]

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -96,6 +96,12 @@ namespace LightBDD.AcceptanceTests.Features
             Assert.That(actual, Is.EqualTo(Features.SelectMany(f => f.GetScenarios()).SelectMany(s => s.GetSteps()).Count()));
         }
 
+        public async Task Then_all_sub_steps_should_be_VISIBLE(bool visible)
+        {
+            var actual = Driver.FindAllSubSteps().Count(e => e.Displayed == visible);
+            Assert.That(actual, Is.EqualTo(Features.SelectMany(f => f.GetScenarios()).SelectMany(s => s.GetSteps()).Count(s => s.GetSubSteps().Any())));
+        }
+
         public async Task When_a_feature_collapse_button_is_clicked(int feature)
         {
             ClickLabeledButton(ToFeatureToggle(feature));
@@ -135,6 +141,17 @@ namespace LightBDD.AcceptanceTests.Features
             ClickLabeledButton(ToScenarioToggle(feature, scenario));
         }
 
+        public async Task When_a_feature_scenario_step_collapse_button_is_clicked(int feature, int scenario, int step)
+        {
+           ClickLabeledButton(Features[feature - 1].GetScenarios().ElementAt(scenario - 1).GetSteps().ElementAt(step - 1).Info.RuntimeId.ToString());
+        }
+
+        public async Task Then_the_feature_scenario_step_sub_steps_should_be_VISIBLE(int feature, int scenario, int step, bool visible)
+        {
+            var actual = Driver.FindFeature(feature).FindScenario(scenario).FindStep(step).FindSubSteps().Count(e => e.Displayed == visible);
+            Assert.That(actual, Is.EqualTo(Features[feature - 1].GetScenarios().ElementAt(scenario-1).GetSteps().ElementAt(step-1).GetSubSteps().Count()));
+        }
+
         private static string ToScenarioToggle(int feature, int scenario)
         {
             return $"toggle{feature}_{scenario - 1}";
@@ -154,6 +171,11 @@ namespace LightBDD.AcceptanceTests.Features
         public async Task When_a_scenario_filter_button_is_clicked()
         {
             ClickLabeledButtonSync("toggleScenarios");
+        }
+
+        public async Task When_a_sub_step_filter_button_is_clicked()
+        {
+            ClickLabeledButtonSync("toggleSubSteps");
         }
 
         public async Task Then_the_scenario_filter_button_should_be_SELECTED([SelectedFormat] bool selected)

--- a/test/LightBDD.AcceptanceTests/Helpers/Builders/ScenarioBuilder.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Builders/ScenarioBuilder.cs
@@ -31,8 +31,9 @@ namespace LightBDD.AcceptanceTests.Helpers.Builders
 
         public ScenarioBuilder WithSampleSteps()
         {
-            _steps.Add(TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
-            _steps.Add(TestResults.CreateStepResult(2, "step2", Status, DateTimeOffset.Now, TimeSpan.FromSeconds(1)));
+            _steps.Add(TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, DateTimeOffset.Now, TimeSpan.FromSeconds(1)).WithRuntimeId(Guid.NewGuid()).WithSubSteps(
+                TestResults.CreateStepResult(1, "sub-step1", ExecutionStatus.Passed, DateTimeOffset.Now, TimeSpan.FromMilliseconds(500))).WithRuntimeId(Guid.NewGuid()));
+            _steps.Add(TestResults.CreateStepResult(2, "step2", Status, DateTimeOffset.Now, TimeSpan.FromSeconds(1)).WithRuntimeId(Guid.NewGuid()));
 
             return this;
         }

--- a/test/LightBDD.AcceptanceTests/Helpers/Extensions.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Extensions.cs
@@ -25,7 +25,12 @@ namespace LightBDD.AcceptanceTests.Helpers
 
         public static IEnumerable<IWebElement> FindAllSteps(this ChromeDriver driver)
         {
-            return driver.FindElementsByClassName("step");
+            return driver.FindElementsByCssSelector(".scenario > div > .step");
+        }
+
+        public static IEnumerable<IWebElement> FindAllSubSteps(this ChromeDriver driver)
+        {
+            return driver.FindElementsByClassName("sub-steps");
         }
 
         public static IWebElement FindScenario(this IWebElement element, int scenarioNo)
@@ -39,6 +44,16 @@ namespace LightBDD.AcceptanceTests.Helpers
         }
 
         public static IEnumerable<IWebElement> FindSteps(this IWebElement element)
+        {
+            return element.FindElements(By.CssSelector(".scenario > div > .step"));
+        }
+        
+        public static IWebElement FindStep(this IWebElement element, int stepNo)
+        {
+            return FindSteps(element).ElementAt(stepNo - 1);
+        }
+
+        public static IEnumerable<IWebElement> FindSubSteps(this IWebElement element)
         {
             return element.FindElements(By.ClassName("step"));
         }

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -56,7 +56,7 @@ Feature summary
 Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ignored Not Run Duration Aggregated Average
 My feature [Label 1] 2 0 0 1 1 10 3 1 2 2 2 1m 02s 621000000 1m 04s 642570000 32s 128ms 321285000
 Feature details[&#8734;link]
-Toggle: Features Scenarios
+Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
 Categories: -all- categoryA categoryB categoryC -without category-
 [&#8734;filtered link]
@@ -138,7 +138,7 @@ Feature summary
 Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ignored Not Run Duration Aggregated Average
 My feature 1 0 0 0 1 2 1 0 0 1 0 25ms 250000 25ms 250000 25ms 250000
 Feature details[&#8734;link]
-Toggle: Features Scenarios
+Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
 [&#8734;filtered link]
 My feature[&#8734;link]
@@ -178,7 +178,7 @@ Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ig
 My feature 1 1 0 0 0 1 1 0 0 0 0 20ms 200000 20ms 200000 20ms 200000
 My feature2 1 1 0 0 0 1 1 0 0 0 0 20ms 200000 20ms 200000 20ms 200000
 Feature details[&#8734;link]
-Toggle: Features Scenarios
+Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
 Categories: -all- categoryA categoryB -without category-
 [&#8734;filtered link]
@@ -232,7 +232,7 @@ Feature summary
 Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ignored Not Run Duration Aggregated Average
 My feature 1 1 0 0 0 2 2 0 0 0 0 5s 50000000 5s 50000000 5s 50000000
 Feature details[&#8734;link]
-Toggle: Features Scenarios
+Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
 [&#8734;filtered link]
 My feature[&#8734;link]
@@ -271,7 +271,7 @@ Feature summary
 Feature Scenarios Passed Bypassed Failed Ignored Steps Passed Bypassed Failed Ignored Not Run Duration Aggregated Average
 My Feature 3 3 0 0 0 3 3 0 0 0 0 5s 50000000 9s 90000000 3s 30000000
 Feature details[&#8734;link]
-Toggle: Features Scenarios
+Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
 [&#8734;filtered link]
 My Feature[&#8734;link]

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -76,6 +76,12 @@ namespace LightBDD.UnitTests.Helpers
             return result;
         }
 
+        public static TestStepResult WithRuntimeId(this TestStepResult result, Guid id)
+        {
+            result.Info.RuntimeId = id;
+            return result;
+        }
+
         public static TestStepResult WithGroupPrefix(this TestStepResult result, string groupPrefix)
         {
             result.Info.GroupPrefix = groupPrefix;
@@ -288,7 +294,7 @@ namespace LightBDD.UnitTests.Helpers
         {
             IStepNameInfo IStepInfo.Name => Name;
             public IMetadataInfo Parent { get; set; }
-            public Guid RuntimeId { get; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
+            public Guid RuntimeId { get; set; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
             public string GroupPrefix { get; set; }
             public TestStepNameInfo Name { get; set; }
             public int Number { get; set; }


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #282

List of changes:
(LightBDD.Framework)(Change) Updated Html Report to have collapsible sub-steps being collapsed by default

![image](https://github.com/LightBDD/LightBDD/assets/1894621/bfe02fd2-3dd7-41bf-8afe-325ca96dfb9d)

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
