### PR TITLE
#296 Added net6 target framework to all LightBDD packages

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -12,6 +12,7 @@ Version vNext
 + #288 (LightBDD.Core)(Change) Format of non-inline step parameters with <$name> parameter reference
 + #293 (LightBDD.MsTest3)(New) Created LightBDD.MsTest3 project with dependency on MSTest.TestFramework 3.x
 + #293 (LightBDD.MsTest2)(Change) Deprecated LightBDD.MsTest2 project in favor of LightBDD.MsTest3
++ #296 (all)(Change) Added net6 target framework to all LightBDD packages
 
 Version 3.6.1
 ----------------------------------------

--- a/src/LightBDD.Autofac/LightBDD.Autofac.csproj
+++ b/src/LightBDD.Autofac/LightBDD.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
     <Description>Provides LightBDD integration with Autofac, allowing to use Autofac as DI container for LightBDD scenarios.
     </Description>
   </PropertyGroup>

--- a/src/LightBDD.Core/LightBDD.Core.csproj
+++ b/src/LightBDD.Core/LightBDD.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>LightBDD Test Framework Core</Summary>
     <Description>Provides LightBDD core features, including asynchronous scenario execution with execution tracking and time measurement, metadata discovery and formatting, reporting, in-code configuration, progress notification and framework extensibility.</Description>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/LightBDD.Extensions.DependencyInjection/LightBDD.Extensions.DependencyInjection.csproj
+++ b/src/LightBDD.Extensions.DependencyInjection/LightBDD.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
     <Description>Provides LightBDD integration with Microsoft.Extensions.DependencyInjection, allowing to use Microsoft DI compatible container for LightBDD scenarios.
     </Description>
   </PropertyGroup>

--- a/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
+++ b/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);fixie</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
+++ b/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);nunit;nunit3</PackageTags>
   </PropertyGroup>
 

--- a/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
+++ b/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);xunit;xunit2</PackageTags>
   </PropertyGroup>
 

--- a/test/LightBDD.MsTest3.UnitTests/LightBDD.MsTest3.UnitTests.csproj
+++ b/test/LightBDD.MsTest3.UnitTests/LightBDD.MsTest3.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.Tests.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6;net48;net5</TargetFrameworks>
+    <TargetFrameworks>net6;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #296 

List of changes:


#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
