### PR TITLE
Changed StepExecution.Current.Bypass()/IgnoreScenario() to validate that they are called within running scenario

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,7 @@ Version 3.9.0
 ----------------------------------------
 + #357 (LightBDD.Framework)(New) Implemented Expect.To.BeOfType() and Expect.To.BeCastableTo()
 + #352 (LightBDD.XUnit2)(Change) Obsoleted FeatureFixture constructor that accepts ITestOutputHelper in favour of parameterless ctor
++ #353 (LightBDD.Framework)(Change) Changed StepExecution.Current.Bypass() and StepExecution.Current.IgnoreScenario() to validate that they are called within running scenario
 
 Version 3.8.0
 ----------------------------------------

--- a/src/LightBDD.Core/ExecutionContext/Implementation/CurrentStepProperty.cs
+++ b/src/LightBDD.Core/ExecutionContext/Implementation/CurrentStepProperty.cs
@@ -8,7 +8,7 @@ namespace LightBDD.Core.ExecutionContext.Implementation
     {
         private readonly Stack<IStep> _steps = new();
 
-        public IStep Step => _steps.Peek() ?? throw new InvalidOperationException("Current task is not executing any scenario steps. Ensure that feature is used within task running scenario step.");
+        public IStep Step => _steps.Count > 0 ? _steps.Peek() : null;
 
         public void Stash(IStep step)
         {
@@ -19,7 +19,7 @@ namespace LightBDD.Core.ExecutionContext.Implementation
         {
             var last = _steps.Pop();
             if (last != step)
-                throw new InvalidOperationException("$Expected {step} to be current step but got {last}. Please report this issue on LightBDD project page.");
+                throw new InvalidOperationException($"Expected {step} to be current step but got {last}. Please report this issue on LightBDD project page.");
         }
     }
 }

--- a/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
+++ b/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
@@ -45,26 +45,26 @@ namespace LightBDD.Core.ExecutionContext
         /// Returns currently executed step.
         /// <exception cref="InvalidOperationException">Thrown if no step is executed by current task.</exception>
         /// </summary>
-        public static IStep CurrentStep => Current.Get<CurrentStepProperty>().Step ?? throw new InvalidOperationException("Current task is not executing any scenario steps. Ensure that feature is used within task running scenario step.");
+        public static IStep CurrentStep => ValidateStepScope();
 
         /// <summary>
         /// Returns currently executed scenario.
         /// <exception cref="InvalidOperationException">Thrown if no scenario is executed by current task or if scenario initialization is not complete.</exception>
         /// </summary>
-        public static IScenario CurrentScenario => Current.Get<CurrentScenarioProperty>().Scenario ?? throw new InvalidOperationException("The current task does not run any initialized scenario. Ensure that feature is used within task running fully initialized scenario.");
+        public static IScenario CurrentScenario => ValidateScenarioScope();
 
         /// <summary>
         /// Validates that current task is in step execution scope
         /// <exception cref="InvalidOperationException">Thrown if no step is executed by current task.</exception>
         /// </summary>
         /// <returns>Current Step</returns>
-        public static IStep ValidateStepScope() => CurrentStep;
+        public static IStep ValidateStepScope() => Current.Get<CurrentStepProperty>().Step ?? throw new InvalidOperationException("Current task is not executing any scenario steps. Ensure that feature is used within task running scenario step.");
         /// <summary>
         /// Validates that current task is in scenario execution scope
         /// <exception cref="InvalidOperationException">Thrown if no scenario is executed by current task or if scenario initialization is not complete.</exception>
         /// </summary>
         /// <returns>Current Step</returns>
-        public static IScenario ValidateScenarioScope() => CurrentScenario;
+        public static IScenario ValidateScenarioScope() => Current.Get<CurrentScenarioProperty>().Scenario ?? throw new InvalidOperationException("The current task does not run any initialized scenario. Ensure that feature is used within task running fully initialized scenario.");
 
         /// <summary>
         /// Returns currently executed scenario fixture object if present or <c>null</c> if no scenario is currently executed.<br/>

--- a/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
+++ b/src/LightBDD.Core/ExecutionContext/ScenarioExecutionContext.cs
@@ -16,7 +16,7 @@ namespace LightBDD.Core.ExecutionContext
 
         /// <summary>
         /// Provides property value of <typeparamref name="TProperty"/> type that is stored in scenario context.
-        /// If such property does not exists yet, a new instance will be registered in context and returned.
+        /// If such property does not exist yet, a new instance will be registered in context and returned.
         /// </summary>
         /// <typeparam name="TProperty">Property type to retrieve.</typeparam>
         /// <returns>Property object.</returns>
@@ -45,13 +45,26 @@ namespace LightBDD.Core.ExecutionContext
         /// Returns currently executed step.
         /// <exception cref="InvalidOperationException">Thrown if no step is executed by current task.</exception>
         /// </summary>
-        public static IStep CurrentStep => Current.Get<CurrentStepProperty>().Step;
+        public static IStep CurrentStep => Current.Get<CurrentStepProperty>().Step ?? throw new InvalidOperationException("Current task is not executing any scenario steps. Ensure that feature is used within task running scenario step.");
 
         /// <summary>
         /// Returns currently executed scenario.
         /// <exception cref="InvalidOperationException">Thrown if no scenario is executed by current task or if scenario initialization is not complete.</exception>
         /// </summary>
         public static IScenario CurrentScenario => Current.Get<CurrentScenarioProperty>().Scenario ?? throw new InvalidOperationException("The current task does not run any initialized scenario. Ensure that feature is used within task running fully initialized scenario.");
