### PR TITLE
#356 Captured LightBddScope OnConfigure() failures

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,7 @@ LightBDD
 Version 3.9.0
 ----------------------------------------
 + #357 (LightBDD.Framework)(New) Implemented Expect.To.BeOfType() and Expect.To.BeCastableTo()
++ #356 (LightBDD.Core)(Change) Captured LightBddScope OnConfigure() failures
 + #352 (LightBDD.XUnit2)(Change) Obsoleted FeatureFixture constructor that accepts ITestOutputHelper in favour of parameterless ctor
 + #353 (LightBDD.Framework)(Change) Changed StepExecution.Current.Bypass() and StepExecution.Current.IgnoreScenario() to validate that they are called within running scenario
 + #351 (LightBDD.Framework)(Change) Updated Expect.To.BeLike()/BeLikeIgnoreCase() to match multiline text

--- a/src/LightBDD.Core/Configuration/ExecutionExtensionsConfiguration.cs
+++ b/src/LightBDD.Core/Configuration/ExecutionExtensionsConfiguration.cs
@@ -17,6 +17,7 @@ namespace LightBDD.Core.Configuration
 
         private readonly List<IScenarioDecorator> _scenarioExtensions = new();
         private readonly List<IStepDecorator> _stepExtensions = new();
+        private readonly List<Exception> _initializationExceptions = new();
 
         /// <summary>
         /// Collection of scenario execution extensions.
@@ -26,6 +27,11 @@ namespace LightBDD.Core.Configuration
         /// Collection of step execution extensions.
         /// </summary>
         public IEnumerable<IStepDecorator> StepDecorators => _stepExtensions;
+
+        /// <summary>
+        /// Returns captured LightBDD framework initialization exceptions. If provided, all scenarios will fail.
+        /// </summary>
+        public IReadOnlyCollection<Exception> FrameworkInitializationExceptions => _initializationExceptions;
 
         /// <summary>
         /// Enables scenario decorator of specified type.
@@ -110,7 +116,7 @@ namespace LightBDD.Core.Configuration
         /// The <paramref name="setUp"/> delegate will be executed once, before any tests are run. If multiple set up methods are registered, they will be executed in the registration order.<br/>
         /// If <paramref name="tearDown"/> delegate is specified, it will be executed once after all tests are run, but only if <paramref name="setUp"/> has been successfully run. The tear down methods are executed in reverse registration order.
         /// </summary>
-        /// <param name="activityName">Name of the set up activity</param>
+        /// <param name="activityName">Name of the set-up activity</param>
         /// <param name="setUp">Set up method</param>
         /// <param name="tearDown">Tear down method</param>
         /// <returns></returns>
@@ -126,7 +132,7 @@ namespace LightBDD.Core.Configuration
         /// The <paramref name="setUp"/> delegate will be executed once, before any tests are run. If multiple set up methods are registered, they will be executed in the registration order.<br/>
         /// If <paramref name="tearDown"/> delegate is specified, it will be executed once after all tests are run, but only if <paramref name="setUp"/> has been successfully run. The tear down methods are executed in reverse registration order.
         /// </summary>
-        /// <param name="activityName">Name of the set up activity</param>
+        /// <param name="activityName">Name of the set-up activity</param>
         /// <param name="setUp">Set up method</param>
         /// <param name="tearDown">Tear down method</param>
         /// <returns></returns>
@@ -188,6 +194,18 @@ namespace LightBDD.Core.Configuration
                     return Task.CompletedTask;
                 });
 
+            return this;
+        }
+
+        /// <summary>
+        /// Captures LightBDD framework initialization exception, which will cause all scenarios to fail.
+        /// </summary>
+        /// <param name="exception">Exception to capture</param>
+        /// <returns>Self</returns>
+        public ExecutionExtensionsConfiguration CaptureFrameworkInitializationException(Exception exception)
+        {
+            ThrowIfSealed();
+            _initializationExceptions.Add(exception);
             return this;
         }
     }

--- a/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableScenario.cs
@@ -47,6 +47,8 @@ namespace LightBDD.Core.Execution.Implementation
 
         public async Task ExecuteAsync()
         {
+            VerifyFrameworkInitialization();
+
             if (Interlocked.Exchange(ref _alreadyRun, RunValue) != NotRunValue)
                 throw new InvalidOperationException("Scenario can be run only once");
 
@@ -66,6 +68,13 @@ namespace LightBDD.Core.Execution.Implementation
             }
 
             ProcessExceptions();
+        }
+
+        private void VerifyFrameworkInitialization()
+        {
+            var initializationExceptions = _scenarioContext.IntegrationContext.ExecutionExtensions.FrameworkInitializationExceptions;
+            if (initializationExceptions.Any())
+                throw new AggregateException("LightBDD initialization failed", initializationExceptions);
         }
 
         private async Task RunScenarioAsync()

