### PR TITLE
#288 Format of non-inline step parameters with <$name> parameter reference

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -7,6 +7,7 @@ Version vNext
 + #281 (LightBDD.Core)(Change) Exposed IScenario.Fixture property allowing scenario decorators accessing the fixture object
 + #281 (LightBDD.Core)(New) Added ability to register global set up and tear down for resources and activities by using `ExecutionExtensionsConfiguration`
 + #282 (LightBDD.Framework)(Change) Updated Html Report to have collapsible sub-steps being collapsed by default
++ #288 (LightBDD.Core)(Change) Format of non-inline step parameters with <$name> parameter reference
 
 Version 3.6.1
 ----------------------------------------


### PR DESCRIPTION
#### Details

Issue reference: #288

List of changes:
- (LightBDD.Core)(Change) Format of non-inline step parameters with `<$name>` parameter reference

### Before
```
	Scenario: Adding contacts - Failed (35ms)
		Step 1: GIVEN an empty address book - Passed (<1ms)
		Step 2: WHEN I associate contact "<tree>" with address "<tree>" as alias "Joey" - Passed (24ms)
		contact:
		  $: <object>
		  $.Email: joe67@email.com
		  $.Name: Joe Jonnes
		  $.PhoneNumber: 666777888
		address:
		  $: <object>
		  $.Address: 47 Main Street
		  $.City: London
		  $.Country: UK
		  $.PostCode: AB1 2CD
```
### After
```
	Scenario: Adding contacts - Failed (51ms)
		Step 1: GIVEN an empty address book - Passed (<1ms)
		Step 2: WHEN I associate contact "<$contact>" with address "<$address>" as alias "Joey" - Passed (21ms)
		contact:
		  $: <object>
		  $.Email: joe67@email.com
		  $.Name: Joe Jonnes
		  $.PhoneNumber: 666777888
		address:
		  $: <object>
		  $.Address: 47 Main Street
		  $.City: London
		  $.Country: UK
		  $.PostCode: AB1 2CD
```

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
