### PR TITLE
Added ResetActual() method to Verifiable/VerifiableTable/VerifiableTree to allow setting them once more

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ LightBDD
 
 Version 3.10.0
 ----------------------------------------
++ #365 (LightBDD.Framework)(New) Added ResetActual() method to Verifiable/VerifiableTable/VerifiableTree to allow setting them once more
 + #350 (LightBDD.Core)(New) Added IScenario.Descriptor property providing access to scenario MethodInfo
 
 Version 3.9.0

--- a/src/LightBDD.Framework/Parameters/Verifiable.cs
+++ b/src/LightBDD.Framework/Parameters/Verifiable.cs
@@ -81,6 +81,18 @@ namespace LightBDD.Framework.Parameters
         }
 
         /// <summary>
+        /// Clears actual state allowing to specify it once more.
+        /// </summary>
+        public Verifiable<T> ResetActual()
+        {
+            _exception = null;
+            _actual = default;
+            _actualText = null;
+            _result = default;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the actual value and performs the validation against the expectation, updating <see cref="Status"/> property.
         /// The value specified by <paramref name="value"/> parameter can be retrieved by <see cref="GetActual"/> method.
         ///
@@ -126,6 +138,7 @@ namespace LightBDD.Framework.Parameters
 
             return this;
         }
+
 
         /// <summary>
         /// Sets the actual value and performs the validation against the expectation, updating <see cref="Status"/> property.

--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -72,11 +72,12 @@ namespace LightBDD.Framework.Parameters
         }
 
         /// <summary>
-        /// Resets the actual rows.
+        /// Clears actual state allowing to specify it once more.
         /// </summary>
         public void ResetActual()
         {
             ActualRows = null;
+            _details = null;
         }
 
         /// <summary>

--- a/src/LightBDD.Framework/Parameters/VerifiableTable.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTable.cs
@@ -72,6 +72,14 @@ namespace LightBDD.Framework.Parameters
         }
 
         /// <summary>
+        /// Resets the actual rows.
+        /// </summary>
+        public void ResetActual()
+        {
+            ActualRows = null;
+        }
+
+        /// <summary>
         /// Sets the actual rows specified by <paramref name="actualRowsProvider"/> parameter and verifies them against expectations.<br/>
         /// If evaluation of <paramref name="actualRowsProvider"/> throws, the exception will be included in the report, but won't be propagated out of this method.
         /// </summary>

--- a/src/LightBDD.Framework/Parameters/VerifiableTree.cs
+++ b/src/LightBDD.Framework/Parameters/VerifiableTree.cs
@@ -57,6 +57,16 @@ public class VerifiableTree : IComplexParameter, ISelfFormattable
         _details = null;
     }
 
+
+    /// <summary>
+    /// Clears actual state allowing to specify it once more.
+    /// </summary>
+    public void ResetActual()
+    {
+        _actualTree = null;
+        _details = null;
+    }
+
     void IComplexParameter.SetValueFormattingService(IValueFormattingService formattingService)
     {
         _formattingService = formattingService;

--- a/test/LightBDD.Framework.UnitTests/Parameters/TableValidator_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/TableValidator_tests.cs
@@ -90,6 +90,18 @@ namespace LightBDD.Framework.UnitTests.Parameters
         }
 
         [Test]
+        public void ResetActual_should_reset_table_and_allow_setting_another_value()
+        {
+            var table = CreateNotNullValidator();
+            table.SetActual(Array.Empty<Testable>());
+            table.ResetActual();
+            Assert.That(table.Details.VerificationStatus,Is.EqualTo(ParameterVerificationStatus.NotProvided));
+
+            Assert.DoesNotThrow(() => table.SetActual(Array.Empty<Testable>()));
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Success));
+        }
+
+        [Test]
         public async Task SetActualAsync_should_capture_exception()
         {
             var table = CreateNotNullValidator();

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableDataTable_tests.cs
@@ -644,6 +644,18 @@ namespace LightBDD.Framework.UnitTests.Parameters
         }
 
         [Test]
+        public void ResetActual_should_reset_table_and_allow_setting_another_value()
+        {
+            var table = new[] { 1 }.ToVerifiableDataTable();
+            table.SetActual(e => e);
+            table.ResetActual();
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.NotProvided));
+
+            Assert.DoesNotThrow(() => table.SetActual(e=>e));
+            Assert.That(table.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Success));
+        }
+
+        [Test]
         public async Task SetActualAsync_should_capture_exception()
         {
             var table = Enumerable.Empty<int>().ToVerifiableDataTable();

--- a/test/LightBDD.Framework.UnitTests/Parameters/VerifiableTree_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/VerifiableTree_tests.cs
@@ -71,6 +71,30 @@ public class VerifiableTree_tests
     }
 
     [Test]
+    public void SetActual_should_be_callable_once()
+    {
+        var expected = new { Name = "Bob" };
+        var tree = Tree.ExpectEquivalent(expected);
+        tree.SetActual(null);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => tree.SetActual(expected));
+        Assert.That(ex.Message, Is.EqualTo("Actual value is already set"));
+    }
+
+    [Test]
+    public void ResetActual_should_reset_tree_and_allow_setting_another_value()
+    {
+        var expected = new { Name = "Bob" };
+        var tree = Tree.ExpectEquivalent(expected);
+        tree.SetActual(null);
+        tree.ResetActual();
+        Assert.That(tree.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.NotProvided));
+
+        Assert.DoesNotThrow(() => tree.SetActual(expected));
+        Assert.That(tree.Details.VerificationStatus, Is.EqualTo(ParameterVerificationStatus.Success));
+    }
+
+    [Test]
     public void Tree_should_fail_on_unequal_objects()
     {
         var expected = new

--- a/test/LightBDD.Framework.UnitTests/Parameters/Verifiable_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Parameters/Verifiable_tests.cs
@@ -7,6 +7,7 @@ using LightBDD.Framework.Parameters;
 using LightBDD.Framework.UnitTests.Formatting;
 using LightBDD.UnitTests.Helpers;
 using NUnit.Framework;
+using Shouldly;
 
 namespace LightBDD.Framework.UnitTests.Parameters
 {
@@ -115,6 +116,18 @@ namespace LightBDD.Framework.UnitTests.Parameters
             Assert.That(ex.Message, Is.EqualTo("Actual value has been already specified"));
             ex = Assert.Throws<InvalidOperationException>(() => expectation.SetActual(Fake.Int()));
             Assert.That(ex.Message, Is.EqualTo("Actual value has been already specified"));
+        }
+
+        [Test]
+        public void ResetActual_should_reset_verifiable_and_allow_setting_another_value()
+        {
+            var value = Fake.Int();
+            Verifiable<int> expectation = value;
+            expectation.SetActual(value + 1);
+            expectation.ResetActual();
+            expectation.Status.ShouldBe(ParameterVerificationStatus.NotProvided);
+            Assert.DoesNotThrow(() => expectation.SetActual(value));
+            expectation.Status.ShouldBe(ParameterVerificationStatus.Success);
         }
 
         [Test]


### PR DESCRIPTION
<!-- Add brief description here -->

#### Details

Issue reference: #365

List of changes:
Added ResetActual() method to Verifiable/VerifiableTable/VerifiableTree to allow setting them once more

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
