### PR TITLE
#357 Implemented BeOfType<T>() and BeCastableTo<T>()

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 LightBDD
 ===========================================
 
+Version 3.9.0
+----------------------------------------
++ #357 (LightBDD.Framework)(New) Implemented Expect.To.BeOfType() and Expect.To.BeCastableTo()
+
 Version 3.8.0
 ----------------------------------------
 + #338 (LightBDD.Framework)(New) Added ScenarioDescriptionAttribute to decorate scenarios with description. Updated ReportFormatters and ProgressNotifiers to include it when provided.

--- a/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
+++ b/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
@@ -349,6 +349,28 @@ namespace LightBDD.Framework.Expectations
         }
 
         /// <summary>
+        /// Creates expectation for values to be castable to <typeparamref name="T"/> type.
+        /// </summary>
+        /// <typeparam name="T">Expectation type</typeparam>
+        /// <param name="composer">Composer</param>
+        /// <returns>Expectation</returns>
+        public static Expectation<object> BeCastableTo<T>(this IExpectationComposer composer)
+        {
+            return composer.Compose(CastableExpectation<T>.Instance);
+        }
+
+        /// <summary>
+        /// Creates expectation for values to be of <typeparamref name="T"/> type.
+        /// </summary>
+        /// <typeparam name="T">Expectation type</typeparam>
+        /// <param name="composer">Composer</param>
+        /// <returns>Expectation</returns>
+        public static Expectation<object> BeOfType<T>(this IExpectationComposer composer)
+        {
+            return composer.Compose(TypeExpectation<T>.Instance);
+        }
+
+        /// <summary>
         /// Creates a base type expectation for given expectation, that internally will cast <typeparamref name="TBase"/> to <typeparamref name="TDerived"/> during evaluation.
         ///
         /// Example usage: <code>Expect.To.MatchRegex("[0-9]+").CastFrom(Expect.Type&lt;object&gt;)</code>

--- a/src/LightBDD.Framework/Expectations/Implementation/CastHelper.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/CastHelper.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+using System;
+
+namespace LightBDD.Framework.Expectations.Implementation;
+
+internal static class CastHelper
+{
+    public static bool IsAssignableTo<T>(object? value) => value is T || value is null && IsNullAssignableTo<T>();
+    private static bool IsNullAssignableTo<T>() => !typeof(T).IsValueType || (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>));
+
+    public static bool TryConvertWithoutPrecisionLoss<T>(object value, out T o)
+    {
+        o = (T)Convert.ChangeType(value, typeof(T));
+        var castBack = Convert.ChangeType(o, value.GetType());
+        return Equals(value, castBack);
+    }
+}

--- a/src/LightBDD.Framework/Expectations/Implementation/CastableExpectation.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/CastableExpectation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using LightBDD.Core.Formatting.Values;
+
+namespace LightBDD.Framework.Expectations.Implementation;
+
+internal class CastableExpectation<T> : Expectation<object>
+{
+    public static readonly CastableExpectation<T> Instance = new();
+
+    public override ExpectationResult Verify(object value, IValueFormattingService formattingService)
+    {
+        if (CastHelper.IsAssignableTo<T>(value))
+            return ExpectationResult.Success;
+
+        if (NumericTypeHelper.IsNumeric(typeof(T)) && NumericTypeHelper.IsNumeric(value))
+        {
+            try
+            {
+                if (CastHelper.TryConvertWithoutPrecisionLoss<T>(value, out _))
+                    return ExpectationResult.Success;
+                return FormatFailure(formattingService, $"got '{value.GetType().Name}' type with value '{formattingService.FormatValue(value)}' which cannot be cast without precision loss");
+            }
+            catch (Exception ex)
+            {
+                return FormatFailure(formattingService, $"got '{value.GetType().Name}' type with value '{formattingService.FormatValue(value)}' which cannot be cast: {ex.Message}");
+            }
+        }
+
+        return FormatFailure(formattingService, $"got '{value?.GetType().Name ?? formattingService.Symbols.NullValue}' type");
+    }
+
+    public override string Format(IValueFormattingService formattingService) => $"be castable to '{typeof(T).Name}'";
+}

