### PR TITLE
Allow resetting ActualRows to null to avoid "Actual rows have been already specified" when retrying a scenario

### DIFF
--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -72,6 +72,14 @@ namespace LightBDD.Framework.Parameters
         }
 
         /// <summary>
+        /// Resets the actual rows.
+        /// </summary>
+        public void ResetActual()
+        {
+            ActualRows = null;
+        }
+
+        /// <summary>
         /// Sets the actual rows specified by <paramref name="actualRowsProvider"/> parameter and verifies them against expectations.<br/>
         /// If evaluation of <paramref name="actualRowsProvider"/> throws, the exception will be included in the report, but won't be propagated out of this method.
         /// </summary>


### PR DESCRIPTION
This is needed when using [RetryScenario] because on each retry ActualRows were already set and EnsureActualNotSet() will make the retry fail because "Actual rows have been already specified".

See related https://github.com/LightBDD/LightBDD/issues/257

#### Details

Issue reference: https://github.com/LightBDD/LightBDD/issues/365

List of changes:


#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