--- a/src/LightBDD.Core/Extensibility/Execution/IExecutionExtensions.cs
+++ b/src/LightBDD.Core/Extensibility/Execution/IExecutionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace LightBDD.Core.Extensibility.Execution
@@ -15,5 +16,10 @@ namespace LightBDD.Core.Extensibility.Execution
         /// Collection of step decorators.
         /// </summary>
         IEnumerable<IStepDecorator> StepDecorators { get; }
+
+        /// <summary>
+        /// Captured LightBDD framework initialization exceptions. If provided, all scenarios should fail.
+        /// </summary>
+        IReadOnlyCollection<Exception> FrameworkInitializationExceptions { get; }
     }
 }

--- a/src/LightBDD.Fixie3/LightBddScope.cs
+++ b/src/LightBDD.Fixie3/LightBddScope.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Fixie;
 using LightBDD.Core.Configuration;
@@ -69,7 +70,15 @@ namespace LightBDD.Fixie3
             configuration.ExceptionHandlingConfiguration()
                 .UpdateExceptionDetailsFormatter(new DefaultExceptionFormatter().WithTestFrameworkDefaults().Format);
 
-            OnConfigure(configuration);
+            try
+            {
+                OnConfigure(configuration);
+            }
+            catch (Exception ex)
+            {
+                configuration.ExecutionExtensionsConfiguration().CaptureFrameworkInitializationException(ex);
+            }
+
             return configuration;
         }
 

--- a/src/LightBDD.MsTest3/LightBddScope.cs
+++ b/src/LightBDD.MsTest3/LightBddScope.cs
@@ -56,7 +56,14 @@ namespace LightBDD.MsTest3
             configuration.ExceptionHandlingConfiguration()
                 .UpdateExceptionDetailsFormatter(new DefaultExceptionFormatter().WithTestFrameworkDefaults().Format);
 
-            onConfigure(configuration);
+            try
+            {
+                onConfigure(configuration);
+            }
+            catch (Exception ex)
+            {
+                configuration.ExecutionExtensionsConfiguration().CaptureFrameworkInitializationException(ex);
+            }
             return configuration;
         }
     }

--- a/src/LightBDD.NUnit3/LightBddScopeAttribute.cs
+++ b/src/LightBDD.NUnit3/LightBddScopeAttribute.cs
@@ -57,7 +57,14 @@ namespace LightBDD.NUnit3
             configuration.ExceptionHandlingConfiguration()
                 .UpdateExceptionDetailsFormatter(new DefaultExceptionFormatter().WithTestFrameworkDefaults().Format);
 
-            OnConfigure(configuration);
+            try
+            {
+                OnConfigure(configuration);
+            }
+            catch (Exception ex)
+            {
+                configuration.ExecutionExtensionsConfiguration().CaptureFrameworkInitializationException(ex);
+            }
             return configuration;
         }
 

--- a/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
+++ b/src/LightBDD.XUnit2/LightBddScopeAttribute.cs
@@ -31,7 +31,7 @@ namespace LightBDD.XUnit2
         /// <summary>
         /// Returns XUnit diagnostic MessageSink.<br/>
         /// When accessed within <seealso cref="OnSetUp"/>, <seealso cref="OnConfigure"/>, <seealso cref="OnTearDown"/> or during test execution, the current XUnit diagnostic message sink is returned.<br/>
-        /// When accessed outside of mentioned scopes, the instance of <seealso cref="NullMessageSink"/> is returned.
+        /// When accessed outside mentioned scopes, the instance of <seealso cref="NullMessageSink"/> is returned.
         /// </summary>
         protected IMessageSink DiagnosticMessageSink { get; private set; } = NullDiagnosticMessageSink;
 
@@ -81,7 +81,14 @@ namespace LightBDD.XUnit2
             configuration.ExecutionExtensionsConfiguration()
                 .EnableScenarioDecorator<TestSkippedDecorator>();
 
-            OnConfigure(configuration);
+            try
+            {
+                OnConfigure(configuration);
+            }
+            catch (Exception ex)
+            {
+                configuration.ExecutionExtensionsConfiguration().CaptureFrameworkInitializationException(ex);
+            }
             return configuration;
         }
     }

--- a/test/LightBDD.Core.UnitTests/Configuration/ExecutionExtensionsConfiguration_tests.cs
+++ b/test/LightBDD.Core.UnitTests/Configuration/ExecutionExtensionsConfiguration_tests.cs
@@ -85,6 +85,7 @@ namespace LightBDD.Core.UnitTests.Configuration
 
             Assert.Throws<InvalidOperationException>(() => cfg.EnableStepDecorator<StepDecorator2>());
             Assert.Throws<InvalidOperationException>(() => cfg.EnableScenarioDecorator<ScenarioDecorator2>());
