### PR TITLE
#344 Allowed IReportFormatter and IGlobalResourceSetUp implementations to use LightBDDConfigurationAware base

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,7 @@ Version 3.8.0
 ----------------------------------------
 + #338 (LightBDD.Framework)(New) Added ScenarioDescriptionAttribute to decorate scenarios with description and updated ReportFormatters to include it
 + #338 Updated XmlReportFormatterSchema.xsd to v2.2 with support for Scenario Description
++ #344 (LightBDD.Core)(Change) Allowed IReportFormatter and IGlobalResourceSetUp implementations to use LightBDDConfigurationAware base
 
 Version 3.7.0
 ----------------------------------------

--- a/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
+++ b/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
@@ -18,6 +18,7 @@ namespace LightBDD.Core.Execution.Coordination
         /// Feature coordinator instance.
         /// </summary>
         protected static FeatureCoordinator Instance { get; private set; }
+        private bool _disposing = false;
         private readonly IFeatureAggregator _featureAggregator;
         /// <summary>
         /// Runner factory.
@@ -113,14 +114,21 @@ namespace LightBDD.Core.Execution.Coordination
         /// </summary>
         public void Dispose()
         {
-            if (IsDisposed)
+            if (IsDisposed || _disposing)
                 return;
 
-            IsDisposed = true;
-            CollectFeatureResults();
-            UninstallSelf();
-            _featureAggregator.Dispose();
-            RunnerRepository.Dispose();
+            _disposing = true;
+            try
+            {
+                CollectFeatureResults();
+                _featureAggregator.Dispose();
+                RunnerRepository.Dispose();
+            }
+            finally
+            {
+                UninstallSelf();
+                IsDisposed = true;
+            }
         }
 
         private void CollectFeatureResults()

--- a/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
+++ b/src/LightBDD.Core/Execution/Coordination/FeatureCoordinator.cs
@@ -117,8 +117,8 @@ namespace LightBDD.Core.Execution.Coordination
                 return;
 
             IsDisposed = true;
-            UninstallSelf();
             CollectFeatureResults();
+            UninstallSelf();
             _featureAggregator.Dispose();
             RunnerRepository.Dispose();
         }


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #344

List of changes:
- (LightBDD.Core)(Change) Allowed IReportFormatter and IGlobalResourceSetUp implementations to use LightBDDConfigurationAware base

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