--- a/src/LightBDD.Framework/Expectations/Implementation/NumericTypeHelper.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/NumericTypeHelper.cs
@@ -5,7 +5,7 @@ namespace LightBDD.Framework.Expectations.Implementation;
 
 internal static class NumericTypeHelper
 {
-    public static bool IsNumeric(object o)
+    public static bool IsNumeric(object? o)
     {
         return o is double or float or decimal or byte or sbyte or int or uint or long or ulong or short or ushort;
     }

--- a/src/LightBDD.Framework/Expectations/Implementation/TypeExpectation.cs
+++ b/src/LightBDD.Framework/Expectations/Implementation/TypeExpectation.cs
@@ -1,0 +1,20 @@
+﻿using LightBDD.Core.Formatting.Values;
+
+namespace LightBDD.Framework.Expectations.Implementation;
+
+internal class TypeExpectation<T> : Expectation<object>
+{
+    public static readonly TypeExpectation<T> Instance = new();
+
+    public override ExpectationResult Verify(object value, IValueFormattingService formattingService)
+    {
+        var actualType = value?.GetType();
+
+        if (actualType == typeof(T))
+            return ExpectationResult.Success;
+
+        return FormatFailure(formattingService, $"got type '{actualType?.Name ?? formattingService.Symbols.NullValue}'");
+    }
+
+    public override string Format(IValueFormattingService formattingService) => $"be of type '{typeof(T).Name}'";
+}

--- a/src/LightBDD.Framework/LightBDD.Framework.csproj
+++ b/src/LightBDD.Framework/LightBDD.Framework.csproj
@@ -31,7 +31,7 @@ High level features:
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="System.Text.Json" Version="6.0.8" Condition="'$(TargetFramework)' != 'net6'" />
+	  <PackageReference Include="System.Text.Json" Version="6.0.11" Condition="'$(TargetFramework)' != 'net6'" />
 	  <PackageReference Include="System.Collections.Immutable" Version="6.0.0" Condition="'$(TargetFramework)' != 'net6'" />
   </ItemGroup>
 

--- a/test/LightBDD.Framework.UnitTests/Expectations/BeCastableTo_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/BeCastableTo_tests.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using LightBDD.Framework.Expectations;
+using LightBDD.Framework.Formatting.Values;
+using LightBDD.Framework.UnitTests.Expectations.Helpers;
+using NUnit.Framework;
+using Shouldly;
+
+namespace LightBDD.Framework.UnitTests.Expectations;
+
+[TestFixture]
+public class BeCastableTo_tests : ExpectationTests
+{
+    protected override IEnumerable<IExpectationScenario> GetScenarios()
+    {
+        yield return new ExpectationScenario<object>(
+                "be castable to 'String'",
+                x => x.BeCastableTo<string>())
+            .WithMatchingValues("abc", "", null)
+            .WithNotMatchingValue('c', "expected: be castable to 'String', but got 'Char' type");
+
+        yield return new ExpectationScenario<object>(
+                "be castable to 'Int32'",
+                x => x.BeCastableTo<int>())
+            .WithMatchingValues(5, 5L, (byte)5, 5f, 5d, 5m, (int?)5)
+            .WithNotMatchingValue("", "expected: be castable to 'Int32', but got 'String' type");
+    }
+
+    [Test]
+    public void Casting_from_null_to_value_type_should_fail()
+    {
+        var result = Expect.To.BeCastableTo<int>().Verify(null, ValueFormattingServices.Current);
+        Assert.False(result);
+        Assert.That(result.Message, Is.EqualTo("expected: be castable to 'Int32', but got '<null>' type"));
+    }
+
+    [Test]
+    public void Casting_of_numerics_with_overflow_should_fail()
+    {
+        var result = Expect.To.BeCastableTo<int>().Verify(long.MaxValue, ValueFormattingServices.Current);
+        Assert.False(result);
+        result.Message.ShouldBe("expected: be castable to 'Int32', but got 'Int64' type with value '9223372036854775807' which cannot be cast: Value was either too large or too small for an Int32.");
+    }
+
+    [Test]
+    public void Casting_of_numerics_with_precision_loss_should_fail()
+    {
+        var result = Expect.To.BeCastableTo<int>().Verify(5.14, ValueFormattingServices.Current);
+        Assert.False(result);
+        result.Message.ShouldBe("expected: be castable to 'Int32', but got 'Double' type with value '5.14' which cannot be cast without precision loss");
+    }
+
+    [Test]
+    public void Casting_null_to_Nullable()
+    {
+        var result = Expect.To.BeCastableTo<int?>().Verify(null, ValueFormattingServices.Current);
+        Assert.True(result);
+    }
+}

--- a/test/LightBDD.Framework.UnitTests/Expectations/BeOfType_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/BeOfType_tests.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using LightBDD.Framework.Expectations;
+using LightBDD.Framework.UnitTests.Expectations.Helpers;
+using NUnit.Framework;
+
+namespace LightBDD.Framework.UnitTests.Expectations;
+
+[TestFixture]
+public class BeOfType_tests : ExpectationTests
+{
+    protected override IEnumerable<IExpectationScenario> GetScenarios()
+    {
+        yield return new ExpectationScenario<object>(
+                "be of type 'String'",
+                x => x.BeOfType<string>())
+            .WithMatchingValues("abc", "")
+            .WithNotMatchingValue(null, "expected: be of type 'String', but got type '<null>'")
+            .WithNotMatchingValue('c', "expected: be of type 'String', but got type 'Char'");
+    }
+}


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #357

List of changes:
- Implemented BeOfType<T>() and BeCastableTo<T>()

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