+            Assert.Throws<InvalidOperationException>(() => cfg.CaptureFrameworkInitializationException(new Exception()));
 
             CollectionAssert.AreEquivalent(
                 new[] { typeof(ScenarioDecorator1) },
@@ -92,6 +93,19 @@ namespace LightBDD.Core.UnitTests.Configuration
             CollectionAssert.AreEquivalent(
                 new[] { typeof(StepDecorator1) },
                 cfg.StepDecorators.Select(e => e.GetType()).ToArray());
+        }
+
+        [Test]
+        public void CaptureFrameworkInitializationException_should_allow_capturing_exceptions()
+        {
+            var ex1 = new Exception("foo");
+            var ex2 = new InvalidOperationException("bar");
+            var actual = new ExecutionExtensionsConfiguration()
+                .CaptureFrameworkInitializationException(ex1)
+                .CaptureFrameworkInitializationException(ex2)
+                .FrameworkInitializationExceptions
+                .ToArray();
+            Assert.That(actual, Is.EquivalentTo(new[] { ex1, ex2 }));
         }
     }
 }

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
@@ -296,6 +296,27 @@ namespace LightBDD.Core.UnitTests
             Assert.AreSame(this, scenarioFixture);
         }
 
+        [Test]
+        public void It_should_fail_scenario_if_framework_initialization_exceptions_are_captured()
+        {
+            var ex1 = new InvalidOperationException("Exception 1");
+            var ex2 = new Exception("Exception 2");
+            var featureRunner = CreateRunner(cfg =>
+            {
+                cfg.ExecutionExtensionsConfiguration()
+                    .CaptureFrameworkInitializationException(ex1)
+                    .CaptureFrameworkInitializationException(ex2);
+            });
+            var runner = featureRunner.GetBddRunner(this);
+
+            var ex = Assert.Throws<AggregateException>(() => runner
+                .Test()
+                .TestScenario(Some_step1));
+
+            Assert.That(ex!.Message, Does.StartWith("LightBDD initialization failed"));
+            Assert.That(ex.InnerExceptions, Is.EqualTo(new[] { ex1, ex2 }));
+        }
+
         [MyThrowingDecorator(ExecutionStatus.Failed)]
         private void My_failed_step() { }
 

--- a/test/LightBDD.Fixie3.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.Fixie3.UnitTests/ConfiguredLightBddScope.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using LightBDD.Core.Configuration;
 using LightBDD.Framework.Configuration;
 using LightBDD.Framework.Notification;
@@ -8,14 +9,20 @@ namespace LightBDD.Fixie3.UnitTests
     public class ConfiguredLightBddScope : LightBddScope
     {
         public static readonly ConcurrentQueue<string> CapturedNotifications = new();
+        public bool ThrowOnConfigure { get; set; }
+        public LightBddConfiguration Captured { get; private set; }
+
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
+            Captured = configuration;
             configuration.ReportWritersConfiguration()
                 .Clear();
 
             configuration.ProgressNotifierConfiguration()
                 .Clear()
                 .Append(new DefaultProgressNotifier(x => CapturedNotifications.Enqueue(x)));
+            if (ThrowOnConfigure)
+                throw new InvalidOperationException("I failed!");
         }
     }
 }

--- a/test/LightBDD.Fixie3.UnitTests/LightBddScope_tests.cs
+++ b/test/LightBDD.Fixie3.UnitTests/LightBddScope_tests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using LightBDD.Core.Configuration;
+using Shouldly;
+
+namespace LightBDD.Fixie3.UnitTests;
+
+public class LightBddScope_tests : FeatureFixture
+{
+    [Scenario]
+    public void OnConfigure_failure_should_be_captured()
+    {
+        var scope = new ConfiguredLightBddScope() { ThrowOnConfigure = true };
+
+        typeof(LightBddScope).GetMethod("Configure", BindingFlags.Instance | BindingFlags.NonPublic)
+            !.Invoke(scope, null);
+
+        var exception = scope.Captured.ExecutionExtensionsConfiguration().FrameworkInitializationExceptions.FirstOrDefault();
+        exception.ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("I failed!");
+    }
+}

--- a/test/LightBDD.MsTest3.UnitTests/LightBddScopeAttribute_tests.cs
+++ b/test/LightBDD.MsTest3.UnitTests/LightBddScopeAttribute_tests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using LightBDD.Core.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest3.UnitTests;
+
+[TestClass]
+public class LightBddScopeAttribute_tests
+{
+    [TestMethod]
+    public void OnConfigure_failure_should_be_captured()
+    {
+        LightBddConfiguration captured = null;
+        Action<LightBddConfiguration> onConfigure = cfg =>
+        {
+            captured = cfg;
+            throw new InvalidOperationException("I failed!");
+        };
+        
+        typeof(LightBddScope).GetMethod("Configure", BindingFlags.Static | BindingFlags.NonPublic)
+            !.Invoke(null, [onConfigure]);
+
+        var exception = captured.ExecutionExtensionsConfiguration().FrameworkInitializationExceptions.FirstOrDefault();
+        Assert.IsInstanceOfType<InvalidOperationException>(exception);
+        Assert.AreEqual("I failed!", exception.Message);
+    }
+}

