### PR TITLE
#351 Updated Expect.To.BeLike()/BeLikeIgnoreCase() to match multiline text and added Expect.To.Match(string, RegexOptions) overload

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,8 @@ Version 3.9.0
 + #357 (LightBDD.Framework)(New) Implemented Expect.To.BeOfType() and Expect.To.BeCastableTo()
 + #352 (LightBDD.XUnit2)(Change) Obsoleted FeatureFixture constructor that accepts ITestOutputHelper in favour of parameterless ctor
 + #353 (LightBDD.Framework)(Change) Changed StepExecution.Current.Bypass() and StepExecution.Current.IgnoreScenario() to validate that they are called within running scenario
++ #351 (LightBDD.Framework)(Change) Updated Expect.To.BeLike()/BeLikeIgnoreCase() to match multiline text
++ #351 (LightBDD.Framework)(New) Added Expect.To.Match(string, RegexOptions) overload
 
 Version 3.8.0
 ----------------------------------------

--- a/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
+++ b/src/LightBDD.Framework/Expectations/ExpectationExtensions.cs
@@ -157,7 +157,7 @@ namespace LightBDD.Framework.Expectations
         /// <param name="pattern">Expected pattern</param>
         public static Expectation<string> BeLike(this IExpectationComposer composer, string pattern)
         {
-            return BeLike(composer, pattern, RegexOptions.None, $"like '{pattern}'");
+            return BeLike(composer, pattern, RegexOptions.Singleline, $"like '{pattern}'");
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace LightBDD.Framework.Expectations
         /// <param name="pattern">Expected pattern</param>
         public static Expectation<string> BeLikeIgnoreCase(this IExpectationComposer composer, string pattern)
         {
-            return BeLike(composer, pattern, RegexOptions.IgnoreCase, $"like '{pattern}' ignore case");
+            return BeLike(composer, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline, $"like '{pattern}' ignore case");
         }
 
         private static Expectation<string> BeLike(IExpectationComposer composer, string pattern, RegexOptions options, string format)
@@ -191,7 +191,18 @@ namespace LightBDD.Framework.Expectations
         /// <param name="pattern">Expected pattern</param>
         public static Expectation<string> Match(this IExpectationComposer composer, string pattern)
         {
-            return Match(composer, pattern, RegexOptions.None, $"matches '{pattern}'");
+            return Match(composer, pattern, RegexOptions.None);
+        }
+
+        /// <summary>
+        /// Creates expectation for strings to match regex pattern specified by <paramref name="pattern"/> parameter.
+        /// </summary>
+        /// <param name="composer">Composer</param>
+        /// <param name="pattern">Expected pattern</param>
+        /// <param name="options">Regex options</param>
+        public static Expectation<string> Match(this IExpectationComposer composer, string pattern, RegexOptions options)
+        {
+            return Match(composer, pattern, options, $"matches '{pattern}'");
         }
 
         /// <summary>

--- a/test/LightBDD.Framework.UnitTests/Expectations/BeLikeExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/BeLikeExpectation_tests.cs
@@ -32,6 +32,17 @@ namespace LightBDD.Framework.UnitTests.Expectations
                 .WithNotMatchingValue("no1", "expected: like 'no###' ignore case, but got: 'no1'")
                 .WithNotMatchingValue("no1234", "expected: like 'no###' ignore case, but got: 'no1234'")
                 .WithNotMatchingValue("noabc", "expected: like 'no###' ignore case, but got: 'noabc'");
+
+            yield return new ExpectationScenario<string>("like '<p>*</p>'",
+                    x => x.BeLike("<p>*</p>"))
+                .WithMatchingValues("<p>some text</p>", "<p>some\nmultiline\r\ntext</p>")
+                .WithNotMatchingValue("<span>text</span>", "expected: like '<p>*</p>', but got: '<span>text</span>'")
+                .WithNotMatchingValue("<P>text</P>", "expected: like '<p>*</p>', but got: '<P>text</P>'");
+
+            yield return new ExpectationScenario<string>("like '<p>*</p>' ignore case",
+                    x => x.BeLikeIgnoreCase("<p>*</p>"))
+                .WithMatchingValues("<p>some text</p>", "<p>some\nmultiline\r\ntext</p>", "<P>text</P>")
+                .WithNotMatchingValue("<span>text</span>", "expected: like '<p>*</p>' ignore case, but got: '<span>text</span>'");
         }
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Expectations/Helpers/ExpectationScenario.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/Helpers/ExpectationScenario.cs
@@ -71,15 +71,15 @@ namespace LightBDD.Framework.UnitTests.Expectations.Helpers
         private void AssertSuccess(IExpectation<T> expectation, T value)
         {
             var result = expectation.Verify(value, ValueFormattingServices.Current);
-            Assert.True(result, $"{value}");
-            Assert.IsEmpty(result.Message, $"{value}");
+            Assert.True(result, $"{expectation}: {value}");
+            Assert.IsEmpty(result.Message, $"{expectation}: {value}");
         }
 
         private void AssertFailure(IExpectation<T> expectation, T value, string expectedMessage)
         {
             var result = expectation.Verify(value, ValueFormattingServices.Current);
-            Assert.False(result, $"{value}");
-            Assert.That(result.Message.Replace("\r", ""), Is.EqualTo(expectedMessage.Replace("\r", "")), $"{value}");
+            Assert.False(result, $"{expectation}: {value}");
+            Assert.That(result.Message.Replace("\r", ""), Is.EqualTo(expectedMessage.Replace("\r", "")), $"{expectation}: {value}");
         }
 
         private void AssertFormat(IExpectation<T> expectation, string format)

--- a/test/LightBDD.Framework.UnitTests/Expectations/MatchExpectation_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Expectations/MatchExpectation_tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using LightBDD.Framework.Expectations;
 using LightBDD.Framework.UnitTests.Expectations.Helpers;
 using NUnit.Framework;
@@ -20,7 +21,6 @@ namespace LightBDD.Framework.UnitTests.Expectations
                 .WithNotMatchingValue("afile1.txt", "expected: matches 'fi.e[0-9]+.txt', but got: 'afile1.txt'")
                 .WithNotMatchingValue("fine123.txt2", "expected: matches 'fi.e[0-9]+.txt', but got: 'fine123.txt2'");
 
-
             yield return new ExpectationScenario<string>(
                     "matches 'fi.e[0-9]+.txt' ignore case",
                     x => x.MatchIgnoreCase("fi.e[0-9]+.txt"))
@@ -34,6 +34,17 @@ namespace LightBDD.Framework.UnitTests.Expectations
                     "matches '.*some-text.*'",
                     x => x.Match(".*some-text.*"))
                 .WithMatchingValues("some-text", "awesome-texture");
+
+            yield return new ExpectationScenario<string>(
+                    "matches '<p>.*</p>'",
+                    x => x.Match("<p>.*</p>"))
+                .WithMatchingValues("<p>single line</p>")
+                .WithNotMatchingValue("<p>multi\nline</p>", "expected: matches '<p>.*</p>', but got: '<p>multi\nline</p>'");
+
+            yield return new ExpectationScenario<string>(
+                    "matches '<p>.*</p>'",
+                    x => x.Match("<p>.*</p>", RegexOptions.Singleline))
+                .WithMatchingValues("<p>multi\nline</p>", "<p>single line</p>");
         }
     }
 }


### PR DESCRIPTION
#### Details

Issue reference: #351

List of changes:
+ Updated Expect.To.BeLike()/BeLikeIgnoreCase() to match multiline text
+ Added Expect.To.Match(string, RegexOptions) overload

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