+
+        /// <summary>
+        /// Validates that current task is in step execution scope
+        /// <exception cref="InvalidOperationException">Thrown if no step is executed by current task.</exception>
+        /// </summary>
+        /// <returns>Current Step</returns>
+        public static IStep ValidateStepScope() => CurrentStep;
+        /// <summary>
+        /// Validates that current task is in scenario execution scope
+        /// <exception cref="InvalidOperationException">Thrown if no scenario is executed by current task or if scenario initialization is not complete.</exception>
+        /// </summary>
+        /// <returns>Current Step</returns>
+        public static IScenario ValidateScenarioScope() => CurrentScenario;
 
         /// <summary>
         /// Returns currently executed scenario fixture object if present or <c>null</c> if no scenario is currently executed.<br/>

--- a/src/LightBDD.Fixie3/StepExecutionExtensions.cs
+++ b/src/LightBDD.Fixie3/StepExecutionExtensions.cs
@@ -1,3 +1,4 @@
+using LightBDD.Core.ExecutionContext;
 using LightBDD.Core.Results;
 using LightBDD.Framework;
 
@@ -16,6 +17,7 @@ namespace LightBDD.Fixie3
         /// <param name="reason">Ignore reason.</param>
         public static void IgnoreScenario(this StepExecution execution, string reason)
         {
+            ScenarioExecutionContext.ValidateScenarioScope();
             throw new IgnoreException(reason);
         }
     }

--- a/src/LightBDD.Framework/StepExecution.cs
+++ b/src/LightBDD.Framework/StepExecution.cs
@@ -35,13 +35,17 @@ namespace LightBDD.Framework
         /// The <see cref="Bypass"/>() method could be used in situations when:
         /// <list type="bullet">
         /// <item><description>It is not possible to implement given step at the moment (no required API is implemented yet), but all other steps are precise enough to prove that scenario is successful, i.e. situation when scenario checks overall and detailed cost of product and one of price component cannot be retrieved.</description></item>
-        /// <item><description>Step implementation does not exists, but it is possible to simulate it, so further steps can be executed, i.e. end-to-end tests, where the middle component does not exist yet.</description></item>
+        /// <item><description>Step implementation does not exist, but it is possible to simulate it, so further steps can be executed, i.e. end-to-end tests, where the middle component does not exist yet.</description></item>
         /// <item><description>The required API is not exposed yet, but it is possible to implement a workaround like direct data insert to database.</description></item>
         /// </list>
         /// </summary>
         /// <param name="reason">Bypass reason.</param>
         /// <exception cref="StepBypassException">Bypass exception used to control scenario execution.</exception>
-        public void Bypass(string reason) => throw new StepBypassException(reason);
+        public void Bypass(string reason)
+        {
+            ScenarioExecutionContext.ValidateScenarioScope();
+            throw new StepBypassException(reason);
+        }
 
         /// <summary>
         /// Comments currently executed step with a <paramref name="comment"/> text.

--- a/src/LightBDD.XUnit2/StepExecutionExtensions.cs
+++ b/src/LightBDD.XUnit2/StepExecutionExtensions.cs
@@ -1,3 +1,4 @@
+using LightBDD.Core.ExecutionContext;
 using LightBDD.Core.Results;
 using LightBDD.Framework;
 using LightBDD.XUnit2.Implementation.Customization;
@@ -17,6 +18,7 @@ namespace LightBDD.XUnit2
         /// <param name="reason">Ignore reason.</param>
         public static void IgnoreScenario(this StepExecution execution, string reason)
         {
+            ScenarioExecutionContext.ValidateScenarioScope();
             throw new IgnoreException(reason);
         }
     }

--- a/test/LightBDD.Core.UnitTests/StepExecution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/StepExecution_tests.cs
@@ -1,5 +1,6 @@
-﻿using LightBDD.Core.Execution;
+﻿using System;
 using LightBDD.Framework;
+using LightBDD.UnitTests.Helpers.TestableIntegration;
 using NUnit.Framework;
 
 namespace LightBDD.Core.UnitTests
@@ -8,12 +9,17 @@ namespace LightBDD.Core.UnitTests
     public class StepExecution_tests
     {
         [Test]
-        public void Bypass_should_throw_StepBypassException()
+        public void Bypass_should_fail_when_called_outside_of_step()
         {
-            var bypassReason = "reason";
+            var exception = Assert.Throws<InvalidOperationException>(() => StepExecution.Current.Bypass("reason"));
+            Assert.That(exception!.Message, Does.StartWith("Current task is not executing any scenarios."));
+        }
 
-            var exception = Assert.Throws<StepBypassException>(() => StepExecution.Current.Bypass(bypassReason));
-            Assert.That(exception.Message, Is.EqualTo(bypassReason));
+        [Test]
+        public void IgnoreScenario_should_fail_when_called_outside_of_step()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => StepExecution.Current.IgnoreScenario("reason"));
+            Assert.That(exception!.Message, Does.StartWith("Current task is not executing any scenarios."));
         }
     }
 }

--- a/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepExecutionExtensions.cs
+++ b/test/LightBDD.UnitTests.Helpers/TestableIntegration/StepExecutionExtensions.cs
@@ -1,3 +1,4 @@
+using LightBDD.Core.ExecutionContext;
 using LightBDD.Framework;
 
 namespace LightBDD.UnitTests.Helpers.TestableIntegration
@@ -6,6 +7,7 @@ namespace LightBDD.UnitTests.Helpers.TestableIntegration
     {
         public static void IgnoreScenario(this StepExecution execution, string reason)
         {
+            ScenarioExecutionContext.ValidateScenarioScope();
             throw new CustomIgnoreException(reason);
         }
     }


### PR DESCRIPTION
#### Details

Issue reference: #353 

List of changes:
- (LightBDD.Framework)(Change) Changed StepExecution.Current.Bypass() and StepExecution.Current.IgnoreScenario() to validate that they are called within running scenario

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
