### PR TITLE
#294 Updated library dependencies and run code cleanup before release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -12,6 +12,10 @@ Version vNext
 + #288 (LightBDD.Core)(Change) Format of non-inline step parameters with <$name> parameter reference
 + #293 (LightBDD.MsTest3)(New) Created LightBDD.MsTest3 project with dependency on MSTest.TestFramework 3.x
 + #293 (LightBDD.MsTest2)(Change) Deprecated LightBDD.MsTest2 project in favor of LightBDD.MsTest3
++ #294 (all)(Change) Updated net461 target framework to net462 (while leaving net461 coverage via .netstandard2.0 target framework)
++ #294 (LightBDD.XUnit2)(Change) Updated xunit package dependency version from 2.4.1 to 2.4.2
++ #294 (LightBDD.Framework)(Change) Updated dependency versions of System.Text.Json to 6.0.8 and System.Collections.Immutable to 6.0.0
++ #294 (VSIX)(Change) Updated package versions to latest
 + #296 (all)(Change) Added net6 target framework to all LightBDD packages
 
 Version 3.6.1

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ![logo](https://github.com/LightBDD/LightBDD/blob/master/logo/lightbdd.ico) LightBDD <br><br>The Lightweight Behavior Driven Development test framework
 ===========
 
-Category|Badge |Platforms
---------|------|--------
-Build | [![Build status](https://ci.appveyor.com/api/projects/status/xkd7qc950o07o3x8/branch/master?svg=true)](https://ci.appveyor.com/project/Suremaker/lightbdd/branch/master) |
-Chat (gitter) | [![Join the chat at https://gitter.im/LightBDD/LightBDD](https://badges.gitter.im/LightBDD/LightBDD.svg)](https://gitter.im/LightBDD/LightBDD?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) | 
-LightBDD.NUnit3 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.NUnit3?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.NUnit3/) | .NET Standard >= 2.0 <br> .NET Framework >= 4.6.1 <br> .NET Core >= 2.0
-LightBDD.XUnit2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.XUnit2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.XUnit2/) | .NET Standard >= 2.0 <br> .NET Framework >= 4.6.1 <br> .NET Core >= 2.0
-LightBDD.MsTest2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.MsTest2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.MsTest2/) | .NET Standard >= 2.0 <br> .NET Framework >= 4.6.1 <br> .NET Core >= 2.0 <br> UWP >= 10.0.16299
-LightBDD.Fixie2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Fixie2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Fixie2/) | .NET Framework >= 4.6.1 <br> .NET Core >= 3.1
-LightBDD.Autofac | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Autofac?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Autofac/) | .NET Standard >= 2.0 <br> .NET Framework >= 4.6.1
-LightBDD.Extensions.DependencyInjection | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Extensions.DependencyInjection?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Extensions.DependencyInjection/) | .NET Standard >= 2.0
+Category|Badge
+--------|------
+Build | [![Build status](https://ci.appveyor.com/api/projects/status/xkd7qc950o07o3x8/branch/master?svg=true)](https://ci.appveyor.com/project/Suremaker/lightbdd/branch/master)
+Chat (gitter) | [![Join the chat at https://gitter.im/LightBDD/LightBDD](https://badges.gitter.im/LightBDD/LightBDD.svg)](https://gitter.im/LightBDD/LightBDD?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+LightBDD.NUnit3 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.NUnit3?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.NUnit3/)
+LightBDD.XUnit2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.XUnit2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.XUnit2/)
+LightBDD.MsTest2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.MsTest2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.MsTest2/)
+LightBDD.Fixie2 | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Fixie2?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Fixie2/)
+LightBDD.Autofac | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Autofac?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Autofac/)
+LightBDD.Extensions.DependencyInjection | [![NuGet Badge](https://buildstats.info/nuget/LightBDD.Extensions.DependencyInjection?includePreReleases=true)](https://www.nuget.org/packages/LightBDD.Extensions.DependencyInjection/)
 
 ## Project description
 **LightBDD** is a behaviour-driven development test framework offering ability to write tests that are easy to read, easy to track during execution and summarize in user friendly report, while allowing developers to use all of the standard development tools to maintain them.
@@ -28,7 +28,7 @@ LightBDD.Extensions.DependencyInjection | [![NuGet Badge](https://buildstats.inf
 * Productivity extensions for VisualStudio with Feature Class Templates, Project Templates and Code Snippets,
 * Integration with [NUnit](http://www.nunit.org/), [xUnit](http://xunit.github.io/), [MsTest.TestFramework](https://www.nuget.org/packages/MSTest.TestFramework/) and [Fixie](http://fixie.github.io/) frameworks,
 * Async scenario and steps execution support,
-* Cross-platform support (.NET Framework / .NET Standard / .NET Core / [UWP](https://github.com/LightBDD/LightBDD/tree/3.4.2/examples/Example.LightBDD.MsTest2.UWP)).
+* Cross-platform support (.NET 5+ / .NET Framework / .NET Standard / .NET Core / [UWP](https://github.com/LightBDD/LightBDD/tree/3.4.2/examples/Example.LightBDD.MsTest2.UWP)).
 
 ### Tests structure and conventions
 **LightBDD** runs on top of [NUnit](http://www.nunit.org/), [xUnit](http://xunit.github.io/), [MsTest.TestFramework](https://www.nuget.org/packages/MSTest.TestFramework/) and [Fixie](http://fixie.github.io/), allowing to leverage the well known test frameworks and their features in writing the behavioral style scenarios, which makes it very easy to learn, adapt and use.

--- a/examples/Example.LightBDD.Fixie2/Example.LightBDD.Fixie2.csproj
+++ b/examples/Example.LightBDD.Fixie2/Example.LightBDD.Fixie2.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="Fixie" Version="2.2.2" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.2.1" />
   </ItemGroup>

--- a/examples/Example.LightBDD.NUnit3/Example.LightBDD.NUnit3.csproj
+++ b/examples/Example.LightBDD.NUnit3/Example.LightBDD.NUnit3.csproj
@@ -10,10 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/examples/Example.LightBDD.NUnit3/run-nunit3-console.cmd
+++ b/examples/Example.LightBDD.NUnit3/run-nunit3-console.cmd
@@ -1,7 +1,7 @@
 dotnet build
-..\..\.nuget\nuget.exe install NUnit.ConsoleRunner -Version 3.12.0 -NonInteractive -ExcludeVersion -Output packages
+..\..\.nuget\nuget.exe install NUnit.ConsoleRunner -Version 3.16.3 -NonInteractive -ExcludeVersion -Output packages
 
 @echo.
 @echo Running tests
 
-packages\NUnit.ConsoleRunner\tools\nunit3-console.exe bin\Debug\net461\Example.LightBDD.NUnit3.dll
+packages\NUnit.ConsoleRunner\tools\nunit3-console.exe bin\Debug\net48\Example.LightBDD.NUnit3.dll

--- a/examples/Example.LightBDD.XUnit2/Example.LightBDD.XUnit2.csproj
+++ b/examples/Example.LightBDD.XUnit2/Example.LightBDD.XUnit2.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/examples/Example.LightBDD.XUnit2/run-xunit.console.cmd
+++ b/examples/Example.LightBDD.XUnit2/run-xunit.console.cmd
@@ -1,7 +1,7 @@
 dotnet build
-..\..\.nuget\nuget.exe install xunit.runner.console -Version 2.4.1 -NonInteractive -ExcludeVersion -Output packages
+..\..\.nuget\nuget.exe install xunit.runner.console -Version 2.4.2 -NonInteractive -ExcludeVersion -Output packages
 
 @echo.
 @echo Running tests
 
-packages\xunit.runner.console\tools\net461\xunit.console.exe bin\Debug\net461\Example.LightBDD.XUnit2.dll
+packages\xunit.runner.console\tools\net472\xunit.console.exe bin\Debug\net48\Example.LightBDD.XUnit2.dll

--- a/src/LightBDD.Autofac/LightBDD.Autofac.csproj
+++ b/src/LightBDD.Autofac/LightBDD.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6</TargetFrameworks>
     <Description>Provides LightBDD integration with Autofac, allowing to use Autofac as DI container for LightBDD scenarios.
     </Description>
   </PropertyGroup>

--- a/src/LightBDD.Core/Configuration/ExecutionExtensionsConfiguration.cs
+++ b/src/LightBDD.Core/Configuration/ExecutionExtensionsConfiguration.cs
@@ -15,8 +15,8 @@ namespace LightBDD.Core.Configuration
     {
         internal GlobalSetUpRegistry GlobalSetUpRegistry { get; } = new();
 
-        private readonly List<IScenarioDecorator> _scenarioExtensions = new List<IScenarioDecorator>();
-        private readonly List<IStepDecorator> _stepExtensions = new List<IStepDecorator>();
+        private readonly List<IScenarioDecorator> _scenarioExtensions = new();
+        private readonly List<IStepDecorator> _stepExtensions = new();
 
         /// <summary>
         /// Collection of scenario execution extensions.

--- a/src/LightBDD.Core/Configuration/LightBddConfiguration.cs
+++ b/src/LightBDD.Core/Configuration/LightBddConfiguration.cs
@@ -8,7 +8,7 @@ namespace LightBDD.Core.Configuration
     /// </summary>
     public class LightBddConfiguration
     {
-        private readonly ConcurrentDictionary<Type, IFeatureConfiguration> _configuration = new ConcurrentDictionary<Type, IFeatureConfiguration>();
+        private readonly ConcurrentDictionary<Type, IFeatureConfiguration> _configuration = new();
 
         /// <summary>
         /// Returns current feature configuration of requested type.

--- a/src/LightBDD.Core/Configuration/ValueFormattingConfiguration.cs
+++ b/src/LightBDD.Core/Configuration/ValueFormattingConfiguration.cs
@@ -12,9 +12,9 @@ namespace LightBDD.Core.Configuration
     /// </summary>
     public class ValueFormattingConfiguration : FeatureConfiguration
     {
-        private readonly ConcurrentDictionary<Type, IValueFormatter> _explicitFormatters = new ConcurrentDictionary<Type, IValueFormatter>();
+        private readonly ConcurrentDictionary<Type, IValueFormatter> _explicitFormatters = new();
 
-        private readonly List<IConditionalValueFormatter> _generalFormatters = new List<IConditionalValueFormatter>();
+        private readonly List<IConditionalValueFormatter> _generalFormatters = new();
 
         /// <summary>
         /// Default constructor.

--- a/src/LightBDD.Core/Dependencies/Implementation/DefaultDependencyContainer.cs
+++ b/src/LightBDD.Core/Dependencies/Implementation/DefaultDependencyContainer.cs
@@ -115,7 +115,7 @@ namespace LightBDD.Core.Dependencies.Implementation
             {
                 sb.Append("Container scope: ").Append(container._scope);
                 foreach (var slot in container._slots.OrderBy(x => x.Key.FullName))
-                    sb.AppendLine().Append(slot.Key).Append(" -> ").Append(slot.Value.ToString());
+                    sb.AppendLine().Append(slot.Key).Append(" -> ").Append(slot.Value);
                 container = container._parent;
 
                 if (container == null)

--- a/src/LightBDD.Core/Dependencies/Implementation/DefaultDependencyContainer.cs
+++ b/src/LightBDD.Core/Dependencies/Implementation/DefaultDependencyContainer.cs
@@ -13,7 +13,7 @@ namespace LightBDD.Core.Dependencies.Implementation
         class Slot
         {
             public int Id { get; }
-            public readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
+            public readonly SemaphoreSlim Lock = new(1);
             public readonly DependencyDescriptor Descriptor;
             public object Instance;
 
@@ -31,8 +31,8 @@ namespace LightBDD.Core.Dependencies.Implementation
         private readonly DependencyFactory _dependencyFactory;
         private readonly DefaultDependencyContainer _parent;
         private readonly LifetimeScope _scope;
-        private readonly ConcurrentQueue<IDisposable> _disposable = new ConcurrentQueue<IDisposable>();
-        private readonly ConcurrentDictionary<Type, Slot> _slots = new ConcurrentDictionary<Type, Slot>();
+        private readonly ConcurrentQueue<IDisposable> _disposable = new();
+        private readonly ConcurrentDictionary<Type, Slot> _slots = new();
 
         public DefaultDependencyContainer(LifetimeScope scope, Action<DependencyFactory> configuration = null) : this(null, scope, configuration) { }
         private DefaultDependencyContainer(DefaultDependencyContainer parent, LifetimeScope scope, Action<DependencyFactory> configuration = null)

--- a/src/LightBDD.Core/Dependencies/Implementation/DependencyDescriptor.cs
+++ b/src/LightBDD.Core/Dependencies/Implementation/DependencyDescriptor.cs
@@ -7,7 +7,7 @@ namespace LightBDD.Core.Dependencies.Implementation
 {
     class DependencyDescriptor
     {
-        private static ConcurrentDictionary<Type, Func<IDependencyResolver, object>> _ctorCache = new ConcurrentDictionary<Type, Func<IDependencyResolver, object>>();
+        private static ConcurrentDictionary<Type, Func<IDependencyResolver, object>> _ctorCache = new();
         public Type Type { get; }
         public Func<IDependencyResolver, object> ResolveFn { get; }
         public RegistrationOptions Registration { get; }

--- a/src/LightBDD.Core/Dependencies/Implementation/DependencyFactory.cs
+++ b/src/LightBDD.Core/Dependencies/Implementation/DependencyFactory.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Core.Dependencies.Implementation
 {
     class DependencyFactory : ContainerConfigurator, IDefaultContainerConfigurator
     {
-        private readonly List<DependencyDescriptor> _descriptors = new List<DependencyDescriptor>();
+        private readonly List<DependencyDescriptor> _descriptors = new();
         public IReadOnlyList<DependencyDescriptor> Descriptors => _descriptors;
         public FallbackResolveBehavior FallbackBehavior { get; private set; }
 

--- a/src/LightBDD.Core/Dependencies/InstanceScope.cs
+++ b/src/LightBDD.Core/Dependencies/InstanceScope.cs
@@ -8,20 +8,20 @@
         /// <summary>
         /// The same instance is returned for requests within the root and nested scopes.
         /// </summary>
-        public static readonly InstanceScope Single = new InstanceScope(nameof(Single), true, true);
+        public static readonly InstanceScope Single = new(nameof(Single), true, true);
         /// <summary>
         /// The same instance is returned for requests within the given scope, however not shared with nested scopes. Each scope will receive one instance upon request.
         /// </summary>
-        public static readonly InstanceScope Local = new InstanceScope(nameof(Local), true, false);
+        public static readonly InstanceScope Local = new(nameof(Local), true, false);
         /// <summary>
         /// The new instance is returned upon every request.
         /// </summary>
-        public static readonly InstanceScope Transient = new InstanceScope(nameof(Transient), false, false);
+        public static readonly InstanceScope Transient = new(nameof(Transient), false, false);
         /// <summary>
         /// The instance is shared within given scenario scope and across all nested scopes, but instantiated independently between scenarios.<br/>
         /// The instance definition will be ignored when resolution request is made outside of the scenario.
         /// </summary>
-        public static readonly InstanceScope Scenario = new InstanceScope(nameof(Scenario), true, true, LifetimeScope.Scenario);
+        public static readonly InstanceScope Scenario = new(nameof(Scenario), true, true, LifetimeScope.Scenario);
 
         /// <summary>
         /// Instance scope name

--- a/src/LightBDD.Core/Dependencies/LifetimeScope.cs
+++ b/src/LightBDD.Core/Dependencies/LifetimeScope.cs
@@ -11,17 +11,17 @@ namespace LightBDD.Core.Dependencies
         /// Global scope created once and affecting all tests.
         /// The global scope should be used by container root.
         /// </summary>
-        public static readonly LifetimeScope Global = new LifetimeScope("#global");
+        public static readonly LifetimeScope Global = new("#global");
 
         /// <summary>
         /// Scenario scope created once per each scenario.
         /// </summary>
-        public static readonly LifetimeScope Scenario = new LifetimeScope("#scenario");
+        public static readonly LifetimeScope Scenario = new("#scenario");
 
         /// <summary>
         /// Local scope created for all nested scopes such as composite steps.
         /// </summary>
-        public static readonly LifetimeScope Local = new LifetimeScope("#local");
+        public static readonly LifetimeScope Local = new("#local");
 
         /// <summary>
         /// Scope name.

--- a/src/LightBDD.Core/Dependencies/RegistrationOptions.cs
+++ b/src/LightBDD.Core/Dependencies/RegistrationOptions.cs
@@ -9,7 +9,7 @@ namespace LightBDD.Core.Dependencies
     /// </summary>
     public class RegistrationOptions
     {
-        private readonly HashSet<Type> _asTypes = new HashSet<Type>();
+        private readonly HashSet<Type> _asTypes = new();
         /// <summary>
         /// Returns true if configured dependency is externally owned or false if container controls it's lifetime.
         /// </summary>

--- a/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
+++ b/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using LightBDD.Core.Configuration;
 using LightBDD.Core.Extensibility;
 using LightBDD.Core.Formatting.Values;
@@ -15,7 +13,7 @@ namespace LightBDD.Core.Execution.Coordination
     /// </summary>
     public abstract class FeatureCoordinator : IDisposable
     {
-        private static readonly object Sync = new object();
+        private static readonly object Sync = new();
         /// <summary>
         /// Feature coordinator instance.
         /// </summary>

--- a/src/LightBDD.Core/Execution/Implementation/AsyncStepSynchronizationContext.cs
+++ b/src/LightBDD.Core/Execution/Implementation/AsyncStepSynchronizationContext.cs
@@ -11,8 +11,8 @@ namespace LightBDD.Core.Execution.Implementation
     {
         private readonly SynchronizationContext _inner;
         private int _counter = 1;
-        private readonly TaskCompletionSource<bool> _resetEvent = new TaskCompletionSource<bool>();
-        private readonly ConcurrentQueue<Exception> _exceptions = new ConcurrentQueue<Exception>();
+        private readonly TaskCompletionSource<bool> _resetEvent = new();
+        private readonly ConcurrentQueue<Exception> _exceptions = new();
 
         private AsyncStepSynchronizationContext(SynchronizationContext inner)
         {

--- a/src/LightBDD.Core/Execution/Implementation/DefaultExecutionTimer.cs
+++ b/src/LightBDD.Core/Execution/Implementation/DefaultExecutionTimer.cs
@@ -16,6 +16,6 @@ namespace LightBDD.Core.Execution.Implementation
 
         public static IExecutionTimer StartNew() => new DefaultExecutionTimer();
 
-        public EventTime GetTime() => new EventTime(_start, _watch.Elapsed);
+        public EventTime GetTime() => new(_start, _watch.Elapsed);
     }
 }

--- a/src/LightBDD.Core/Execution/Implementation/ExceptionCollector.cs
+++ b/src/LightBDD.Core/Execution/Implementation/ExceptionCollector.cs
@@ -7,7 +7,7 @@ namespace LightBDD.Core.Execution.Implementation
 {
     internal class ExceptionCollector
     {
-        private readonly List<Exception> _executionExceptions = new List<Exception>();
+        private readonly List<Exception> _executionExceptions = new();
 
         public void Capture(Exception exception)
         {

--- a/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using LightBDD.Core.Dependencies.Implementation;
 using LightBDD.Core.Notification.Events;
 
 namespace LightBDD.Core.Execution.Implementation
@@ -24,7 +23,7 @@ namespace LightBDD.Core.Execution.Implementation
         private readonly IEnumerable<StepDescriptor> _stepDescriptors;
         private readonly ExecutionContextDescriptor _contextDescriptor;
         private readonly ScenarioResult _result;
-        private readonly ExceptionCollector _exceptionCollector = new ExceptionCollector();
+        private readonly ExceptionCollector _exceptionCollector = new();
         private readonly Func<Task> _decoratedScenarioMethod;
         private IDependencyContainer _scope;
         private Func<Exception, bool> _shouldAbortSubStepExecutionFn = ex => true;

--- a/src/LightBDD.Core/ExecutionContext/AsyncLocalContext.cs
+++ b/src/LightBDD.Core/ExecutionContext/AsyncLocalContext.cs
@@ -10,7 +10,7 @@ namespace LightBDD.Core.ExecutionContext
     [Obsolete("Use System.Threading.AsyncLocal<T> instead.")]
     public class AsyncLocalContext<T>
     {
-        private readonly AsyncLocal<T> _context = new AsyncLocal<T>();
+        private readonly AsyncLocal<T> _context = new();
         /// <summary>
         /// Allows to get and set value to store.
         /// </summary>

--- a/src/LightBDD.Core/ExecutionContext/Implementation/CurrentScenarioProperty.cs
+++ b/src/LightBDD.Core/ExecutionContext/Implementation/CurrentScenarioProperty.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using LightBDD.Core.Execution;
+﻿using LightBDD.Core.Execution;
 
 namespace LightBDD.Core.ExecutionContext.Implementation
 {

--- a/src/LightBDD.Core/ExecutionContext/Implementation/CurrentStepProperty.cs
+++ b/src/LightBDD.Core/ExecutionContext/Implementation/CurrentStepProperty.cs
@@ -6,7 +6,7 @@ namespace LightBDD.Core.ExecutionContext.Implementation
 {
     internal class CurrentStepProperty : IContextProperty
     {
-        private readonly Stack<IStep> _steps = new Stack<IStep>();
+        private readonly Stack<IStep> _steps = new();
 
         public IStep Step => _steps.Peek() ?? throw new InvalidOperationException("Current task is not executing any scenario steps. Ensure that feature is used within task running scenario step.");
 

--- a/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
+++ b/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
@@ -11,8 +11,8 @@ namespace LightBDD.Core.ExecutionContext
     /// </summary>
     public sealed class ScenarioExecutionContext
     {
-        private static readonly AsyncLocal<ScenarioExecutionContext> CurrentContext = new AsyncLocal<ScenarioExecutionContext>();
-        private readonly ConcurrentDictionary<Type, IContextProperty> _properties = new ConcurrentDictionary<Type, IContextProperty>();
+        private static readonly AsyncLocal<ScenarioExecutionContext> CurrentContext = new();
+        private readonly ConcurrentDictionary<Type, IContextProperty> _properties = new();
 
         /// <summary>
         /// Provides property value of <typeparamref name="TProperty"/> type that is stored in scenario context.

--- a/src/LightBDD.Core/Extensibility/ExecutionContextDescriptor.cs
+++ b/src/LightBDD.Core/Extensibility/ExecutionContextDescriptor.cs
@@ -11,7 +11,7 @@ namespace LightBDD.Core.Extensibility
         /// <summary>
         /// No context descriptor.
         /// </summary>
-        public static readonly ExecutionContextDescriptor NoContext = new ExecutionContextDescriptor(ProvideNoContext, null);
+        public static readonly ExecutionContextDescriptor NoContext = new(ProvideNoContext, null);
 
         /// <summary>
         /// Returns container configurator function used to configure container used in the execution context scope.

--- a/src/LightBDD.Core/Extensibility/FeatureRunnerRepository.cs
+++ b/src/LightBDD.Core/Extensibility/FeatureRunnerRepository.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Core.Configuration;
-using LightBDD.Core.Dependencies;
-using LightBDD.Core.Execution.Implementation;
 using LightBDD.Core.Extensibility.Implementation;
 
 namespace LightBDD.Core.Extensibility
@@ -18,7 +16,7 @@ namespace LightBDD.Core.Extensibility
     public class FeatureRunnerRepository : IDisposable
     {
         private readonly IntegrationContext _integrationContext;
-        private readonly ConcurrentDictionary<Type, Lazy<IFeatureRunner>> _runners = new ConcurrentDictionary<Type, Lazy<IFeatureRunner>>();
+        private readonly ConcurrentDictionary<Type, Lazy<IFeatureRunner>> _runners = new();
 
         /// <summary>
         /// Constructor instantiating factory with specified runner context.

--- a/src/LightBDD.Core/Extensibility/Implementation/FeatureRunner.cs
+++ b/src/LightBDD.Core/Extensibility/Implementation/FeatureRunner.cs
@@ -2,7 +2,6 @@ using LightBDD.Core.Execution.Implementation;
 using LightBDD.Core.Results;
 using LightBDD.Core.Results.Implementation;
 using System;
-using LightBDD.Core.Execution;
 using LightBDD.Core.Notification.Events;
 
 namespace LightBDD.Core.Extensibility.Implementation

--- a/src/LightBDD.Core/Extensibility/StepDescriptor.cs
+++ b/src/LightBDD.Core/Extensibility/StepDescriptor.cs
@@ -41,7 +41,7 @@ namespace LightBDD.Core.Extensibility
         /// Creates invalid descriptor indicating that original descriptor creation failed due to <paramref name="creationException"/> exception.
         /// Using this method will allow LightBDD to properly capture the invalid steps in the reports, helping with locating and correcting them properly.
         /// </summary>
-        public static StepDescriptor CreateInvalid(Exception creationException) => new StepDescriptor(creationException);
+        public static StepDescriptor CreateInvalid(Exception creationException) => new(creationException);
 
         private StepDescriptor(MethodBase methodInfo, string rawName, StepFunc stepInvocation, params ParameterDescriptor[] parameters)
         {

--- a/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
+++ b/src/LightBDD.Core/Formatting/ExceptionFormatting/DefaultExceptionFormatter.cs
@@ -11,7 +11,7 @@ namespace LightBDD.Core.Formatting.ExceptionFormatting
     /// </summary>
     public class DefaultExceptionFormatter
     {
-        private readonly List<Regex> _excludeMembers = new List<Regex>();
+        private readonly List<Regex> _excludeMembers = new();
         private int _stackTraceLinesLimit = 8;
 
         /// <summary>

--- a/src/LightBDD.Core/Formatting/TimeFormatter.cs
+++ b/src/LightBDD.Core/Formatting/TimeFormatter.cs
@@ -10,11 +10,11 @@ namespace LightBDD.Core.Formatting
     public static class TimeFormatter
     {
         private static readonly Tuple<string, int, Func<TimeSpan, int>>[] Formatters = {
-            new Tuple<string, int, Func<TimeSpan, int>>("d", 1, GetDays),
-            new Tuple<string, int, Func<TimeSpan, int>>("h", 2, GetHours),
-            new Tuple<string, int, Func<TimeSpan, int>>("m", 2, GetMinutes),
-            new Tuple<string, int, Func<TimeSpan, int>>("s", 2, GetSeconds),
-            new Tuple<string, int, Func<TimeSpan, int>>("ms", 3, GetMilliseconds)
+            new("d", 1, GetDays),
+            new("h", 2, GetHours),
+            new("m", 2, GetMinutes),
+            new("s", 2, GetSeconds),
+            new("ms", 3, GetMilliseconds)
         };
 
         /// <summary>

--- a/src/LightBDD.Core/Formatting/Values/DefaultValueFormatter.cs
+++ b/src/LightBDD.Core/Formatting/Values/DefaultValueFormatter.cs
@@ -14,7 +14,7 @@ namespace LightBDD.Core.Formatting.Values
         /// <summary>
         /// Default instance.
         /// </summary>
-        public static DefaultValueFormatter Instance { get; } = new DefaultValueFormatter();
+        public static DefaultValueFormatter Instance { get; } = new();
 
         /// <summary>
         /// Formats value provided with <paramref name="value"/> parameter using <see cref="string.Format(System.IFormatProvider,string,object[])"/> and current <see cref="CultureInfo"/> provided by <paramref name="formattingService"/>.

--- a/src/LightBDD.Core/Formatting/Values/Implementation/SelfFormattable.cs
+++ b/src/LightBDD.Core/Formatting/Values/Implementation/SelfFormattable.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Core.Formatting.Values.Implementation
 {
     internal class SelfFormattable : IConditionalValueFormatter
     {
-        public static SelfFormattable Instance { get; } = new SelfFormattable();
+        public static SelfFormattable Instance { get; } = new();
         public string FormatValue(object value, IValueFormattingService formattingService)
         {
             return ((ISelfFormattable)value).Format(formattingService);

--- a/src/LightBDD.Core/LightBDD.Core.csproj
+++ b/src/LightBDD.Core/LightBDD.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>LightBDD Test Framework Core</Summary>
     <Description>Provides LightBDD core features, including asynchronous scenario execution with execution tracking and time measurement, metadata discovery and formatting, reporting, in-code configuration, progress notification and framework extensibility.</Description>
-    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/LightBDD.Core/Notification/Implementation/NotificationAdapter.cs
+++ b/src/LightBDD.Core/Notification/Implementation/NotificationAdapter.cs
@@ -11,7 +11,7 @@ namespace LightBDD.Core.Notification.Implementation
     {
         private readonly IFeatureProgressNotifier _featureProgressNotifier;
         private readonly Func<object, IScenarioProgressNotifier> _scenarioProgressNotifierProvider;
-        private readonly AsyncLocal<IScenarioProgressNotifier> _scenarioNotifier = new AsyncLocal<IScenarioProgressNotifier>();
+        private readonly AsyncLocal<IScenarioProgressNotifier> _scenarioNotifier = new();
 
         public NotificationAdapter(IFeatureProgressNotifier featureProgressNotifier, Func<object, IScenarioProgressNotifier> scenarioProgressNotifierProvider)
         {

--- a/src/LightBDD.Core/Reporting/FeatureReportGenerator.cs
+++ b/src/LightBDD.Core/Reporting/FeatureReportGenerator.cs
@@ -13,7 +13,7 @@ namespace LightBDD.Core.Reporting
     public class FeatureReportGenerator : IFeatureAggregator
     {
         private readonly IReportWriter[] _writers;
-        private readonly ConcurrentQueue<IFeatureResult> _results = new ConcurrentQueue<IFeatureResult>();
+        private readonly ConcurrentQueue<IFeatureResult> _results = new();
         private bool _disposed;
         /// <summary>
         /// Constructor configuring report generator with <paramref name="writers"/> that would be used to write reports on generator disposal.

--- a/src/LightBDD.Core/Results/IStepResult.cs
+++ b/src/LightBDD.Core/Results/IStepResult.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using LightBDD.Core.Metadata;
-using LightBDD.Core.Results.Implementation;
 using LightBDD.Core.Results.Parameters;
 
 namespace LightBDD.Core.Results

--- a/src/LightBDD.Core/Results/Implementation/FeatureResult.cs
+++ b/src/LightBDD.Core/Results/Implementation/FeatureResult.cs
@@ -6,7 +6,7 @@ namespace LightBDD.Core.Results.Implementation
 {
     internal class FeatureResult : IFeatureResult
     {
-        private readonly ConcurrentQueue<IScenarioResult> _scenarios = new ConcurrentQueue<IScenarioResult>();
+        private readonly ConcurrentQueue<IScenarioResult> _scenarios = new();
 
         public FeatureResult(IFeatureInfo info)
         {

--- a/src/LightBDD.Core/Results/Parameters/Trees/ITreeParameterDetails.cs
+++ b/src/LightBDD.Core/Results/Parameters/Trees/ITreeParameterDetails.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace LightBDD.Core.Results.Parameters.Trees;
 
 /// <summary>

--- a/src/LightBDD.Extensions.DependencyInjection/Implementation/ContainerOverrides.cs
+++ b/src/LightBDD.Extensions.DependencyInjection/Implementation/ContainerOverrides.cs
@@ -9,8 +9,8 @@ namespace LightBDD.Extensions.DependencyInjection.Implementation
 {
     internal class ContainerOverrides : ContainerConfigurator, IDisposable
     {
-        private readonly ConcurrentStack<IDisposable> _disposables = new ConcurrentStack<IDisposable>();
-        private readonly ConcurrentDictionary<Type, object> _singletons = new ConcurrentDictionary<Type, object>();
+        private readonly ConcurrentStack<IDisposable> _disposables = new();
+        private readonly ConcurrentDictionary<Type, object> _singletons = new();
 
         public override void RegisterInstance(object instance, RegistrationOptions options)
         {

--- a/src/LightBDD.Extensions.DependencyInjection/Implementation/DiContainer.cs
+++ b/src/LightBDD.Extensions.DependencyInjection/Implementation/DiContainer.cs
@@ -10,7 +10,7 @@ namespace LightBDD.Extensions.DependencyInjection.Implementation
     {
         private readonly IContainerScope _scope;
         private readonly ContainerOverrides _overrides;
-        private readonly List<IDisposable> _disposables = new List<IDisposable>();
+        private readonly List<IDisposable> _disposables = new();
 
         public DiContainer(IContainerScope scope, ContainerOverrides overrides)
         {

--- a/src/LightBDD.Fixie2/Implementation/TestContextProvider.cs
+++ b/src/LightBDD.Fixie2/Implementation/TestContextProvider.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Fixie2.Implementation
 {
     internal class TestContextProvider
     {
-        private static readonly AsyncLocal<TestContextProvider> Provider = new AsyncLocal<TestContextProvider>();
+        private static readonly AsyncLocal<TestContextProvider> Provider = new();
         public MethodInfo TestMethod { get; }
         public object[] TestMethodArguments { get; }
 

--- a/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
+++ b/src/LightBDD.Fixie2/LightBDD.Fixie2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>net461;netcoreapp3.1;net6</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);fixie</PackageTags>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/LightBDD.Fixie2/LightBddDiscoveryConvention.cs
+++ b/src/LightBDD.Fixie2/LightBddDiscoveryConvention.cs
@@ -20,7 +20,7 @@ namespace LightBDD.Fixie2
     /// </summary>
     public abstract class LightBddDiscoveryConvention : Discovery
     {
-        private string[] _categoriesToInclude = new string[0];
+        private string[] _categoriesToInclude = Array.Empty<string>();
         /// <summary>
         /// Constructor describing the LightBDD discovery conventions.
         /// </summary>

--- a/src/LightBDD.Framework/Configuration/ScenarioProgressNotifierConfiguration.cs
+++ b/src/LightBDD.Framework/Configuration/ScenarioProgressNotifierConfiguration.cs
@@ -12,7 +12,7 @@ namespace LightBDD.Framework.Configuration
     [Obsolete]
     public class ScenarioProgressNotifierConfiguration : FeatureConfiguration
     {
-        private readonly ScenarioProgressNotifierComposer _composer = new ScenarioProgressNotifierComposer();
+        private readonly ScenarioProgressNotifierComposer _composer = new();
 
         /// <summary>
         /// Returns function providing scenario progress notifier, where function parameter is feature fixture class instance.

--- a/src/LightBDD.Framework/Expectations/ExpectationResult.cs
+++ b/src/LightBDD.Framework/Expectations/ExpectationResult.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Default result representing success.
         /// </summary>
-        public static ExpectationResult Success { get; } = new ExpectationResult(true, string.Empty);
+        public static ExpectationResult Success { get; } = new(true, string.Empty);
 
         /// <summary>
         /// Returns <c>true</c> if verification passed.

--- a/src/LightBDD.Framework/Formatting/DefaultNameFormatter.cs
+++ b/src/LightBDD.Framework/Formatting/DefaultNameFormatter.cs
@@ -14,7 +14,7 @@ namespace LightBDD.Framework.Formatting
         /// <summary>
         /// Returns instance of the <see cref="DefaultNameFormatter"/>.
         /// </summary>
-        public static DefaultNameFormatter Instance { get; } = new DefaultNameFormatter();
+        public static DefaultNameFormatter Instance { get; } = new();
 
         /// <summary>
         /// Formats name into readable text.

--- a/src/LightBDD.Framework/LightBDD.Framework.csproj
+++ b/src/LightBDD.Framework/LightBDD.Framework.csproj
@@ -31,8 +31,8 @@ High level features:
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="System.Text.Json" Version="4.6.0" Condition="'$(TargetFramework)' != 'net6'" />
-	  <PackageReference Include="System.Collections.Immutable" Version="6.0.0" Condition="'$(TargetFramework)' != 'net6'" />
+	  <PackageReference Include="System.Text.Json" Version="7.0.3" Condition="'$(TargetFramework)' != 'net6'" />
+	  <PackageReference Include="System.Collections.Immutable" Version="7.0.0" Condition="'$(TargetFramework)' != 'net6'" />
   </ItemGroup>
 
 </Project>

--- a/src/LightBDD.Framework/LightBDD.Framework.csproj
+++ b/src/LightBDD.Framework/LightBDD.Framework.csproj
@@ -13,7 +13,7 @@ High level features:
 * Xml/Html/Plain text report generation;
 * DI support;
 * inline and tabular parameters.</Description>
-    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,8 +31,8 @@ High level features:
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="System.Text.Json" Version="7.0.3" Condition="'$(TargetFramework)' != 'net6'" />
-	  <PackageReference Include="System.Collections.Immutable" Version="7.0.0" Condition="'$(TargetFramework)' != 'net6'" />
+	  <PackageReference Include="System.Text.Json" Version="6.0.8" Condition="'$(TargetFramework)' != 'net6'" />
+	  <PackageReference Include="System.Collections.Immutable" Version="6.0.0" Condition="'$(TargetFramework)' != 'net6'" />
   </ItemGroup>
 
 </Project>

--- a/src/LightBDD.Framework/Messaging/Implementation/MessageCounter.cs
+++ b/src/LightBDD.Framework/Messaging/Implementation/MessageCounter.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Core.Formatting;
 using LightBDD.Core.Formatting.Diagnostics;
-using LightBDD.Framework.Implementation;
 
 namespace LightBDD.Framework.Messaging.Implementation
 {
@@ -15,8 +14,8 @@ namespace LightBDD.Framework.Messaging.Implementation
         private readonly int _expectedCount;
         private readonly Func<TMessage, bool> _predicate;
         private volatile int _current = 0;
-        private readonly HashSet<TMessage> _messageHash = new HashSet<TMessage>();
-        private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+        private readonly HashSet<TMessage> _messageHash = new();
+        private readonly TaskCompletionSource<bool> _tcs = new();
 
         private bool IsFinished => _tcs.Task.IsCompleted;
 

--- a/src/LightBDD.Framework/Messaging/Implementation/MessageWaiter.cs
+++ b/src/LightBDD.Framework/Messaging/Implementation/MessageWaiter.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Core.Formatting;
 using LightBDD.Core.Formatting.Diagnostics;
-using LightBDD.Framework.Implementation;
 
 namespace LightBDD.Framework.Messaging.Implementation
 {
@@ -13,7 +11,7 @@ namespace LightBDD.Framework.Messaging.Implementation
     {
         private readonly MessageListener _listener;
         private readonly Func<TMessage, bool> _predicate;
-        private readonly TaskCompletionSource<TMessage> _tcs = new TaskCompletionSource<TMessage>();
+        private readonly TaskCompletionSource<TMessage> _tcs = new();
 
         public MessageWaiter(MessageListener listener, Func<TMessage, bool> predicate)
         {

--- a/src/LightBDD.Framework/Messaging/MessageListener.cs
+++ b/src/LightBDD.Framework/Messaging/MessageListener.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Framework.Messaging.Implementation;
@@ -15,9 +14,9 @@ namespace LightBDD.Framework.Messaging
     public class MessageListener : IDisposable
     {
         private readonly IMessageSource _source;
-        private readonly ConcurrentStack<object> _messages = new ConcurrentStack<object>();
+        private readonly ConcurrentStack<object> _messages = new();
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
-        private readonly CancellationTokenSource _listenerDisposedTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _listenerDisposedTokenSource = new();
         internal event Action<object> OnMessage;
 
         private MessageListener(IMessageSource source)
@@ -38,7 +37,7 @@ namespace LightBDD.Framework.Messaging
         /// Please note, the listener should be disposed after usage, in order to stop listening.
         /// </summary>
         /// <param name="source">Message source.</param>
-        public static MessageListener Start(IMessageSource source) => new MessageListener(source);
+        public static MessageListener Start(IMessageSource source) => new(source);
 
         /// <summary>
         /// Returns all received messages of specified type, in order from latest to oldest.

--- a/src/LightBDD.Framework/Messaging/MessagePredicateEvaluationException.cs
+++ b/src/LightBDD.Framework/Messaging/MessagePredicateEvaluationException.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using LightBDD.Core.Formatting;
 using LightBDD.Core.Formatting.Diagnostics;
-using LightBDD.Framework.Implementation;
 
 namespace LightBDD.Framework.Messaging
 {

--- a/src/LightBDD.Framework/Notification/Implementation/NotificationAdapter.cs
+++ b/src/LightBDD.Framework/Notification/Implementation/NotificationAdapter.cs
@@ -12,7 +12,7 @@ namespace LightBDD.Framework.Notification.Implementation
     {
         private readonly IFeatureProgressNotifier _featureProgressNotifier;
         private readonly Func<object, IScenarioProgressNotifier> _scenarioProgressNotifierProvider;
-        private readonly AsyncLocal<IScenarioProgressNotifier> _scenarioNotifier = new AsyncLocal<IScenarioProgressNotifier>();
+        private readonly AsyncLocal<IScenarioProgressNotifier> _scenarioNotifier = new();
 
         public NotificationAdapter(IFeatureProgressNotifier featureProgressNotifier, Func<object, IScenarioProgressNotifier> scenarioProgressNotifierProvider)
         {

--- a/src/LightBDD.Framework/Notification/Implementation/ParallelProgressNotifier.cs
+++ b/src/LightBDD.Framework/Notification/Implementation/ParallelProgressNotifier.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Threading;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Notification;
 using LightBDD.Core.Notification.Events;

--- a/src/LightBDD.Framework/Notification/Implementation/ProgressManager.cs
+++ b/src/LightBDD.Framework/Notification/Implementation/ProgressManager.cs
@@ -5,8 +5,8 @@ namespace LightBDD.Framework.Notification.Implementation
 {
     internal class ProgressManager
     {
-        private readonly object _sync = new object();
-        private readonly AsyncLocal<int?> _currentScenarioId = new AsyncLocal<int?>();
+        private readonly object _sync = new();
+        private readonly AsyncLocal<int?> _currentScenarioId = new();
         private int _totalScenarios;
         private int _finishedScenarios;
         private int _pendingScenarios;

--- a/src/LightBDD.Framework/Notification/NoProgressNotifier.cs
+++ b/src/LightBDD.Framework/Notification/NoProgressNotifier.cs
@@ -15,7 +15,7 @@ namespace LightBDD.Framework.Notification
         /// <summary>
         /// Returns default instance.
         /// </summary>
-        public static NoProgressNotifier Default { get; } = new NoProgressNotifier();
+        public static NoProgressNotifier Default { get; } = new();
         /// <summary>
         /// Does nothing.
         /// </summary>

--- a/src/LightBDD.Framework/Notification/ParallelProgressNotifierProvider.cs
+++ b/src/LightBDD.Framework/Notification/ParallelProgressNotifierProvider.cs
@@ -11,11 +11,11 @@ namespace LightBDD.Framework.Notification
     /// </summary>
     public class ParallelProgressNotifierProvider
     {
-        private readonly ProgressManager _manager = new ProgressManager();
+        private readonly ProgressManager _manager = new();
         /// <summary>
         /// Returns default instance of provider.
         /// </summary>
-        public static ParallelProgressNotifierProvider Default { get; } = new ParallelProgressNotifierProvider();
+        public static ParallelProgressNotifierProvider Default { get; } = new();
 
         /// <summary>
         /// Default constructor.

--- a/src/LightBDD.Framework/Parameters/ColumnValue.cs
+++ b/src/LightBDD.Framework/Parameters/ColumnValue.cs
@@ -28,7 +28,7 @@ namespace LightBDD.Framework.Parameters
         /// <summary>
         /// Represents no value, which means that for given row, this column value does not exists.
         /// </summary>
-        public static readonly ColumnValue None = new ColumnValue();
+        public static readonly ColumnValue None = new();
 
         /// <summary>
         /// Creates column value object with <see cref="HasValue"/> equal true and <see cref="Value"/> equal <paramref name="value"/>.

--- a/src/LightBDD.Framework/Parameters/Implementation/AbstractTableBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/AbstractTableBuilder.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Framework.Parameters.Implementation
 {
     internal abstract class AbstractTableBuilder<TRow, TColumn> where TColumn : InputTableColumn
     {
-        private readonly List<TColumn> _customColumns = new List<TColumn>();
+        private readonly List<TColumn> _customColumns = new();
         protected bool InferColumns { get; set; }
         protected InferredColumnsOrder InferredColumnsOrder { get; set; } = InferredColumnsOrder.Name;
 

--- a/src/LightBDD.Framework/Parameters/Implementation/TableValidatorBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/Implementation/TableValidatorBuilder.cs
@@ -9,7 +9,7 @@ namespace LightBDD.Framework.Parameters.Implementation
     {
         public TableValidator<TRow> Build()
         {
-            return new TableValidator<TRow>(BuildColumns(new TRow[0]));
+            return new TableValidator<TRow>(BuildColumns(Array.Empty<TRow>()));
         }
 
         protected override VerifiableTableColumn CreateColumn(ColumnInfo columnInfo)

--- a/src/LightBDD.Framework/Parameters/ObjectTrees/ObjectTreeBuilder.cs
+++ b/src/LightBDD.Framework/Parameters/ObjectTrees/ObjectTreeBuilder.cs
@@ -102,7 +102,7 @@ public class ObjectTreeBuilder
     private ObjectTreeArray CreateArray(ArrayMap map, string node, ObjectTreeNode? parent, object o)
     {
         var result = new ObjectTreeArray(parent, node, o);
-        result.Items = map.Items.Cast<object>().Select((o, i) => Build(o, GetNodePath(i), result)).ToArray();
+        result.Items = map.Items.Cast<object>().Select((n, i) => Build(n, GetNodePath(i), result)).ToArray();
         return result;
     }
 

--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -7,7 +7,6 @@ using LightBDD.Core.Formatting.Values;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
-using LightBDD.Framework.Expectations;
 using LightBDD.Framework.Formatting.Values;
 using LightBDD.Framework.Parameters.Implementation;
 using LightBDD.Framework.Results.Implementation;
@@ -193,7 +192,7 @@ namespace LightBDD.Framework.Parameters
             /// <summary>
             /// Value representing no actual value.
             /// </summary>
-            public static readonly RowDataActualValue None = new RowDataActualValue(default(TRow));
+            public static readonly RowDataActualValue None = new(default(TRow));
 
             /// <summary>
             /// Constructor setting row value.
@@ -226,7 +225,7 @@ namespace LightBDD.Framework.Parameters
             /// Implicit operator converting row to actual row value.
             /// </summary>
             /// <param name="row"></param>
-            public static implicit operator RowDataActualValue(TRow row) => new RowDataActualValue(row);
+            public static implicit operator RowDataActualValue(TRow row) => new(row);
         }
 
         void IComplexParameter.SetValueFormattingService(IValueFormattingService formattingService)

--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -98,7 +98,7 @@ namespace LightBDD.Framework.Parameters
                     GetExpectedRowResults(),
                     ParameterVerificationStatus.Exception,
                     new InvalidOperationException($"Failed to retrieve rows: {ex.Message}", ex));
-                ActualRows = new TRow[0];
+                ActualRows = Array.Empty<TRow>();
                 return;
             }
             SetActual(actualCollection);

--- a/src/LightBDD.Framework/Reporting/FileAttachmentsManagerExtensions.cs
+++ b/src/LightBDD.Framework/Reporting/FileAttachmentsManagerExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using LightBDD.Core.Reporting;

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/TagBuilder.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/TagBuilder.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
 {
     internal class TagBuilder : IHtmlNode
     {
-        private readonly List<KeyValuePair<string, string>> _attributes = new List<KeyValuePair<string, string>>();
+        private readonly List<KeyValuePair<string, string>> _attributes = new();
         private bool _skipEmpty;
         private IHtmlNode[] _nodes = new IHtmlNode[0];
         private bool _spaceBefore;

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/TagBuilder.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/TagBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,7 +8,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
     {
         private readonly List<KeyValuePair<string, string>> _attributes = new();
         private bool _skipEmpty;
-        private IHtmlNode[] _nodes = new IHtmlNode[0];
+        private IHtmlNode[] _nodes = Array.Empty<IHtmlNode>();
         private bool _spaceBefore;
         private bool _spaceAfter;
         private readonly string _tag;

--- a/src/LightBDD.Framework/Reporting/Formatters/PlainTextReportFormatter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/PlainTextReportFormatter.cs
@@ -226,7 +226,7 @@ namespace LightBDD.Framework.Reporting.Formatters
             };
 
             var maxLength = summary.Keys.Max(k => k.Length);
-            var format = string.Format("\t{{0,-{0}}}: {{1}}", maxLength);
+            var format = $"\t{{0,-{maxLength}}}: {{1}}";
             foreach (var row in summary)
             {
                 writer.Write(format, row.Key, row.Value);

--- a/src/LightBDD.Framework/Reporting/Formatters/TextTableRenderer.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/TextTableRenderer.cs
@@ -12,7 +12,7 @@ namespace LightBDD.Framework.Reporting.Formatters
     internal class TextTableRenderer
     {
         private readonly TextColumn[] _columns;
-        private readonly List<TextRow> _rows = new List<TextRow>();
+        private readonly List<TextRow> _rows = new();
         private readonly bool _renderRowStatus;
 
         public TextTableRenderer(ITabularParameterDetails table)
@@ -104,7 +104,7 @@ namespace LightBDD.Framework.Reporting.Formatters
 
         class TextRow
         {
-            private readonly List<TextCell> _cells = new List<TextCell>();
+            private readonly List<TextCell> _cells = new();
             private readonly char _status;
 
             public TextRow(TableRowType rowType, ParameterVerificationStatus rowVerificationStatus)

--- a/src/LightBDD.Framework/Reporting/Formatters/XmlReportFormatter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/XmlReportFormatter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,7 +8,6 @@ using LightBDD.Core.Results;
 using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Core.Results.Parameters.Trees;
-using LightBDD.Framework.Results.Implementation;
 
 namespace LightBDD.Framework.Reporting.Formatters
 {

--- a/src/LightBDD.Framework/Reporting/ReportPathFormatter.cs
+++ b/src/LightBDD.Framework/Reporting/ReportPathFormatter.cs
@@ -12,7 +12,7 @@ namespace LightBDD.Framework.Reporting
     /// </summary>
     public class ReportPathFormatter
     {
-        private readonly List<KeyValuePair<string, Func<IFeatureResult[], object>>> _parameters = new List<KeyValuePair<string, Func<IFeatureResult[], object>>>();
+        private readonly List<KeyValuePair<string, Func<IFeatureResult[], object>>> _parameters = new();
 
         /// <summary>
         /// Creates default <see cref="ReportPathFormatter"/> that supports following format parameters:

--- a/src/LightBDD.Framework/Resources/ResourceHandle.cs
+++ b/src/LightBDD.Framework/Resources/ResourceHandle.cs
@@ -10,9 +10,9 @@ namespace LightBDD.Framework.Resources
     /// <typeparam name="TResource"></typeparam>
     public class ResourceHandle<TResource> : IDisposable
     {
-        private readonly CancellationTokenSource _cancellationSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellationSource = new();
         private readonly ResourcePool<TResource> _pool;
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private Task<TResource> _instanceTask;
         private bool _disposed;
 

--- a/src/LightBDD.Framework/Resources/ResourcePool.cs
+++ b/src/LightBDD.Framework/Resources/ResourcePool.cs
@@ -17,10 +17,10 @@ namespace LightBDD.Framework.Resources
     {
         private readonly Func<CancellationToken, Task<TResource>> _resourceFactory;
         private readonly SemaphoreSlim _semaphore;
-        private readonly ConcurrentQueue<TResource> _resources = new ConcurrentQueue<TResource>();
-        private readonly ConcurrentQueue<TResource> _pool = new ConcurrentQueue<TResource>();
+        private readonly ConcurrentQueue<TResource> _resources = new();
+        private readonly ConcurrentQueue<TResource> _pool = new();
         private readonly bool _controlDisposal;
-        private readonly CancellationTokenSource _disposalCancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _disposalCancellationTokenSource = new();
 
         /// <summary>
         /// Creates resource pool with pre-set list of resources, specified by <paramref name="resources"/> parameter.

--- a/src/LightBDD.Framework/Results/Implementation/TreeParameterDetails.cs
+++ b/src/LightBDD.Framework/Results/Implementation/TreeParameterDetails.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results.Parameters.Trees;

--- a/src/LightBDD.Framework/State.cs
+++ b/src/LightBDD.Framework/State.cs
@@ -57,7 +57,7 @@ namespace LightBDD.Framework
         /// <summary>
         /// Implicit cast, converting <paramref name="value"/> to initialized state instance.
         /// </summary>
-        public static implicit operator State<T>(T value) => new State<T>(value);
+        public static implicit operator State<T>(T value) => new(value);
         /// <summary>
         /// Implicit cast, retrieving value of <paramref name="state"/> or throwing <see cref="InvalidOperationException"/> if state is not initialized.
         /// </summary>

--- a/src/LightBDD.MsTest3/Implementation/TestContextProvider.cs
+++ b/src/LightBDD.MsTest3/Implementation/TestContextProvider.cs
@@ -5,7 +5,7 @@ namespace LightBDD.MsTest3.Implementation
 {
     internal class TestContextProvider
     {
-        private static readonly AsyncLocal<TestContextProvider> Provider = new AsyncLocal<TestContextProvider>();
+        private static readonly AsyncLocal<TestContextProvider> Provider = new();
         public MethodInfo TestMethod { get; }
         public object[] TestMethodArguments { get; }
 

--- a/src/LightBDD.NUnit3/Implementation/NUnit3ProgressNotifier.cs
+++ b/src/LightBDD.NUnit3/Implementation/NUnit3ProgressNotifier.cs
@@ -7,7 +7,7 @@ namespace LightBDD.NUnit3.Implementation
 {
     internal class NUnit3ProgressNotifier
     {
-        private static readonly DefaultProgressNotifier SummarizingProgressNotifier = new DefaultProgressNotifier(WriteOutput);
+        private static readonly DefaultProgressNotifier SummarizingProgressNotifier = new(WriteOutput);
 
         [Obsolete]
         public static IFeatureProgressNotifier CreateFeatureProgressNotifier()

--- a/src/LightBDD.NUnit3/Implementation/TestContextProvider.cs
+++ b/src/LightBDD.NUnit3/Implementation/TestContextProvider.cs
@@ -5,7 +5,7 @@ namespace LightBDD.NUnit3.Implementation
 {
     internal class TestContextProvider
     {
-        private static readonly AsyncLocal<TestContextProvider> Provider = new AsyncLocal<TestContextProvider>();
+        private static readonly AsyncLocal<TestContextProvider> Provider = new();
         public  MethodInfo TestMethod { get; }
         public  object[] TestMethodArguments { get; }
 

--- a/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
+++ b/src/LightBDD.NUnit3/LightBDD.NUnit3.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);nunit;nunit3</PackageTags>
   </PropertyGroup>
 

--- a/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/AssemblySettings.cs
@@ -6,7 +6,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
 {
     internal class AssemblySettings
     {
-        private static readonly AsyncLocal<AssemblySettings> AsyncLocal = new AsyncLocal<AssemblySettings>();
+        private static readonly AsyncLocal<AssemblySettings> AsyncLocal = new();
 
         public static AssemblySettings Current => AsyncLocal.Value ?? new AssemblySettings();
         public static void SetSettings(AssemblySettings settings) => AsyncLocal.Value = settings;

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioMultiTestCaseRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioMultiTestCaseRunner.cs
@@ -15,7 +15,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
     /// </summary>
     internal class ScenarioMultiTestCaseRunner : XunitTestCaseRunner
     {
-        private static readonly object[] NoArguments = new object[0];
+        private static readonly object[] NoArguments = Array.Empty<object>();
         private readonly ExceptionAggregator _cleanupAggregator = new();
         private Exception _dataDiscoveryException;
         private readonly List<ScenarioTestRunner> _testRunners = new();

--- a/src/LightBDD.XUnit2/Implementation/Customization/ScenarioMultiTestCaseRunner.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/ScenarioMultiTestCaseRunner.cs
@@ -16,10 +16,10 @@ namespace LightBDD.XUnit2.Implementation.Customization
     internal class ScenarioMultiTestCaseRunner : XunitTestCaseRunner
     {
         private static readonly object[] NoArguments = new object[0];
-        private readonly ExceptionAggregator _cleanupAggregator = new ExceptionAggregator();
+        private readonly ExceptionAggregator _cleanupAggregator = new();
         private Exception _dataDiscoveryException;
-        private readonly List<ScenarioTestRunner> _testRunners = new List<ScenarioTestRunner>();
-        private readonly List<IDisposable> _toDispose = new List<IDisposable>();
+        private readonly List<ScenarioTestRunner> _testRunners = new();
+        private readonly List<IDisposable> _toDispose = new();
         private readonly IMessageSink _diagnosticMessageSink;
 
         public ScenarioMultiTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)

--- a/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
+++ b/src/LightBDD.XUnit2/Implementation/Customization/SkippedDataRowTestCase.cs
@@ -46,7 +46,7 @@ namespace LightBDD.XUnit2.Implementation.Customization
         public override void Serialize(IXunitSerializationInfo data)
         {
             base.Serialize(data);
-            data.AddValue("SkipReason", (object)SkipReason, (Type)null);
+            data.AddValue("SkipReason", SkipReason);
         }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/TestContextProvider.cs
+++ b/src/LightBDD.XUnit2/Implementation/TestContextProvider.cs
@@ -6,7 +6,7 @@ namespace LightBDD.XUnit2.Implementation
 {
     internal class TestContextProvider
     {
-        private static readonly AsyncLocal<TestContextProvider> Provider = new AsyncLocal<TestContextProvider>();
+        private static readonly AsyncLocal<TestContextProvider> Provider = new();
         public MethodInfo TestMethod { get; }
         public object[] TestMethodArguments { get; }
         public ITestOutputHelper OutputHelper { get; }

--- a/src/LightBDD.XUnit2/Implementation/XUnit2FeatureCoordinator.cs
+++ b/src/LightBDD.XUnit2/Implementation/XUnit2FeatureCoordinator.cs
@@ -16,7 +16,7 @@ namespace LightBDD.XUnit2.Implementation
             if (Instance == null)
                 throw new InvalidOperationException(string.Format("{0} is not defined in the project. Please ensure that following attribute, or attribute extending it is defined at assembly level: [assembly:{0}]", nameof(LightBddScopeAttribute)));
             if (Instance.IsDisposed)
-                throw new InvalidOperationException(string.Format("LightBDD scenario test execution is already finished. Please ensure that no tests are executed outside of assembly execution scope specified by {0} attribute.", nameof(LightBddScopeAttribute)));
+                throw new InvalidOperationException($"LightBDD scenario test execution is already finished. Please ensure that no tests are executed outside of assembly execution scope specified by {nameof(LightBddScopeAttribute)} attribute.");
             return Instance;
         }
 

--- a/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
+++ b/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
@@ -28,7 +28,7 @@ High level features:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
+++ b/src/LightBDD.XUnit2/LightBDD.XUnit2.csproj
@@ -12,7 +12,7 @@ High level features:
 * in-code LightBDD configuration;
 * DI support;
 * inline and tabular parameters support.</Description>
-    <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6</TargetFrameworks>
     <PackageTags>$(PackageTags);xunit;xunit2</PackageTags>
   </PropertyGroup>
 

--- a/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
+++ b/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
@@ -20,7 +20,7 @@ namespace LightBDD.XUnit2
     [AttributeUsage(AttributeTargets.Assembly)]
     public class LightBddScopeAttribute : Attribute, ITestFrameworkAttribute
     {
-        private static readonly NullMessageSink NullDiagnosticMessageSink = new NullMessageSink();
+        private static readonly NullMessageSink NullDiagnosticMessageSink = new();
         internal void SetUp(IMessageSink diagnosticMessageSink)
         {
             DiagnosticMessageSink = diagnosticMessageSink;

--- a/templates/ProjectTemplates/LightBDD.NUnit3.ProjectTemplate/ProjectTemplate.csproj
+++ b/templates/ProjectTemplates/LightBDD.NUnit3.ProjectTemplate/ProjectTemplate.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightBDD.NUnit3" Version="3.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/templates/ProjectTemplates/LightBDD.XUnit2.ProjectTemplate/ProjectTemplate.csproj
+++ b/templates/ProjectTemplates/LightBDD.XUnit2.ProjectTemplate/ProjectTemplate.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightBDD.XUnit2" Version="3.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -81,7 +81,7 @@ namespace LightBDD.AcceptanceTests.Features
         public async Task Then_all_features_should_be_VISIBLE([VisibleFormat] bool visible)
         {
             var actual = Driver.FindFeatures().Count(e => e.Displayed == visible);
-            Assert.That(actual, Is.EqualTo(Features.Count()));
+            Assert.That(actual, Is.EqualTo(Features.Length));
         }
 
         public async Task Then_all_scenarios_should_be_VISIBLE([VisibleFormat] bool visible)
@@ -308,7 +308,7 @@ namespace LightBDD.AcceptanceTests.Features
         public async Task Then_the_page_should_be_redirected_to_url_with_query_part()
         {
             Repeat.Until(
-                () => Driver.Url.Contains("?"),
+                () => Driver.Url.Contains('?'),
                 () => $"Page was not redirected, actual value: {Driver.Url}");
             Driver.EnsurePageIsLoaded();
         }
@@ -359,11 +359,9 @@ namespace LightBDD.AcceptanceTests.Features
 
         private string FormatResults(params IFeatureResult[] results)
         {
-            using (var memory = new MemoryStream())
-            {
-                new HtmlReportFormatter().Format(memory, results);
-                return Encoding.UTF8.GetString(memory.ToArray());
-            }
+            using var memory = new MemoryStream();
+            new HtmlReportFormatter().Format(memory, results);
+            return Encoding.UTF8.GetString(memory.ToArray());
         }
 
         public async Task Then_overall_status_should_be_STATUS(ExecutionStatus status)

--- a/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
+++ b/test/LightBDD.AcceptanceTests/Features/HtmlReportContext.cs
@@ -120,8 +120,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         private IWebElement FindLabeledButton(string buttonId)
         {
-            var label = Driver
-                .FindElementsByTagName("label")
+            var label = Driver.FindElements(By.TagName("label"))
                 .Single(l => l.GetAttribute("for") == buttonId);
 
             return label.FindElement(By.ClassName("chbox"));
@@ -182,12 +181,12 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Then_the_scenario_filter_button_should_be_SELECTED([SelectedFormat] bool selected)
         {
-            Assert.That(Driver.FindElementById("toggleScenarios").Selected, Is.EqualTo(selected));
+            Assert.That(Driver.FindElement(By.Id("toggleScenarios")).Selected, Is.EqualTo(selected));
         }
 
         public async Task Then_the_feature_filter_button_should_be_SELECTED([SelectedFormat] bool selected)
         {
-            Assert.That(Driver.FindElementById("toggleFeatures").Selected, Is.EqualTo(selected));
+            Assert.That(Driver.FindElement(By.Id("toggleFeatures")).Selected, Is.EqualTo(selected));
         }
 
         public async Task When_a_filter_status_button_is_clicked(ExecutionStatus status)
@@ -197,7 +196,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Then_the_filter_status_button_should_be_SELECTED(ExecutionStatus status, [SelectedFormat] bool selected)
         {
-            Assert.That(Driver.FindElementById($"show{status}").Selected, Is.EqualTo(selected));
+            Assert.That(Driver.FindElement(By.Id($"show{status}")).Selected, Is.EqualTo(selected));
         }
 
         public async Task Then_all_scenarios_with_status_should_be_VISIBLE(ExecutionStatus status, [VisibleFormat] bool visible)
@@ -230,7 +229,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task When_the_link_to_details_of_STATUS_scenarios_is_clicked(ExecutionStatus status)
         {
-            Driver.FindElementsByTagName("section").First(t => t.HasClassName("execution-summary"))
+            Driver.FindElements(By.TagName("section")).First(t => t.HasClassName("execution-summary"))
                 .FindElements(By.TagName("td"))
                 .First(td => td.FindElements(By.TagName("span")).Any(span => span.HasClassName(status.ToString().ToLower() + "Alert")))
                 .FindElements(By.TagName("a")).First()
@@ -297,13 +296,12 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Then_the_options_link_should_be_VISIBLE([VisibleFormat] bool visible)
         {
-            Assert.That(Driver.FindElementById("optionsLink").Displayed, Is.EqualTo(visible));
+            Assert.That(Driver.FindElement(By.Id("optionsLink")).Displayed, Is.EqualTo(visible));
         }
 
         public async Task When_the_options_link_is_clicked()
         {
-            Driver
-                .FindElementById("optionsLink")
+            Driver.FindElement(By.Id("optionsLink"))
                 .Click();
         }
 
@@ -317,8 +315,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Then_the_Feature_Summary_table_should_be_sorted_ASCENDING_by_column([OrderFormat] bool ascending, FeatureSummaryColumn column)
         {
-            var values = Driver
-                .FindElementById("featuresSummary")
+            var values = Driver.FindElement(By.Id("featuresSummary"))
                 .FindElements(By.TagName("tr"))
                 .Skip(1)
                 .SkipLast(1)
@@ -333,8 +330,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task When_the_Feature_Summary_table_column_is_clicked(FeatureSummaryColumn column)
         {
-            var webElement = Driver
-                .FindElementById("featuresSummary")
+            var webElement = Driver.FindElement(By.Id("featuresSummary"))
                 .FindElements(By.TagName("tr"))
                 .First()
                 .FindElements(By.TagName("th"))
@@ -372,7 +368,7 @@ namespace LightBDD.AcceptanceTests.Features
 
         public async Task Then_overall_status_should_be_STATUS(ExecutionStatus status)
         {
-            var element = Driver.FindElementByCssSelector(".execution-summary td.overall-status");
+            var element = Driver.FindElement(By.CssSelector(".execution-summary td.overall-status"));
             Assert.That(element.GetClassNames(), Does.Contain(status.ToString().ToLowerInvariant()));
         }
     }

--- a/test/LightBDD.AcceptanceTests/Helpers/Builders/FeatureBuilder.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Builders/FeatureBuilder.cs
@@ -7,7 +7,7 @@ namespace LightBDD.AcceptanceTests.Helpers.Builders
 {
     internal class FeatureBuilder
     {
-        private readonly List<ScenarioBuilder> _scenarios = new List<ScenarioBuilder>();
+        private readonly List<ScenarioBuilder> _scenarios = new();
 
         public FeatureBuilder(string feature)
         {

--- a/test/LightBDD.AcceptanceTests/Helpers/Builders/ResultBuilder.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Builders/ResultBuilder.cs
@@ -6,7 +6,7 @@ namespace LightBDD.AcceptanceTests.Helpers.Builders
 {
     internal class ResultBuilder
     {
-        private readonly List<FeatureBuilder> _features = new List<FeatureBuilder>();
+        private readonly List<FeatureBuilder> _features = new();
 
         public FeatureBuilder NewFeature(string feature)
         {

--- a/test/LightBDD.AcceptanceTests/Helpers/Builders/ScenarioBuilder.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Builders/ScenarioBuilder.cs
@@ -7,7 +7,7 @@ namespace LightBDD.AcceptanceTests.Helpers.Builders
 {
     internal class ScenarioBuilder
     {
-        private readonly List<TestResults.TestStepResult> _steps = new List<TestResults.TestStepResult>();
+        private readonly List<TestResults.TestStepResult> _steps = new();
         public ExecutionStatus Status { get; }
         public string[] Categories { get; private set; }
         public string Name { get; private set; } = "scenario";

--- a/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
@@ -17,14 +17,14 @@ namespace LightBDD.AcceptanceTests.Helpers
     /// </summary>
     public class ChromeDriverInstaller : IDisposable
     {
-        private readonly SemaphoreSlim _sem = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _sem = new(1);
         private bool _installed;
-        private readonly HttpClient _httpClient = new HttpClient
+        private readonly HttpClient _httpClient = new()
         {
             BaseAddress = new Uri("https://chromedriver.storage.googleapis.com/")
         };
 
-        public static ChromeDriverInstaller Instance { get; } = new ChromeDriverInstaller();
+        public static ChromeDriverInstaller Instance { get; } = new();
 
         private ChromeDriverInstaller() { }
 

--- a/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
@@ -73,21 +73,20 @@ namespace LightBDD.AcceptanceTests.Helpers
         {
             var chromeDriverVersionResponse = await _httpClient.GetAsync($"LATEST_RELEASE_{chromeVersion}", cancellationToken);
             if (chromeDriverVersionResponse.IsSuccessStatusCode)
-                return await chromeDriverVersionResponse.Content.ReadAsStringAsync();
+                return await chromeDriverVersionResponse.Content.ReadAsStringAsync(cancellationToken);
 
             if (chromeDriverVersionResponse.StatusCode == HttpStatusCode.NotFound)
                 throw new Exception($"ChromeDriver version not found for Chrome version {chromeVersion}");
             throw new Exception($"ChromeDriver version request failed with status code: {chromeDriverVersionResponse.StatusCode}, reason phrase: {chromeDriverVersionResponse.ReasonPhrase}");
         }
 
-        public string GetChromeVersion()
+        private static string GetChromeVersion()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("Your operating system is not supported.");
 
-            var chromePath = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe", null, null);
-            if (chromePath == null)
-                throw new Exception("Google Chrome not found in registry");
+            var chromePath = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe", null, null)
+                ?? throw new Exception("Google Chrome not found in registry");
 
             var chromeVersion = FileVersionInfo.GetVersionInfo(chromePath).FileVersion;
             return chromeVersion.Substring(0, chromeVersion.LastIndexOf('.'));

--- a/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/ChromeDriverInstaller.cs
@@ -45,7 +45,7 @@ namespace LightBDD.AcceptanceTests.Helpers
                 var targetPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
                     driverName);
 
-                await using (var zipFileStream = await _httpClient.GetStreamAsync($"{chromeDriverVersion}/{zipName}"))
+                await using (var zipFileStream = await _httpClient.GetStreamAsync($"{chromeDriverVersion}/{zipName}", cancellationToken))
                 using (var zipArchive = new ZipArchive(zipFileStream, ZipArchiveMode.Read))
                 await using (var chromeDriverWriter = new FileStream(targetPath, FileMode.Create))
                 {

--- a/test/LightBDD.AcceptanceTests/Helpers/Extensions.cs
+++ b/test/LightBDD.AcceptanceTests/Helpers/Extensions.cs
@@ -15,22 +15,22 @@ namespace LightBDD.AcceptanceTests.Helpers
 
         public static IEnumerable<IWebElement> FindFeatures(this ChromeDriver driver)
         {
-            return driver.FindElementsByClassName("feature");
+            return driver.FindElements(By.ClassName("feature"));
         }
 
         public static IEnumerable<IWebElement> FindAllScenarios(this ChromeDriver driver)
         {
-            return driver.FindElementsByClassName("scenario");
+            return driver.FindElements(By.ClassName("scenario"));
         }
 
         public static IEnumerable<IWebElement> FindAllSteps(this ChromeDriver driver)
         {
-            return driver.FindElementsByCssSelector(".scenario > .content > .scenario-steps > .step");
+            return driver.FindElements(By.CssSelector(".scenario > .content > .scenario-steps > .step"));
         }
 
         public static IEnumerable<IWebElement> FindAllSubSteps(this ChromeDriver driver)
         {
-            return driver.FindElementsByClassName("sub-steps");
+            return driver.FindElements(By.ClassName("sub-steps"));
         }
 
         public static IWebElement FindScenario(this IWebElement element, int scenarioNo)
@@ -70,12 +70,12 @@ namespace LightBDD.AcceptanceTests.Helpers
 
         public static IWebElement FindLabelByText(this ChromeDriver driver, string text)
         {
-            return driver.FindElementsByTagName("label").Single(l => l.Text == text);
+            return driver.FindElements(By.TagName("label")).Single(l => l.Text == text);
         }
 
         public static IWebElement FindLabelTarget(this ChromeDriver driver, IWebElement label)
         {
-            return driver.FindElementById(label.GetAttribute("for"));
+            return driver.FindElement(By.Id(label.GetAttribute("for")));
         }
 
         public static void ClickSync(this IWebElement element, ChromeDriver driver)

--- a/test/LightBDD.AcceptanceTests/LightBDD.AcceptanceTests.csproj
+++ b/test/LightBDD.AcceptanceTests/LightBDD.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LightBDD.Autofac.UnitTests/LightBDD.Autofac.UnitTests.csproj
+++ b/test/LightBDD.Autofac.UnitTests/LightBDD.Autofac.UnitTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.4.0" />
+    <PackageReference Include="Autofac" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
@@ -19,7 +19,7 @@ namespace LightBDD.Core.UnitTests
     [Parallelizable(ParallelScope.None)]
     public class CoreBddRunner_execution_extension_tests
     {
-        private static readonly List<string> CapturedMessages = new List<string>();
+        private static readonly List<string> CapturedMessages = new();
 
         [SetUp]
         public void SetUp() { CapturedMessages.Clear(); }

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_invalid_step_handling_tests.cs
@@ -50,7 +50,7 @@ namespace LightBDD.Core.UnitTests
         [Test]
         public void Invalid_step_descriptors_should_make_composite_failing_immediately_without_execution()
         {
-            TestCompositeStep Composite_step() => new TestCompositeStep(
+            TestCompositeStep Composite_step() => new(
                 TestStep.Create(Step_that_should_not_run),
                 StepDescriptor.CreateInvalid(new Exception("reason1")),
                 StepDescriptor.CreateInvalid(new Exception("reason2")));

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_parameterized_step_execution_tests.cs
@@ -68,7 +68,7 @@ namespace LightBDD.Core.UnitTests
             {
                 _runner.Test().TestScenario(
                     TestStep.CreateAsync(Given_step_one, () => "def"),
-                    TestStep.CreateAsync<int>(When_step_two, () => { throw new Exception("reason"); }),
+                    TestStep.CreateAsync<int>(When_step_two, () => throw new Exception("reason")),
                     TestStep.CreateAsync(Then_step_three, () => 3.14));
             });
 

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_progress_notification_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_progress_notification_tests.cs
@@ -278,7 +278,7 @@ namespace LightBDD.Core.UnitTests
         private class CapturingProgressNotifier : IProgressNotifier, IScenarioProgressNotifier, IFeatureProgressNotifier
 #pragma warning restore 618
         {
-            private readonly List<string> _notifications = new List<string>();
+            private readonly List<string> _notifications = new();
 
             public IEnumerable<string> Notifications => _notifications;
 

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_step_execution_with_dependency_injection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_step_execution_with_dependency_injection_tests.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using LightBDD.Core.Configuration;
 using LightBDD.Core.Dependencies;
 using LightBDD.Core.Extensibility;
-using LightBDD.Core.Extensibility.Results;
-using LightBDD.Core.Results;
 using LightBDD.Framework;
 using LightBDD.Framework.Extensibility;
 using LightBDD.UnitTests.Helpers.TestableIntegration;

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_synchronous_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_synchronous_step_execution_tests.cs
@@ -32,7 +32,7 @@ namespace LightBDD.Core.UnitTests
             var stepThreadIds = new List<int>();
 
             var steps = Enumerable
-                .Repeat<Action>(() => stepThreadIds.Add(Thread.CurrentThread.ManagedThreadId), 500)
+                .Repeat(() => stepThreadIds.Add(Thread.CurrentThread.ManagedThreadId), 500)
                 .ToArray();
 
             _runner.Test().TestScenarioPurelySync(steps);
@@ -46,7 +46,7 @@ namespace LightBDD.Core.UnitTests
         {
             var readSharedData = new List<Guid>();
             var steps = Enumerable
-                .Repeat<Action>(() => readSharedData.Add(_threadLocal.Value), 500)
+                .Repeat(() => readSharedData.Add(_threadLocal.Value), 500)
                 .ToArray();
 
             _runner.Test().TestScenarioPurelySync(steps);

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_synchronous_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_synchronous_step_execution_tests.cs
@@ -13,7 +13,7 @@ namespace LightBDD.Core.UnitTests
     public class CoreBddRunner_synchronous_step_execution_tests
     {
         private IBddRunner _runner;
-        private readonly ThreadLocal<Guid> _threadLocal = new ThreadLocal<Guid>(Guid.NewGuid);
+        private readonly ThreadLocal<Guid> _threadLocal = new(Guid.NewGuid);
 
         #region Setup/Teardown
 

--- a/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/CoreMetadataProvider_tests.cs
@@ -45,7 +45,7 @@ namespace LightBDD.Core.UnitTests.Extensibility
         public void GetScenarioName_should_capture_parameterless_scenario_name_from_descriptor()
         {
             var method = typeof(Feature_type).GetMethod(nameof(Feature_type.Some_method_without_arguments));
-            var scenarioName = _metadataProvider.GetScenarioName(new ScenarioDescriptor(method, new object[0]));
+            var scenarioName = _metadataProvider.GetScenarioName(new ScenarioDescriptor(method, Array.Empty<object>()));
 
             Assert.That(scenarioName.ToString(), Is.EqualTo("Some method without arguments"));
             Assert.That(scenarioName.Parameters, Is.Empty);

--- a/test/LightBDD.Core.UnitTests/Extensibility/FeatureRunnerRepository_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/FeatureRunnerRepository_tests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading;
 using LightBDD.Core.Extensibility;
-using LightBDD.Core.Metadata;
 using LightBDD.Core.Notification;
 using LightBDD.Core.Notification.Events;
 using LightBDD.UnitTests.Helpers.TestableIntegration;

--- a/test/LightBDD.Core.UnitTests/Extensibility/ScenarioDescriptor_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Extensibility/ScenarioDescriptor_tests.cs
@@ -19,7 +19,7 @@ namespace LightBDD.Core.UnitTests.Extensibility
         public void It_should_accept_parameterless_methods()
         {
             var methodInfo = GetMethod(nameof(Parameterless_method));
-            var descriptor = new ScenarioDescriptor(methodInfo, new object[0]);
+            var descriptor = new ScenarioDescriptor(methodInfo, Array.Empty<object>());
             Assert.That(descriptor.MethodInfo, Is.SameAs(methodInfo));
             Assert.That(descriptor.Parameters, Is.Empty);
         }

--- a/test/LightBDD.Core.UnitTests/Formatting/Diagnostics/ObjectFormatter_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Formatting/Diagnostics/ObjectFormatter_tests.cs
@@ -19,7 +19,7 @@ namespace LightBDD.Core.UnitTests.Formatting.Diagnostics
             public bool Flag { get; set; }
             public float ReadonlyFloat => 3.14f;
             public DateTimeKind[] Array => new[] { DateTimeKind.Local, DateTimeKind.Unspecified, DateTimeKind.Utc };
-            public Dictionary<string, ComplexType> Dictionary { get; } = new Dictionary<string, ComplexType>();
+            public Dictionary<string, ComplexType> Dictionary { get; } = new();
             public TimeSpan? Span { get; set; }
         }
 

--- a/test/LightBDD.Core.UnitTests/LightBDD.Core.UnitTests.csproj
+++ b/test/LightBDD.Core.UnitTests/LightBDD.Core.UnitTests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/test/LightBDD.Fixie2.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.Fixie2.UnitTests/ConfiguredLightBddScope.cs
@@ -9,7 +9,7 @@ namespace LightBDD.Fixie2.UnitTests
 
     public class ConfiguredLightBddScope : LightBddScope
     {
-        public static readonly ConcurrentQueue<string> CapturedNotifications = new ConcurrentQueue<string>();
+        public static readonly ConcurrentQueue<string> CapturedNotifications = new();
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
             configuration.ReportWritersConfiguration()

--- a/test/LightBDD.Framework.Reporting.UnitTests/FeatureReportExtensions_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/FeatureReportExtensions_tests.cs
@@ -204,7 +204,7 @@ namespace LightBDD.Framework.Reporting.UnitTests
                 },
                 new TestResults.TestFeatureResult
                 {
-                    Scenarios = new TestResults.TestScenarioResult[0]
+                    Scenarios = Array.Empty<TestResults.TestScenarioResult>()
                 }
             };
             AssertExecutionSummary(features.GetTestExecutionTimeSummary(), baseTime, baseTime.AddSeconds(7), TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(5));

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/Helpers/HtmlToPlainTextFormatter.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/Helpers/HtmlToPlainTextFormatter.cs
@@ -10,8 +10,8 @@ internal class HtmlToPlainTextFormatter
 {
     private readonly IEnumerable<string> _blockElements = new[] { "div", "tr", "table", "section", "article", "h1", "h2", "h3", "br" };
     private readonly IEnumerable<string> _inlineElements = new[] { "td", "th" };//browsers are treating td/th in special way while for span they put no spaces when copied to clipboard
-    private readonly List<string> _lines = new List<string>();
-    private readonly StringBuilder _current = new StringBuilder();
+    private readonly List<string> _lines = new();
+    private readonly StringBuilder _current = new();
 
     public void FormatNode(HtmlNode node)
     {

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -186,7 +186,7 @@ initialize();";
         {
             var date = new DateTimeOffset(2019, 10, 21, 05, 06, 07, TimeSpan.Zero);
             var feature = TestResults.CreateFeatureResult("My feature", null, null,
-                TestResults.CreateScenarioResult("scenario1", null, date, TimeSpan.FromSeconds(5), new string[0],
+                TestResults.CreateScenarioResult("scenario1", null, date, TimeSpan.FromSeconds(5), Array.Empty<string>(),
                     TestResults.CreateStepResult(ExecutionStatus.Passed)
                         .WithStepNameDetails(1, "ste<p>", "ste<p>", "ty<p>e")
                         .WithGroupPrefix("<gr>")

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using LightBDD.Core.Metadata;
 using LightBDD.Core.Results;
-using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
 using LightBDD.Core.Results.Parameters.Trees;
-using LightBDD.Framework.Parameters;
 using LightBDD.UnitTests.Helpers;
 
 namespace LightBDD.Framework.Reporting.UnitTests.Formatters
 {
     internal static class ReportFormatterTestData
     {
-        private static DateTimeOffset _startDate = new DateTimeOffset(2014, 09, 23, 19, 21, 57, 55, TimeSpan.Zero);
+        private static DateTimeOffset _startDate = new(2014, 09, 23, 19, 21, 57, 55, TimeSpan.Zero);
 
         public static IFeatureResult GetFeatureResultWithDescription()
         {

--- a/test/LightBDD.Framework.Reporting.UnitTests/LightBDD.Framework.Reporting.UnitTests.csproj
+++ b/test/LightBDD.Framework.Reporting.UnitTests/LightBDD.Framework.Reporting.UnitTests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
   </ItemGroup>
 

--- a/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_formattable_path_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/ReportFileWriter_formattable_path_tests.cs
@@ -26,7 +26,7 @@ namespace LightBDD.Framework.Reporting.UnitTests
         {
             _formatter = new Mock<IReportFormatter>();
             _feature = TestResults.CreateFeatureResult("name", "description", "label",
-                TestResults.CreateScenarioResult("abc", "def", _expectedExecutionStartOffset, TimeSpan.Zero, new string[0],
+                TestResults.CreateScenarioResult("abc", "def", _expectedExecutionStartOffset, TimeSpan.Zero, Array.Empty<string>(),
                     TestResults.CreateStepResult(ExecutionStatus.Passed).WithStepNameDetails(1, "foo", "foo")));
             _formatter.Setup(f => f.Format(It.IsAny<Stream>(), It.Is<IFeatureResult[]>(l => l.Contains(_feature)))).Callback(
                 (Stream s, IFeatureResult[] results) =>

--- a/test/LightBDD.Framework.UnitTests/Expectations/BeEmptyExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/BeEmptyExpectation_tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using LightBDD.Framework.Expectations;
 using LightBDD.Framework.UnitTests.Expectations.Helpers;
@@ -28,7 +29,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
             yield return new ExpectationScenario<IEnumerable<int>>(
                     "empty",
                     x => x.BeEmpty())
-                .WithMatchingValues(new int[0], Enumerable.Empty<int>(), new List<int>())
+                .WithMatchingValues(Array.Empty<int>(), Enumerable.Empty<int>(), new List<int>())
                 .WithNotMatchingValue(null, "expected: empty, but got: '<null>'")
                 .WithNotMatchingValue(new[] { 5 }, "expected: empty, but got: '5'");
         }

--- a/test/LightBDD.Framework.UnitTests/Expectations/EqualExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/EqualExpectation_tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using LightBDD.Framework.Expectations;
 using LightBDD.Framework.UnitTests.Expectations.Helpers;
 using NUnit.Framework;

--- a/test/LightBDD.Framework.UnitTests/Expectations/ToVerifiable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/ToVerifiable_tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using LightBDD.Core.Metadata;
 using LightBDD.Framework.Expectations;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ namespace LightBDD.Framework.UnitTests.Expectations
         {
             var expectation = Expect.To.Not.BeEmpty().And(x => x.EveryItem(item => item.Not.BeNull()));
             Assert.AreEqual(ParameterVerificationStatus.Failure, expectation.ToVerifiable().SetActual(Enumerable.Empty<string>()).Status);
-            Assert.AreEqual(ParameterVerificationStatus.Failure, expectation.ToVerifiable<string[]>().SetActual(new string[0]).Status);
+            Assert.AreEqual(ParameterVerificationStatus.Failure, expectation.ToVerifiable<string[]>().SetActual(Array.Empty<string>()).Status);
             Assert.AreEqual(ParameterVerificationStatus.Failure, expectation.ToVerifiable<string[]>().SetActual(new[] { null, "abc" }).Status);
             Assert.AreEqual(ParameterVerificationStatus.Success, expectation.ToVerifiable<string[]>().SetActual(new[] { "123", "abc" }).Status);
         }

--- a/test/LightBDD.Framework.UnitTests/Formatting/FormatBooleanAttribute_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Formatting/FormatBooleanAttribute_tests.cs
@@ -8,7 +8,7 @@ namespace LightBDD.Framework.UnitTests.Formatting
     [TestFixture]
     public class FormatBooleanAttribute_tests
     {
-        private readonly ValueFormattingServiceStub _formattingService = new ValueFormattingServiceStub(CultureInfo.InvariantCulture);
+        private readonly ValueFormattingServiceStub _formattingService = new(CultureInfo.InvariantCulture);
 
         [Test]
         public void FormatValue_should_format_boolean()

--- a/test/LightBDD.Framework.UnitTests/LightBDD.Framework.UnitTests.csproj
+++ b/test/LightBDD.Framework.UnitTests/LightBDD.Framework.UnitTests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
 

--- a/test/LightBDD.Framework.UnitTests/LightBDD.Framework.UnitTests.csproj
+++ b/test/LightBDD.Framework.UnitTests/LightBDD.Framework.UnitTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_EnsureReceivedMany_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_EnsureReceivedMany_tests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LightBDD.Framework.Messaging;
@@ -12,7 +11,7 @@ namespace LightBDD.Framework.UnitTests.Messaging
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class MessageListener_EnsureReceivedMany_tests
     {
-        private readonly MessageSource _source = new MessageSource();
+        private readonly MessageSource _source = new();
 
         [Test]
         public async Task EnsureReceivedMany_returns_specified_amount_of_messages_matching_criteria_in_order_from_latest_to_oldest()

--- a/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_EnsureReceived_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_EnsureReceived_tests.cs
@@ -11,7 +11,7 @@ namespace LightBDD.Framework.UnitTests.Messaging
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class MessageListener_EnsureReceived_tests
     {
-        private readonly MessageSource _source = new MessageSource();
+        private readonly MessageSource _source = new();
 
         [Test]
         public async Task EnsureReceived_returns_latest_message_matching_criteria_if_it_has_been_already_received()

--- a/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_GetMessages_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_GetMessages_tests.cs
@@ -9,7 +9,7 @@ namespace LightBDD.Framework.UnitTests.Messaging
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class MessageListener_GetMessages_tests
     {
-        private readonly MessageSource _source = new MessageSource();
+        private readonly MessageSource _source = new();
 
         [Test]
         public void GetMessages_Of_Object_should_return_all_received_messages()

--- a/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_Source_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Messaging/MessageListener_Source_tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using LightBDD.Framework.Messaging;
 using LightBDD.Framework.UnitTests.Messaging.Helpers;
 using NUnit.Framework;
@@ -10,7 +9,7 @@ namespace LightBDD.Framework.UnitTests.Messaging
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class MessageListener_Source_tests
     {
-        private readonly MessageSource _source = new MessageSource();
+        private readonly MessageSource _source = new();
 
         [Test]
         public void Dispose_should_deregister_the_listener_from_OnMessage_event()

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_obsolete_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_obsolete_tests.cs
@@ -126,7 +126,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyFeatureStart_should_omit_labels_if_not_provided()
         {
             var featureInfo = Fake.Object<TestResults.TestFeatureInfo>();
-            featureInfo.Labels = new string[0];
+            featureInfo.Labels = Array.Empty<string>();
             ((IFeatureProgressNotifier)_notifier).NotifyFeatureStart(featureInfo);
 
             var expected = $"FEATURE: {featureInfo.Name}{Environment.NewLine}  {featureInfo.Description}";
@@ -137,7 +137,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioStart_should_omit_labels_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             ((IScenarioProgressNotifier)_notifier).NotifyScenarioStart(scenarioInfo);
 
             var expected = $"SCENARIO: {scenarioInfo.Name}";
@@ -148,7 +148,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_execution_time_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -170,7 +170,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_status_details_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
@@ -158,7 +158,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyFeatureStart_should_omit_labels_if_not_provided()
         {
             var featureInfo = Fake.Object<TestResults.TestFeatureInfo>();
-            featureInfo.Labels = new string[0];
+            featureInfo.Labels = Array.Empty<string>();
             _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
 
             var expected = $"FEATURE: {featureInfo.Name}{Environment.NewLine}  {featureInfo.Description}";
@@ -169,7 +169,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioStart_should_omit_labels_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
 
             var expected = $"SCENARIO: {scenarioInfo.Name}";
@@ -180,7 +180,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_execution_time_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -201,7 +201,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_status_details_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
@@ -8,7 +8,6 @@ using LightBDD.Core.Notification.Events;
 using LightBDD.Core.Results;
 using LightBDD.Core.Results.Parameters;
 using LightBDD.Core.Results.Parameters.Tabular;
-using LightBDD.Framework.Expectations;
 using LightBDD.Framework.Notification;
 using LightBDD.Framework.Parameters;
 using LightBDD.UnitTests.Helpers;

--- a/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_obsolete_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_obsolete_tests.cs
@@ -148,7 +148,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyFeatureStart_should_omit_labels_if_not_provided()
         {
             var featureInfo = Fake.Object<TestResults.TestFeatureInfo>();
-            featureInfo.Labels = new string[0];
+            featureInfo.Labels = Array.Empty<string>();
             GetFeatureNotifier().NotifyFeatureStart(featureInfo);
 
             var header = "Fi=000,Fa=000,Pe=000 #   > ";
@@ -160,7 +160,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioStart_should_omit_labels_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             GetScenarioNotifier().NotifyScenarioStart(scenarioInfo);
 
             var expected = $"Fi=000,Fa=000,Pe=001 #  1> SCENARIO: {scenarioInfo.Name}";
@@ -172,8 +172,8 @@ namespace LightBDD.Framework.UnitTests.Notification
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
             var scenarioInfo2 = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
-            scenarioInfo2.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
+            scenarioInfo2.Labels = Array.Empty<string>();
             var scenarioNotifier = GetScenarioNotifier();
 
             scenarioNotifier.NotifyScenarioStart(scenarioInfo);
@@ -193,8 +193,8 @@ namespace LightBDD.Framework.UnitTests.Notification
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
             var scenarioInfo2 = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
-            scenarioInfo2.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
+            scenarioInfo2.Labels = Array.Empty<string>();
 
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
@@ -227,7 +227,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_execution_time_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -251,7 +251,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_status_details_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -281,7 +281,7 @@ namespace LightBDD.Framework.UnitTests.Notification
 
             foreach (var group in _capturedGroups.Values)
             {
-                var identifiers = @group.Select(v => Regex.Match(v, "^[^#]+#([^>]+)>").Groups[1].Value).Distinct().Where(i => !string.IsNullOrWhiteSpace(i)).ToArray();
+                var identifiers = group.Select(v => Regex.Match(v, "^[^#]+#([^>]+)>").Groups[1].Value).Distinct().Where(i => !string.IsNullOrWhiteSpace(i)).ToArray();
                 Assert.That(identifiers.Length, Is.EqualTo(1), "Expected one identifier in group, got: {0}", string.Join(", ", identifiers.Select(i => $"'{i}'")));
             }
 
@@ -322,13 +322,13 @@ namespace LightBDD.Framework.UnitTests.Notification
             await Task.Yield();
 
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
-            scenarioResult.Steps = new TestResults.TestStepResult[0];
+            scenarioResult.Steps = Array.Empty<TestResults.TestStepResult>();
 
             scenarioNotifier.NotifyScenarioFinished(scenarioResult);
             await Task.Yield();
 
             var featureResult = Fake.Object<TestResults.TestFeatureResult>();
-            featureResult.Scenarios = new TestResults.TestScenarioResult[0];
+            featureResult.Scenarios = Array.Empty<TestResults.TestScenarioResult>();
             featureNotifier.NotifyFeatureFinished(featureResult);
         }
 

--- a/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_obsolete_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_obsolete_tests.cs
@@ -23,7 +23,7 @@ namespace LightBDD.Framework.UnitTests.Notification
     {
         private ConcurrentDictionary<int, ConcurrentQueue<string>> _capturedGroups;
         public IEnumerable<string> CapturedItems => _capturedGroups.SelectMany(g => g.Value);
-        private readonly AsyncLocal<int> _currentId = new AsyncLocal<int>();
+        private readonly AsyncLocal<int> _currentId = new();
         private ParallelProgressNotifierProvider _notifierProvider;
 
         private class TestableParallelProgressNotifierProvider : ParallelProgressNotifierProvider { }

--- a/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_tests.cs
@@ -173,7 +173,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyFeatureStart_should_omit_labels_if_not_provided()
         {
             var featureInfo = Fake.Object<TestResults.TestFeatureInfo>();
-            featureInfo.Labels = new string[0];
+            featureInfo.Labels = Array.Empty<string>();
             GetProgressNotifier().Notify(new FeatureStarting(new EventTime(), featureInfo));
 
             var header = "Fi=000,Fa=000,Pe=000 #   > ";
@@ -185,7 +185,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioStart_should_omit_labels_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             GetProgressNotifier().Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
 
             var expected = $"Fi=000,Fa=000,Pe=001 #  1> SCENARIO: {scenarioInfo.Name}";
@@ -197,8 +197,8 @@ namespace LightBDD.Framework.UnitTests.Notification
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
             var scenarioInfo2 = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
-            scenarioInfo2.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
+            scenarioInfo2.Labels = Array.Empty<string>();
 
             var progressNotifier = GetProgressNotifier();
             progressNotifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
@@ -218,8 +218,8 @@ namespace LightBDD.Framework.UnitTests.Notification
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
             var scenarioInfo2 = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
-            scenarioInfo2.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
+            scenarioInfo2.Labels = Array.Empty<string>();
 
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
@@ -253,7 +253,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_execution_time_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -278,7 +278,7 @@ namespace LightBDD.Framework.UnitTests.Notification
         public void NotifyScenarioFinished_should_omit_status_details_if_not_provided()
         {
             var scenarioInfo = Fake.Object<TestResults.TestScenarioInfo>();
-            scenarioInfo.Labels = new string[0];
+            scenarioInfo.Labels = Array.Empty<string>();
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
             scenarioResult.Info = scenarioInfo;
             scenarioResult.Status = ExecutionStatus.Passed;
@@ -348,13 +348,13 @@ namespace LightBDD.Framework.UnitTests.Notification
             await Task.Yield();
 
             var scenarioResult = Fake.Object<TestResults.TestScenarioResult>();
-            scenarioResult.Steps = new TestResults.TestStepResult[0];
+            scenarioResult.Steps = Array.Empty<TestResults.TestStepResult>();
 
             notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
             await Task.Yield();
 
             var featureResult = Fake.Object<TestResults.TestFeatureResult>();
-            featureResult.Scenarios = new TestResults.TestScenarioResult[0];
+            featureResult.Scenarios = Array.Empty<TestResults.TestScenarioResult>();
             notifier.Notify(new FeatureFinished(eventTime, featureResult));
         }
 

--- a/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/ParallelProgressNotifier_tests.cs
@@ -25,7 +25,7 @@ namespace LightBDD.Framework.UnitTests.Notification
     {
         private ConcurrentDictionary<int, ConcurrentQueue<string>> _capturedGroups;
         public IEnumerable<string> CapturedItems => _capturedGroups.SelectMany(g => g.Value);
-        private readonly AsyncLocal<int> _currentId = new AsyncLocal<int>();
+        private readonly AsyncLocal<int> _currentId = new();
         private ParallelProgressNotifierProvider _notifierProvider;
 
         private class TestableParallelProgressNotifierProvider : ParallelProgressNotifierProvider { }

--- a/test/LightBDD.Framework.UnitTests/Parameters/TableValidator_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/TableValidator_tests.cs
@@ -82,9 +82,9 @@ namespace LightBDD.Framework.UnitTests.Parameters
         public void SetActual_should_be_callable_once()
         {
             var table = CreateNotNullValidator();
-            table.SetActual(new Testable[0]);
+            table.SetActual(Array.Empty<Testable>());
 
-            var ex = Assert.Throws<InvalidOperationException>(() => table.SetActual(new Testable[0]));
+            var ex = Assert.Throws<InvalidOperationException>(() => table.SetActual(Array.Empty<Testable>()));
             Assert.That(ex.Message, Is.EqualTo("Actual rows have been already specified"));
             Assert.ThrowsAsync<InvalidOperationException>(() => table.SetActualAsync(() => Task.FromResult(Enumerable.Empty<Testable>())));
         }

--- a/test/LightBDD.Framework.UnitTests/Parameters/Verifiable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Verifiable_tests.cs
@@ -110,8 +110,8 @@ namespace LightBDD.Framework.UnitTests.Parameters
         public void SetActual_should_be_allowed_once()
         {
             Verifiable<int> expectation = Fake.Int();
-            expectation.SetActual(() => Fake.Int());
-            var ex = Assert.Throws<InvalidOperationException>(() => expectation.SetActual(() => Fake.Int()));
+            expectation.SetActual(Fake.Int);
+            var ex = Assert.Throws<InvalidOperationException>(() => expectation.SetActual(Fake.Int));
             Assert.That(ex.Message, Is.EqualTo("Actual value has been already specified"));
             ex = Assert.Throws<InvalidOperationException>(() => expectation.SetActual(Fake.Int()));
             Assert.That(ex.Message, Is.EqualTo("Actual value has been already specified"));
@@ -121,7 +121,7 @@ namespace LightBDD.Framework.UnitTests.Parameters
         public void SetActualAsync_should_be_allowed_once()
         {
             Verifiable<int> expectation = Fake.Int();
-            expectation.SetActual(() => Fake.Int());
+            expectation.SetActual(Fake.Int);
             var ex = Assert.ThrowsAsync<InvalidOperationException>(() => expectation.SetActualAsync(() => Task.FromResult(Fake.Int())));
             Assert.That(ex.Message, Is.EqualTo("Actual value has been already specified"));
         }

--- a/test/LightBDD.Framework.UnitTests/Resources/ResourcePool_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Resources/ResourcePool_tests.cs
@@ -124,7 +124,7 @@ namespace LightBDD.Framework.UnitTests.Resources
             argumentException = Assert.Throws<ArgumentException>(() => new ResourcePool<string>(null, true));
             Assert.That(argumentException.Message, Does.StartWith("At least one resource has to be provided"));
 
-            argumentException = Assert.Throws<ArgumentException>(() => new ResourcePool<string>(new string[0]));
+            argumentException = Assert.Throws<ArgumentException>(() => new ResourcePool<string>(Array.Empty<string>()));
             Assert.That(argumentException.Message, Does.StartWith("At least one resource has to be provided"));
         }
 

--- a/test/LightBDD.Framework.UnitTests/Resources/ResourcePool_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Resources/ResourcePool_tests.cs
@@ -267,7 +267,7 @@ namespace LightBDD.Framework.UnitTests.Resources
 
         class InstanceHolder
         {
-            public ConcurrentQueue<Mock<IDisposable>> Instances { get; } = new ConcurrentQueue<Mock<IDisposable>>();
+            public ConcurrentQueue<Mock<IDisposable>> Instances { get; } = new();
 
             public IDisposable CreateInstance()
             {

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Compact/Compact_scenario_runner_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Compact/Compact_scenario_runner_tests.cs
@@ -95,7 +95,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Compact
 
         class MyContext
         {
-            public readonly List<string> Executed = new List<string>();
+            public readonly List<string> Executed = new();
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_hierarchical_execution_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Extended/Extended_scenario_runner_hierarchical_execution_tests.cs
@@ -52,7 +52,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Extended
         {
             CompositeStep group = null;
             Assert.DoesNotThrow(() => group = new TestableCompositeStepBuilder()
-                .AddAsyncSteps(_ => null as Task)
+                .AddAsyncSteps(_ => null)
                 .Build());
 
             Assert.That(group.SubSteps.Any(s => !s.IsValid), Is.True);

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_integration_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Fluent/Fluent_scenario_integration_tests.cs
@@ -11,7 +11,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Fluent
     [TestFixture]
     public class Fluent_scenario_integration_tests : Steps
     {
-        private readonly ConcurrentQueue<int> _numbers = new ConcurrentQueue<int>();
+        private readonly ConcurrentQueue<int> _numbers = new();
         private IBddRunner _runner;
 
         [SetUp]

--- a/test/LightBDD.Framework.UnitTests/Scenarios/Helpers/ScenarioMocks.cs
+++ b/test/LightBDD.Framework.UnitTests/Scenarios/Helpers/ScenarioMocks.cs
@@ -28,7 +28,7 @@ namespace LightBDD.Framework.UnitTests.Scenarios.Helpers
             return runner.Object;
         }
 
-        public static Mock<ICoreScenarioBuilder> CreateScenarioBuilder() => new Mock<ICoreScenarioBuilder>();
+        public static Mock<ICoreScenarioBuilder> CreateScenarioBuilder() => new();
 
         public static List<StepDescriptor> ExpectAddSteps(this Mock<ICoreScenarioBuilder> builder)
         {

--- a/test/LightBDD.MsTest3.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.MsTest3.UnitTests/ConfiguredLightBddScope.cs
@@ -9,7 +9,7 @@ namespace LightBDD.MsTest3.UnitTests
     [TestClass]
     public class ConfiguredLightBddScope
     {
-        public static readonly ConcurrentQueue<string> CapturedNotifications = new ConcurrentQueue<string>();
+        public static readonly ConcurrentQueue<string> CapturedNotifications = new();
 
         [AssemblyInitialize]
         public static void Setup(TestContext testContext)

--- a/test/LightBDD.NUnit3.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.NUnit3.UnitTests/ConfiguredLightBddScope.cs
@@ -9,7 +9,7 @@ namespace LightBDD.NUnit3.UnitTests
 {
     internal class ConfiguredLightBddScope : LightBddScopeAttribute
     {
-        public static readonly ConcurrentQueue<string> CapturedNotifications = new ConcurrentQueue<string>();
+        public static readonly ConcurrentQueue<string> CapturedNotifications = new();
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
             configuration.ReportWritersConfiguration()

--- a/test/LightBDD.UnitTests.Helpers/Fake.cs
+++ b/test/LightBDD.UnitTests.Helpers/Fake.cs
@@ -4,7 +4,7 @@ namespace LightBDD.UnitTests.Helpers
 {
     public class Fake
     {
-        private static readonly RandomValueSettings Settings = new RandomValueSettings { LengthOfCollection = 2 };
+        private static readonly RandomValueSettings Settings = new() { LengthOfCollection = 2 };
         public static T Object<T>() where T : new() => RandomValue.Object<T>(Settings);
         public static string String() => RandomValue.String();
         public static int Int() => RandomValue.Int();

--- a/test/LightBDD.UnitTests.Helpers/LightBDD.UnitTests.Helpers.csproj
+++ b/test/LightBDD.UnitTests.Helpers/LightBDD.UnitTests.Helpers.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="RandomTestValues" Version="2.1.1" />
   </ItemGroup>
 

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -134,8 +134,8 @@ namespace LightBDD.UnitTests.Helpers
             return new TestScenarioInfo
             {
                 Name = name,
-                Labels = label != null ? new[] { label } : new string[0],
-                Categories = categories ?? new string[0]
+                Labels = label != null ? new[] { label } : Array.Empty<string>(),
+                Categories = categories ?? Array.Empty<string>()
             };
         }
 
@@ -211,7 +211,7 @@ namespace LightBDD.UnitTests.Helpers
             {
                 Name = CreateNameInfo(name),
                 Description = description,
-                Labels = label != null ? new[] { label } : new string[0]
+                Labels = label != null ? new[] { label } : Array.Empty<string>()
             };
         }
 
@@ -284,10 +284,10 @@ namespace LightBDD.UnitTests.Helpers
 
             IEnumerable<FileAttachment> IStepResult.FileAttachments => FileAttachments;
 
-            public IParameterResult[] Parameters { get; set; } = new IParameterResult[0];
-            public TestStepResult[] SubSteps { get; set; } = new TestStepResult[0];
-            public string[] Comments { get; set; } = new string[0];
-            public FileAttachment[] FileAttachments { get; set; } = new FileAttachment[0];
+            public IParameterResult[] Parameters { get; set; } = Array.Empty<IParameterResult>();
+            public TestStepResult[] SubSteps { get; set; } = Array.Empty<TestStepResult>();
+            public string[] Comments { get; set; } = Array.Empty<string>();
+            public FileAttachment[] FileAttachments { get; set; } = Array.Empty<FileAttachment>();
         }
 
         public class TestStepInfo : IStepInfo

--- a/test/LightBDD.UnitTests.Helpers/TestResults.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestResults.cs
@@ -404,8 +404,8 @@ namespace LightBDD.UnitTests.Helpers
             IReadOnlyList<ITabularParameterColumn> ITabularParameterDetails.Columns => Columns;
             IReadOnlyList<ITabularParameterRow> ITabularParameterDetails.Rows => Rows;
 
-            public List<TestTabularParameterColumn> Columns { get; } = new List<TestTabularParameterColumn>();
-            public List<TestTabularParameterRow> Rows { get; } = new List<TestTabularParameterRow>();
+            public List<TestTabularParameterColumn> Columns { get; } = new();
+            public List<TestTabularParameterRow> Rows { get; } = new();
         }
 
         public class TestTabularParameterRow : ITabularParameterRow

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepCommentHelper.cs
@@ -9,7 +9,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
 {
     public class StepCommentHelper : IStepDecorator
     {
-        public static readonly AsyncLocal<IStep> CurrentStep = new AsyncLocal<IStep>();
+        public static readonly AsyncLocal<IStep> CurrentStep = new();
 
         public static void Comment(string commentReason)
         {

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestableIntegrationContextBuilder.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/TestableIntegrationContextBuilder.cs
@@ -13,7 +13,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
 {
     public class TestableIntegrationContextBuilder
     {
-        private readonly LightBddConfiguration _configuration = new LightBddConfiguration();
+        private readonly LightBddConfiguration _configuration = new();
         private Func<Exception, ExecutionStatus> _exceptionToStatusMapper;
 
         public TestableIntegrationContextBuilder WithNameFormatter(INameFormatter formatter)

--- a/test/LightBDD.XUnit2.IntegrationTests/Helpers/ScenarioProgressCapture.cs
+++ b/test/LightBDD.XUnit2.IntegrationTests/Helpers/ScenarioProgressCapture.cs
@@ -8,9 +8,9 @@ namespace LightBDD.XUnit2.IntegrationTests.Helpers
 {
     public class ScenarioProgressCapture : IProgressNotifier
     {
-        private readonly ConcurrentQueue<IScenarioResult> _results = new ConcurrentQueue<IScenarioResult>();
+        private readonly ConcurrentQueue<IScenarioResult> _results = new();
         public IEnumerable<IScenarioResult> Results => _results;
-        public static ScenarioProgressCapture Instance { get; } = new ScenarioProgressCapture();
+        public static ScenarioProgressCapture Instance { get; } = new();
 
         public void Notify(ProgressEvent e)
         {

--- a/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
+++ b/test/LightBDD.XUnit2.IntegrationTests/LightBDD.XUnit2.IntegrationTests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LightBDD.XUnit2.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.XUnit2.UnitTests/ConfiguredLightBddScope.cs
@@ -9,7 +9,7 @@ namespace LightBDD.XUnit2.UnitTests
 {
     internal class ConfiguredLightBddScope : LightBddScopeAttribute
     {
-        public static readonly ConcurrentQueue<string> CapturedNotifications = new ConcurrentQueue<string>();
+        public static readonly ConcurrentQueue<string> CapturedNotifications = new();
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
             configuration.ReportWritersConfiguration()

--- a/test/LightBDD.XUnit2.UnitTests/Cross_domain_tests.cs
+++ b/test/LightBDD.XUnit2.UnitTests/Cross_domain_tests.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using LightBDD.Framework;
 using LightBDD.Framework.Scenarios;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace LightBDD.XUnit2.UnitTests
 {

--- a/test/LightBDD.XUnit2.UnitTests/LightBDD.XUnit2.UnitTests.csproj
+++ b/test/LightBDD.XUnit2.UnitTests/LightBDD.XUnit2.UnitTests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #294

List of changes:
- increased minimum supported NetFramework to 462
- updated LightBDD.XUnit2 xunit version to 2.4.2
- updated LightBDD.Framework to use System.Text.Json 6.0.8 and System.Collections.Immutable 6.0.0
- updated VSIX project dependencies
- updated example project dependencies to the newest
- updated internal dependencies to the newest (test projects)
- code cleanup

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