--- a/test/LightBDD.MsTest3.UnitTests/LightBddScopeAttribute_tests.cs
+++ b/test/LightBDD.MsTest3.UnitTests/LightBddScopeAttribute_tests.cs
@@ -20,7 +20,7 @@ public class LightBddScopeAttribute_tests
         };
         
         typeof(LightBddScope).GetMethod("Configure", BindingFlags.Static | BindingFlags.NonPublic)
-            !.Invoke(null, [onConfigure]);
+            !.Invoke(null, new object[] { onConfigure });
 
         var exception = captured.ExecutionExtensionsConfiguration().FrameworkInitializationExceptions.FirstOrDefault();
         Assert.IsInstanceOfType<InvalidOperationException>(exception);

--- a/test/LightBDD.NUnit3.UnitTests/LightBddScopeAttribute_tests.cs
+++ b/test/LightBDD.NUnit3.UnitTests/LightBddScopeAttribute_tests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using LightBDD.Core.Configuration;
+using NUnit.Framework;
+
+namespace LightBDD.NUnit3.UnitTests;
+
+[TestFixture]
+public class LightBddScopeAttribute_tests
+{
+    [Test]
+    public void OnConfigure_failure_should_be_captured()
+    {
+        var scope = new TestableLightBddScopeAttribute();
+
+        typeof(LightBddScopeAttribute).GetMethod("Configure", BindingFlags.Instance | BindingFlags.NonPublic)
+            !.Invoke(scope, null);
+
+        var exception = scope.Captured.ExecutionExtensionsConfiguration().FrameworkInitializationExceptions.FirstOrDefault();
+        Assert.That(exception, Is.TypeOf<InvalidOperationException>());
+        Assert.That(exception!.Message, Is.EqualTo("I failed!"));
+    }
+
+    class TestableLightBddScopeAttribute : LightBddScopeAttribute
+    {
+        public LightBddConfiguration Captured { get; private set; }
+
+        protected override void OnConfigure(LightBddConfiguration configuration)
+        {
+            Captured = configuration;
+            throw new InvalidOperationException("I failed!");
+        }
+    }
+}

--- a/test/LightBDD.XUnit2.UnitTests/ConfiguredLightBddScope.cs
+++ b/test/LightBDD.XUnit2.UnitTests/ConfiguredLightBddScope.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using LightBDD.Core.Configuration;
 using LightBDD.Framework.Configuration;
 using LightBDD.Framework.Notification;
@@ -10,14 +11,21 @@ namespace LightBDD.XUnit2.UnitTests
     internal class ConfiguredLightBddScope : LightBddScopeAttribute
     {
         public static readonly ConcurrentQueue<string> CapturedNotifications = new();
+        public bool ThrowOnConfigure { get; set; }
+        public LightBddConfiguration Captured { get; private set; }
         protected override void OnConfigure(LightBddConfiguration configuration)
         {
+            Captured = configuration;
+
             configuration.ReportWritersConfiguration()
                 .Clear();
 
             configuration.ProgressNotifierConfiguration()
                 .Clear()
-                .Append(new DefaultProgressNotifier(x => CapturedNotifications.Enqueue(x)));
+                .Append(new DefaultProgressNotifier(CapturedNotifications.Enqueue));
+
+            if (ThrowOnConfigure)
+                throw new InvalidOperationException("I failed!");
         }
     }
 }

--- a/test/LightBDD.XUnit2.UnitTests/LightBddScopeAttribute_tests.cs
+++ b/test/LightBDD.XUnit2.UnitTests/LightBddScopeAttribute_tests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using LightBDD.Core.Configuration;
+using Xunit;
+
+namespace LightBDD.XUnit2.UnitTests;
+
+public class LightBddScopeAttribute_tests
+{
+    [Fact]
+    public void OnConfigure_failure_should_be_captured()
+    {
+        var scope = new ConfiguredLightBddScope { ThrowOnConfigure = true };
+
+        typeof(LightBddScopeAttribute).GetMethod("Configure", BindingFlags.Instance | BindingFlags.NonPublic)
+            !.Invoke(scope, null);
+
+        var exception = scope.Captured.ExecutionExtensionsConfiguration().FrameworkInitializationExceptions.FirstOrDefault();
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Equal("I failed!", exception.Message);
+    }
+}


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #356 

List of changes:
- (LightBDD.Core)(Change) Captured LightBddScope OnConfigure() failures

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
