### PR TITLE
# 397 Add StepExecution.Current.IgnoreStep() And IStepDecoratorAttribute

### DIFF
--- a/src/LightBDD.Core/Execution/Implementation/ExceptionCollector.cs
+++ b/src/LightBDD.Core/Execution/Implementation/ExceptionCollector.cs
@@ -26,6 +26,9 @@ namespace LightBDD.Core.Execution.Implementation
                         .Where(x => x != null))
                 .ToArray();
 
+            if (exceptions.Length == 0)
+                return null;
+
             return executionStatus == ExecutionStatus.Ignored || exceptions.Length == 1
                 ? exceptions.First()
                 : new AggregateException(exceptions);

--- a/src/LightBDD.Core/Execution/Implementation/RunnableStep.cs
+++ b/src/LightBDD.Core/Execution/Implementation/RunnableStep.cs
@@ -256,6 +256,9 @@ namespace LightBDD.Core.Execution.Implementation
                 case ScenarioExecutionException { InnerException: StepBypassException }:
                     _result.SetStatus(ExecutionStatus.Bypassed, exception.InnerException.Message);
                     break;
+                case ScenarioExecutionException { InnerException: StepIgnoreException }:
+                    _result.SetStatus(ExecutionStatus.Ignored, exception.InnerException.Message);
+                    break;
                 case ScenarioExecutionException e:
                     _stepContext.ExceptionProcessor.UpdateResultsWithException(_result.SetStatus, e.InnerException);
                     _exceptionCollector.Capture(e);

--- a/src/LightBDD.Core/Execution/StepIgnoreException.cs
+++ b/src/LightBDD.Core/Execution/StepIgnoreException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace LightBDD.Core.Execution
+{
+    /// <summary>
+    /// Step ignore exception used to mark step ignored while allowing the scenario to continue.
+    /// </summary>
+    public class StepIgnoreException : Exception
+    {
+        /// <summary>
+        /// Constructor allowing to specify ignore reason.
+        /// </summary>
+        /// <param name="reason">Ignore reason.</param>
+        public StepIgnoreException(string reason) : base(reason) { }
+    }
+}

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -454,7 +454,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                     Html.Tag(Html5Tag.H3).Id(scenarioId).Class("header title").Content(
                         Html.Tag(Html5Tag.Label).For(toggleId).Class("controls").Content(
                             GetCheckBoxTag(),
-                            GetStatus(scenario.Status)),
+                            GetScenarioStatus(scenario)),
                         Html.Tag(Html5Tag.Span).Content(
                             Html.Text(scenario.Info.Name.Format(StepNameDecorator)),
                             Html.Tag(Html5Tag.Span).Content(scenario.Info.Labels.Select(GetLabel)).SkipEmpty(),
@@ -538,6 +538,36 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                 .SpaceAfter();
         }
 
+        private static IHtmlNode GetScenarioStatus(IScenarioResult scenario)
+        {
+            if (scenario.Status == ExecutionStatus.Ignored
+                && scenario.GetSteps().Any(s => s.Status == ExecutionStatus.Passed)
+                && !scenario.GetAllSteps().Any(s => s.Status == ExecutionStatus.NotRun))
+            {
+                return GetPassedIgnoredStatus();
+            }
+            return GetStatus(scenario.Status);
+        }
+
+        private static IHtmlNode GetStepStatus(IStepResult step)
+        {
+            if (step.Status == ExecutionStatus.Ignored
+                && step.GetSubSteps().Any(s => s.Status == ExecutionStatus.Passed)
+                && !step.GetSubSteps().SelectMany(s => s.GetAllSteps()).Any(s => s.Status == ExecutionStatus.NotRun))
+            {
+                return GetPassedIgnoredStatus();
+            }
+            return GetStatus(step.Status);
+        }
+
+        private static IHtmlNode GetPassedIgnoredStatus()
+        {
+            return Html.Tag(Html5Tag.Span)
+                .Class("status passed ignored")
+                .Content(GetStatusValue(ExecutionStatus.Passed))
+                .SpaceAfter();
+        }
+
         private static IHtmlNode GetStep(IStepResult step)
         {
             var toggleId = step.Info.RuntimeId.ToString();
@@ -556,7 +586,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
                 Html.Tag(Html5Tag.Div).Class("header").Content(
                     container.Class("controls").Content(
                         GetCheckBoxTag(!hasSubSteps),
-                        GetStatus(step.Status)),
+                        GetStepStatus(step)),
                     Html.Tag(Html5Tag.Span).Content(
                         Html.Text($"{WebUtility.HtmlEncode(step.Info.GroupPrefix)}{step.Info.Number}. {step.Info.Name.Format(StepNameDecorator)}").Trim(),
                         GetDuration(step.ExecutionTime))),

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/HtmlResultTextWriter.cs
@@ -540,9 +540,7 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
 
         private static IHtmlNode GetScenarioStatus(IScenarioResult scenario)
         {
-            if (scenario.Status == ExecutionStatus.Ignored
-                && scenario.GetSteps().Any(s => s.Status == ExecutionStatus.Passed)
-                && !scenario.GetAllSteps().Any(s => s.Status == ExecutionStatus.NotRun))
+            if (scenario.Status == ExecutionStatus.Ignored && IsPassedIgnored(scenario.GetSteps()))
             {
                 return GetPassedIgnoredStatus();
             }
@@ -551,13 +549,35 @@ namespace LightBDD.Framework.Reporting.Formatters.Html
 
         private static IHtmlNode GetStepStatus(IStepResult step)
         {
-            if (step.Status == ExecutionStatus.Ignored
-                && step.GetSubSteps().Any(s => s.Status == ExecutionStatus.Passed)
-                && !step.GetSubSteps().SelectMany(s => s.GetAllSteps()).Any(s => s.Status == ExecutionStatus.NotRun))
+            if (step.Status == ExecutionStatus.Ignored && IsPassedIgnored(step.GetSubSteps()))
             {
                 return GetPassedIgnoredStatus();
             }
             return GetStatus(step.Status);
+        }
+
+        private static bool IsPassedIgnored(IEnumerable<IStepResult> steps)
+        {
+            var hasPassed = false;
+            foreach (var step in steps)
+            {
+                if (HasNotRunRecursive(step))
+                    return false;
+                hasPassed = hasPassed || step.Status == ExecutionStatus.Passed;
+            }
+            return hasPassed;
+        }
+
+        private static bool HasNotRunRecursive(IStepResult step)
+        {
+            if (step.Status == ExecutionStatus.NotRun)
+                return true;
+            foreach (var sub in step.GetSubSteps())
+            {
+                if (HasNotRunRecursive(sub))
+                    return true;
+            }
+            return false;
         }
 
         private static IHtmlNode GetPassedIgnoredStatus()

--- a/src/LightBDD.Framework/Reporting/Formatters/Html/Resources/styles.css
+++ b/src/LightBDD.Framework/Reporting/Formatters/Html/Resources/styles.css
@@ -26,6 +26,7 @@ span.category{background-color: hsl(24, 100%, 90%); color: hsl(24, 100%, 40%); p
 .status{width:21px;height:21px;display: flex;vertical-align: middle;text-align: center;font-family: 'Roboto Mono', monospace;font-size: 13px;font-weight: bold;line-height: 13px;align-items: center;justify-content: center;padding: 4px;margin-right: 5px;}
 .status{border:0;box-sizing: border-box;border-radius: 50%;color:#ffffff;}
 .status.passed{background-color:#1daf26;}
+.status.passed.ignored{background:linear-gradient(to right, #1daf26, #fbc800);text-shadow:1px 0 #1daf26;color:#ffffff;}
 .status.failed{background-color:#cc0000;}
 .status.ignored{background-color:#fbc800;color: black;}
 .status.bypassed{background-color:#2e7bff;}

--- a/src/LightBDD.Framework/StepExecution.cs
+++ b/src/LightBDD.Framework/StepExecution.cs
@@ -65,6 +65,23 @@ namespace LightBDD.Framework
         public IDependencyResolver GetScenarioDependencyResolver() => ScenarioExecutionContext.CurrentScenario.DependencyResolver;
 
         /// <summary>
+        /// Ignores currently executed step and continues execution of current scenario, allowing to execute all remaining steps.
+        /// The step code located after <c>StepExecution.Current.IgnoreStep()</c> call would not be executed.
+        /// <para>
+        /// The status of ignored step would be <see cref="ExecutionStatus.Ignored"/> and the overall status of scenario would be <see cref="ExecutionStatus.Ignored"/>,
+        /// unless any further step is failed.
+        /// </para>
+        /// <para>The <paramref name="reason"/> argument would be used as step <see cref="IStepResult.StatusDetails"/>, and it would be aggregated in overall scenario <see cref="IScenarioResult.StatusDetails"/> as well.</para>
+        /// </summary>
+        /// <param name="reason">Ignore reason.</param>
+        /// <exception cref="StepIgnoreException">Ignore exception used to control scenario execution.</exception>
+        public void IgnoreStep(string reason)
+        {
+            ScenarioExecutionContext.ValidateScenarioScope();
+            throw new StepIgnoreException(reason);
+        }
+
+        /// <summary>
         /// Adds the file attachment to the step.
         /// </summary>
         /// <param name="createAttachmentFn">Function creating file attachment by using provided attachments manager.</param>

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_complex_parameter_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_complex_parameter_step_execution_tests.cs
@@ -94,6 +94,16 @@ namespace LightBDD.Core.UnitTests
         }
 
         [Test]
+        public void Runner_should_honor_step_ignored_via_IgnoreStep()
+        {
+            _runner.Test().TestScenario(
+                TestStep.CreateAsync(Step_ignored_with_parameter,
+                    new Complex(null, null, ParameterVerificationStatus.Failure, "msg")
+                ));
+            Assert.That(GetStepResults().Single().Status, Is.EqualTo(ExecutionStatus.Ignored));
+        }
+
+        [Test]
         public void Runner_should_process_failed_steps_first()
         {
             Assert.Throws<Exception>(() => _runner.Test().TestScenario(
@@ -129,6 +139,7 @@ namespace LightBDD.Core.UnitTests
 
         private void Step_with_parameters(Complex arg1, Complex arg2, Complex arg3) { }
         private void Ignored_step_with_parameter(Complex arg) { StepExecution.Current.IgnoreScenario("reason"); }
+        private void Step_ignored_with_parameter(Complex arg) { StepExecution.Current.IgnoreStep("reason"); }
         private void Bypassed_step_with_parameter(Complex arg) { StepExecution.Current.Bypass("reason"); }
         private void Failed_step_with_parameter(Complex arg) { throw new Exception("exception reason"); }
 

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_execution_extension_tests.cs
@@ -244,6 +244,25 @@ namespace LightBDD.Core.UnitTests
         }
 
         [Test]
+        public void It_should_IGNORE_step_and_continue_scenario_based_on_step_decorator_throwing_StepIgnoreException()
+        {
+            var featureRunner = CreateRunner(cfg => { });
+            featureRunner
+                .GetBddRunner(this)
+                .Test()
+                .TestScenario(My_step_ignored_step, Some_step1);
+
+            var scenario = featureRunner.GetFeatureResult().GetScenarios().Single();
+
+            Assert.That(scenario.Status, Is.EqualTo(ExecutionStatus.Ignored));
+            Assert.That(scenario.StatusDetails, Is.EqualTo("Step 1: step decorator ignore reason"));
+            Assert.That(scenario.ExecutionTime, Is.Not.Null);
+            var steps = scenario.GetSteps().ToArray();
+            Assert.That(steps[0].Status, Is.EqualTo(ExecutionStatus.Ignored));
+            Assert.That(steps[1].Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Test]
         [MyRetryDecorator]
         public void It_should_clear_step_exceptions_on_retry()
         {
@@ -328,6 +347,9 @@ namespace LightBDD.Core.UnitTests
 
         [MyThrowingDecorator(ExecutionStatus.Ignored)]
         private void My_ignored_step() { }
+
+        [MyStepIgnoreDecorator("step decorator ignore reason")]
+        private void My_step_ignored_step() { }
 
         [MyThrowingDecorator(ExecutionStatus.Bypassed)]
         private void My_bypassed_step() { }
@@ -460,6 +482,24 @@ namespace LightBDD.Core.UnitTests
                 _onCall(scenario);
                 return scenarioInvocation();
             }
+        }
+
+        [AttributeUsage(AttributeTargets.Method)]
+        private class MyStepIgnoreDecorator : Attribute, IStepDecoratorAttribute
+        {
+            private readonly string _reason;
+
+            public MyStepIgnoreDecorator(string reason)
+            {
+                _reason = reason;
+            }
+
+            public Task ExecuteAsync(IStep step, Func<Task> stepInvocation)
+            {
+                throw new StepIgnoreException(_reason);
+            }
+
+            public int Order { get; set; }
         }
     }
 }

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_hierarchical_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_hierarchical_step_execution_tests.cs
@@ -118,6 +118,23 @@ namespace LightBDD.Core.UnitTests
         }
 
         [Test]
+        public void Runner_should_mark_step_ignored_if_substep_uses_IgnoreStep_and_continue_remaining_substeps()
+        {
+            Assert.DoesNotThrow(() => _runner.Test().TestGroupScenario(Ignored_step_step_group));
+
+            var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps().ToArray();
+
+            StepResultExpectation.AssertEqual(steps,
+                new StepResultExpectation(1, 1, "Ignored step step group", ExecutionStatus.Ignored, $"Step 1.2: {StepIgnoreReason}"));
+
+            StepResultExpectation.AssertEqual(steps[0].GetSubSteps(),
+                new StepResultExpectation("1.", 1, 3, "GIVEN step one", ExecutionStatus.Passed),
+                new StepResultExpectation("1.", 2, 3, "WHEN step two ignoring step", ExecutionStatus.Ignored, $"Step 1.2: {StepIgnoreReason}"),
+                new StepResultExpectation("1.", 3, 3, "THEN step three", ExecutionStatus.Passed)
+            );
+        }
+
+        [Test]
         public void Runner_should_properly_associate_steps_to_the_group()
         {
             Assert.DoesNotThrow(() => _runner.Test().TestGroupScenario(Passing_step_group, Composite_group));

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_multiassert_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_multiassert_step_execution_tests.cs
@@ -30,11 +30,18 @@ namespace LightBDD.Core.UnitTests
         public void Passing_step() { }
         public void Failing_step() { throw new InvalidOperationException("failing"); }
         public void Ignoring_step() { StepExecution.Current.IgnoreScenario("ignoring"); }
+        public void Step_ignoring_step() { StepExecution.Current.IgnoreStep("ignoring step"); }
 
         [MultiAssert]
         public TestCompositeStep Multiassert_ignoring_steps()
         {
             return TestCompositeStep.Create(Ignoring_step, Ignoring_step, Passing_step);
+        }
+
+        [MultiAssert]
+        public TestCompositeStep Multiassert_step_ignoring_steps()
+        {
+            return TestCompositeStep.Create(Step_ignoring_step, Step_ignoring_step, Passing_step);
         }
         [MultiAssert]
         public TestCompositeStep Multiassert_failing_composite()
@@ -118,6 +125,33 @@ namespace LightBDD.Core.UnitTests
             StepResultExpectation.AssertEqual(steps[2].GetSubSteps(),
                 new StepResultExpectation("3.", 1, 2, "Passing step", ExecutionStatus.Passed),
                 new StepResultExpectation("3.", 2, 2, "Passing step", ExecutionStatus.Passed)
+            );
+        }
+
+        [Test]
+        [MultiAssert]
+        public void Runner_should_continue_multiassert_substeps_when_IgnoreStep_is_used()
+        {
+            _runner.Test().TestGroupScenario(Multiassert_step_ignoring_steps, Passing_composite);
+
+            var scenario = _feature.GetFeatureResult().GetScenarios().Single();
+            Assert.That(scenario.Status, Is.EqualTo(ExecutionStatus.Ignored));
+
+            var steps = scenario.GetSteps().ToArray();
+            StepResultExpectation.AssertEqual(steps,
+                new StepResultExpectation(1, 2, "Multiassert step ignoring steps", ExecutionStatus.Ignored, $"Step 1.1: ignoring step{Environment.NewLine}Step 1.2: ignoring step"),
+                new StepResultExpectation(2, 2, "Passing composite", ExecutionStatus.Passed)
+                );
+
+            StepResultExpectation.AssertEqual(steps[0].GetSubSteps(),
+                new StepResultExpectation("1.", 1, 3, "Step ignoring step", ExecutionStatus.Ignored, "Step 1.1: ignoring step"),
+                new StepResultExpectation("1.", 2, 3, "Step ignoring step", ExecutionStatus.Ignored, "Step 1.2: ignoring step"),
+                new StepResultExpectation("1.", 3, 3, "Passing step", ExecutionStatus.Passed)
+            );
+
+            StepResultExpectation.AssertEqual(steps[1].GetSubSteps(),
+                new StepResultExpectation("2.", 1, 2, "Passing step", ExecutionStatus.Passed),
+                new StepResultExpectation("2.", 2, 2, "Passing step", ExecutionStatus.Passed)
             );
         }
     }

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_multiassert_step_execution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_multiassert_step_execution_tests.cs
@@ -43,6 +43,7 @@ namespace LightBDD.Core.UnitTests
         {
             return TestCompositeStep.Create(Step_ignoring_step, Step_ignoring_step, Passing_step);
         }
+
         [MultiAssert]
         public TestCompositeStep Multiassert_failing_composite()
         {

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_scenario_metadata_collection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_scenario_metadata_collection_tests.cs
@@ -132,6 +132,50 @@ namespace LightBDD.Core.UnitTests
         }
 
         [Test]
+        public void It_should_capture_scenario_status_for_step_ignored_via_IgnoreStep()
+        {
+            _runner.Test().TestScenario(
+                Given_step_one,
+                When_step_two_ignoring_step,
+                Then_step_three);
+
+            Assert.That(_feature.GetFeatureResult().GetScenarios().Single().Status, Is.EqualTo(ExecutionStatus.Ignored));
+        }
+
+        [Test]
+        public void It_should_capture_failed_scenario_status_when_step_is_ignored_and_later_step_fails()
+        {
+            try
+            {
+                _runner.Test().TestScenario(
+                    Given_step_one,
+                    When_step_two_ignoring_step,
+                    Then_step_three_should_throw_exception);
+            }
+            catch { }
+
+            var scenario = _feature.GetFeatureResult().GetScenarios().Single();
+            Assert.That(scenario.Status, Is.EqualTo(ExecutionStatus.Failed));
+            var expected = "Step 2: " + StepIgnoreReason + Environment.NewLine +
+                           "Step 3: " + ExceptionReason;
+            Assert.That(scenario.StatusDetails, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_capture_ignored_scenario_status_when_step_is_ignored_and_another_is_bypassed()
+        {
+            _runner.Test().TestScenario(
+                Given_step_one,
+                When_step_two_ignoring_step,
+                Then_step_three,
+                Then_step_four);
+
+            var scenario = _feature.GetFeatureResult().GetScenarios().Single();
+            Assert.That(scenario.Status, Is.EqualTo(ExecutionStatus.Ignored));
+            Assert.That(scenario.StatusDetails, Is.EqualTo("Step 2: " + StepIgnoreReason));
+        }
+
+        [Test]
         public void It_should_capture_scenario_execution_status_details_from_all_steps()
         {
             try

--- a/test/LightBDD.Core.UnitTests/CoreBddRunner_step_metadata_collection_tests.cs
+++ b/test/LightBDD.Core.UnitTests/CoreBddRunner_step_metadata_collection_tests.cs
@@ -76,6 +76,40 @@ namespace LightBDD.Core.UnitTests
         }
 
         [Test]
+        public void It_should_capture_ignored_step_and_continue_scenario()
+        {
+            _runner.Test().TestScenario(
+                Given_step_one,
+                When_step_two_ignoring_step,
+                Then_step_three);
+
+            var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
+            StepResultExpectation.AssertEqual(steps,
+                    new StepResultExpectation(1, 3, "GIVEN step one", ExecutionStatus.Passed),
+                    new StepResultExpectation(2, 3, "WHEN step two ignoring step", ExecutionStatus.Ignored, $"Step 2: {StepIgnoreReason}"),
+                    new StepResultExpectation(3, 3, "THEN step three", ExecutionStatus.Passed)
+                );
+        }
+
+        [Test]
+        public void It_should_capture_multiple_ignored_steps_and_continue_scenario()
+        {
+            _runner.Test().TestScenario(
+                Given_step_one,
+                When_step_two_ignoring_step,
+                Then_step_three_ignoring_step,
+                Then_step_four);
+
+            var steps = _feature.GetFeatureResult().GetScenarios().Single().GetSteps();
+            StepResultExpectation.AssertEqual(steps,
+                    new StepResultExpectation(1, 4, "GIVEN step one", ExecutionStatus.Passed),
+                    new StepResultExpectation(2, 4, "WHEN step two ignoring step", ExecutionStatus.Ignored, $"Step 2: {StepIgnoreReason}"),
+                    new StepResultExpectation(3, 4, "THEN step three ignoring step", ExecutionStatus.Ignored, $"Step 3: {StepIgnoreReason}"),
+                    new StepResultExpectation(4, 4, "AND step four", ExecutionStatus.Passed)
+                );
+        }
+
+        [Test]
         public void It_should_infer_and_capture_default_step_types()
         {
             _runner.Test().TestScenario(

--- a/test/LightBDD.Core.UnitTests/Helpers/Steps.cs
+++ b/test/LightBDD.Core.UnitTests/Helpers/Steps.cs
@@ -9,6 +9,7 @@ namespace LightBDD.Core.UnitTests.Helpers
         public const string BypassReason = "bypass reason";
         public const string ExceptionReason = "exception reason";
         public const string IgnoreReason = "ignore reason";
+        public const string StepIgnoreReason = "step ignore reason";
         public const string ParameterExceptionReason = "parameter exception";
         public const string CommentReason = "some comment";
         public const string AttachmentName = "attachment1";
@@ -26,9 +27,11 @@ namespace LightBDD.Core.UnitTests.Helpers
         public void Then_step_three() { }
         public void Then_step_three_should_throw_exception() { throw new InvalidOperationException(ExceptionReason); }
         public void When_step_two_ignoring_scenario() { StepExecution.Current.IgnoreScenario(IgnoreReason); }
+        public void When_step_two_ignoring_step() { StepExecution.Current.IgnoreStep(StepIgnoreReason); }
         public void Then_step_four() { }
         public void Then_step_five() { }
         public void Then_step_three_should_be_ignored() { StepExecution.Current.IgnoreScenario(IgnoreReason); }
+        public void Then_step_three_ignoring_step() { StepExecution.Current.IgnoreStep(StepIgnoreReason); }
         public void Given_step_with_parameter(string parameter) { }
         public void When_step_with_parameter(int parameter) { }
 
@@ -77,6 +80,14 @@ namespace LightBDD.Core.UnitTests.Helpers
             return TestCompositeStep.Create(
                 Given_step_one,
                 When_step_two_ignoring_scenario,
+                Then_step_three);
+        }
+
+        public TestCompositeStep Ignored_step_step_group()
+        {
+            return TestCompositeStep.Create(
+                Given_step_one,
+                When_step_two_ignoring_step,
                 Then_step_three);
         }
 

--- a/test/LightBDD.Core.UnitTests/StepExecution_tests.cs
+++ b/test/LightBDD.Core.UnitTests/StepExecution_tests.cs
@@ -21,5 +21,12 @@ namespace LightBDD.Core.UnitTests
             var exception = Assert.Throws<InvalidOperationException>(() => StepExecution.Current.IgnoreScenario("reason"));
             Assert.That(exception!.Message, Does.StartWith("Current task is not executing any scenarios."));
         }
+
+        [Test]
+        public void IgnoreStep_should_fail_when_called_outside_of_step()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => StepExecution.Current.IgnoreStep("reason"));
+            Assert.That(exception!.Message, Does.StartWith("Current task is not executing any scenarios."));
+        }
     }
 }

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/HtmlReportFormatter_tests.cs
@@ -135,7 +135,7 @@ Toggle: Features Scenarios Sub Steps
 Filter: Passed Bypassed Failed Ignored Not Run
  filtered link
 My feature link
-! name (25ms) link
+✓ name (25ms) link
 ✓ 1. step1 (20ms)
 ! 2. step2 (5ms)
 Generated with LightBDD v{GetExpectedLightBddVersion()}
@@ -406,6 +406,133 @@ $.[2].Surname=Smith";
             Assert.That(text.NormalizeNewLine(), Is.EqualTo(expectedText.NormalizeNewLine()));
         }
 
+        [Test]
+        public void Should_format_ignored_scenario_with_not_run_steps_as_ignored()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithIgnoredScenario();
+
+            var text = FormatAndExtractText(result);
+            TestContext.WriteLine(text);
+
+            Assert.That(text, Does.Contain("! name (45ms)"));
+            Assert.That(text, Does.Not.Contain("✓ name"));
+        }
+
+        [Test]
+        public void Should_format_all_steps_ignored_scenario_as_ignored()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithAllStepsIgnored();
+
+            var text = FormatAndExtractText(result);
+            TestContext.WriteLine(text);
+
+            Assert.That(text, Does.Contain("! name (10ms)"));
+            Assert.That(text, Does.Not.Contain("✓ name"));
+        }
+
+        [Test]
+        public void Should_use_passed_ignored_css_class_for_step_ignored_scenario()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithoutDescriptionNorLabelNorDetails();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+            Assert.That(scenarioDiv.GetAttributeValue("class", ""), Is.EqualTo("scenario ignored"));
+
+            var statusSpan = scenarioDiv.SelectSingleNode(".//span[contains(@class,'status')]");
+            Assert.That(statusSpan.GetAttributeValue("class", ""), Is.EqualTo("status passed ignored"));
+            Assert.That(statusSpan.InnerText.Trim(), Is.EqualTo("\u2713"));
+        }
+
+        [Test]
+        public void Should_use_ignored_css_class_for_scenario_ignored_scenario()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithIgnoredScenario();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+            Assert.That(scenarioDiv.GetAttributeValue("class", ""), Is.EqualTo("scenario ignored"));
+
+            var statusSpan = scenarioDiv.SelectSingleNode(".//span[contains(@class,'status')]");
+            Assert.That(statusSpan.GetAttributeValue("class", ""), Is.EqualTo("status ignored"));
+            Assert.That(statusSpan.InnerText.Trim(), Is.EqualTo("!"));
+        }
+
+        [Test]
+        public void Should_use_ignored_css_class_for_all_steps_ignored_scenario()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithAllStepsIgnored();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+            var statusSpan = scenarioDiv.SelectSingleNode(".//span[contains(@class,'status')]");
+            Assert.That(statusSpan.GetAttributeValue("class", ""), Is.EqualTo("status ignored"));
+            Assert.That(statusSpan.InnerText.Trim(), Is.EqualTo("!"));
+        }
+
+        [Test]
+        public void Should_include_passed_ignored_css_rule_in_stylesheet()
+        {
+            var html = FormatAndParseHtml(ReportFormatterTestData.GetFeatureResultWithoutDescriptionNorLabelNorDetails());
+            var styles = html.DocumentNode.SelectNodes("//style");
+            var allCss = string.Join(" ", styles.Select(s => s.InnerText));
+
+            Assert.That(allCss, Does.Contain(".status.passed.ignored"));
+            Assert.That(allCss, Does.Contain("linear-gradient"));
+        }
+
+        [Test]
+        public void Should_use_ignored_css_class_for_scenario_ignored_in_composite_step()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithIgnoredScenarioInCompositeStep();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+            Assert.That(scenarioDiv.GetAttributeValue("class", ""), Is.EqualTo("scenario ignored"));
+
+            var scenarioStatus = scenarioDiv.SelectSingleNode("./h3//span[contains(@class,'status')]");
+            Assert.That(scenarioStatus.GetAttributeValue("class", ""), Is.EqualTo("status ignored"));
+            Assert.That(scenarioStatus.InnerText.Trim(), Is.EqualTo("!"));
+
+            var stepStatuses = scenarioDiv.SelectNodes(".//div[@class='step']//span[contains(@class,'status')]");
+            Assert.That(stepStatuses[1].GetAttributeValue("class", ""), Is.EqualTo("status ignored"));
+            Assert.That(stepStatuses[1].InnerText.Trim(), Is.EqualTo("!"));
+        }
+
+        [Test]
+        public void Should_use_passed_ignored_css_class_for_step_ignored_in_composite_step()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithIgnoredStepInCompositeStep();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+            Assert.That(scenarioDiv.GetAttributeValue("class", ""), Is.EqualTo("scenario ignored"));
+
+            var scenarioStatus = scenarioDiv.SelectSingleNode("./h3//span[contains(@class,'status')]");
+            Assert.That(scenarioStatus.GetAttributeValue("class", ""), Is.EqualTo("status passed ignored"));
+            Assert.That(scenarioStatus.InnerText.Trim(), Is.EqualTo("\u2713"));
+
+            var stepStatuses = scenarioDiv.SelectNodes(".//div[@class='step']//span[contains(@class,'status')]");
+            Assert.That(stepStatuses[1].GetAttributeValue("class", ""), Is.EqualTo("status passed ignored"));
+            Assert.That(stepStatuses[1].InnerText.Trim(), Is.EqualTo("\u2713"));
+        }
+
+        [Test]
+        public void Should_use_ignored_css_class_for_step_with_all_substeps_ignored()
+        {
+            var result = ReportFormatterTestData.GetFeatureResultWithAllSubStepsIgnoredInCompositeStep();
+            var html = FormatAndParseHtml(result);
+
+            var scenarioDiv = html.DocumentNode.SelectSingleNode("//div[contains(@class,'scenario ignored')]");
+
+            var scenarioStatus = scenarioDiv.SelectSingleNode("./h3//span[contains(@class,'status')]");
+            Assert.That(scenarioStatus.GetAttributeValue("class", ""), Is.EqualTo("status passed ignored"));
+
+            var stepStatuses = scenarioDiv.SelectNodes(".//div[@class='step']//span[contains(@class,'status')]");
+            Assert.That(stepStatuses[1].GetAttributeValue("class", ""), Is.EqualTo("status ignored"));
+            Assert.That(stepStatuses[1].InnerText.Trim(), Is.EqualTo("!"));
+        }
+
         private string GetExpectedLightBddVersion()
         {
             return typeof(IBddRunner).GetTypeInfo().Assembly.GetName().Version.ToString(4);
@@ -420,6 +547,14 @@ $.[2].Surname=Smith";
             builder.FormatNode(doc.DocumentNode.SelectSingleNode("//body"));
             Debug.WriteLine(builder.ToString());
             return builder.ToString();
+        }
+
+        private HtmlDocument FormatAndParseHtml(params IFeatureResult[] results)
+        {
+            var formatted = FormatResults(results);
+            var doc = new HtmlDocument();
+            doc.LoadHtml(formatted);
+            return doc;
         }
 
         private string FormatAndExtractTreeText(string xpath, params IFeatureResult[] results)

--- a/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
+++ b/test/LightBDD.Framework.Reporting.UnitTests/Formatters/ReportFormatterTestData.cs
@@ -74,6 +74,58 @@ namespace LightBDD.Framework.Reporting.UnitTests.Formatters
                     TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5))));
         }
 
+        public static IFeatureResult GetFeatureResultWithIgnoredScenario()
+        {
+            return TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("name", null, _startDate.AddSeconds(1), TimeSpan.FromMilliseconds(45), null,
+                    TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, _startDate.AddSeconds(2), TimeSpan.FromMilliseconds(20)),
+                    TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5), "ignored reason"),
+                    TestResults.CreateStepResult(3, "step3", ExecutionStatus.NotRun)));
+        }
+
+        public static IFeatureResult GetFeatureResultWithAllStepsIgnored()
+        {
+            return TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("name", null, _startDate.AddSeconds(1), TimeSpan.FromMilliseconds(10), null,
+                    TestResults.CreateStepResult(1, "step1", ExecutionStatus.Ignored, _startDate.AddSeconds(2), TimeSpan.FromMilliseconds(5), "not ready"),
+                    TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5), "not ready")));
+        }
+
+        public static IFeatureResult GetFeatureResultWithIgnoredScenarioInCompositeStep()
+        {
+            return TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("name", null, _startDate.AddSeconds(1), TimeSpan.FromMilliseconds(30), null,
+                    TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, _startDate.AddSeconds(2), TimeSpan.FromMilliseconds(10)),
+                    TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(20), "ignored reason")
+                        .WithSubSteps(
+                            TestResults.CreateStepResult(1, "substep1", ExecutionStatus.Passed, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5)).WithGroupPrefix("2."),
+                            TestResults.CreateStepResult(2, "substep2", ExecutionStatus.Ignored, _startDate.AddSeconds(3).AddMilliseconds(5), TimeSpan.FromMilliseconds(5), "ignored reason").WithGroupPrefix("2."),
+                            TestResults.CreateStepResult(3, "substep3", ExecutionStatus.NotRun).WithGroupPrefix("2."))));
+        }
+
+        public static IFeatureResult GetFeatureResultWithIgnoredStepInCompositeStep()
+        {
+            return TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("name", null, _startDate.AddSeconds(1), TimeSpan.FromMilliseconds(30), null,
+                    TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, _startDate.AddSeconds(2), TimeSpan.FromMilliseconds(10)),
+                    TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(20), "step ignored")
+                        .WithSubSteps(
+                            TestResults.CreateStepResult(1, "substep1", ExecutionStatus.Passed, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5)).WithGroupPrefix("2."),
+                            TestResults.CreateStepResult(2, "substep2", ExecutionStatus.Ignored, _startDate.AddSeconds(3).AddMilliseconds(5), TimeSpan.FromMilliseconds(5), "step ignored").WithGroupPrefix("2."),
+                            TestResults.CreateStepResult(3, "substep3", ExecutionStatus.Passed, _startDate.AddSeconds(3).AddMilliseconds(10), TimeSpan.FromMilliseconds(5)).WithGroupPrefix("2."))));
+        }
+
+        public static IFeatureResult GetFeatureResultWithAllSubStepsIgnoredInCompositeStep()
+        {
+            return TestResults.CreateFeatureResult("My feature", null, null,
+                TestResults.CreateScenarioResult("name", null, _startDate.AddSeconds(1), TimeSpan.FromMilliseconds(30), null,
+                    TestResults.CreateStepResult(1, "step1", ExecutionStatus.Passed, _startDate.AddSeconds(2), TimeSpan.FromMilliseconds(10)),
+                    TestResults.CreateStepResult(2, "step2", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(20), "all ignored")
+                        .WithSubSteps(
+                            TestResults.CreateStepResult(1, "substep1", ExecutionStatus.Ignored, _startDate.AddSeconds(3), TimeSpan.FromMilliseconds(5), "not ready").WithGroupPrefix("2."),
+                            TestResults.CreateStepResult(2, "substep2", ExecutionStatus.Ignored, _startDate.AddSeconds(3).AddMilliseconds(5), TimeSpan.FromMilliseconds(5), "not ready").WithGroupPrefix("2."))));
+        }
+
         public static IFeatureResult GetFeatureWithUnsortedScenarios()
         {
             return TestResults.CreateFeatureResult("My Feature", null, null,


### PR DESCRIPTION
Add `StepExecution.Current.IgnoreStep(reason)` API to skip individual steps without aborting the entire scenario

#### Details

Issue reference: #397

List of changes:

**New public API:**
- Added `StepExecution.Current.IgnoreStep(string reason)` method in `LightBDD.Framework` — analogous to the existing `IgnoreScenario(reason)`, but scoped to a single step. When called, the current step is marked as `ExecutionStatus.Ignored` and the scenario continues executing all subsequent steps normally. This contrasts with `IgnoreScenario()` which aborts the entire scenario and marks remaining steps as `NotRun`.
- Added `StepIgnoreException` public exception class in `LightBDD.Core.Execution` — the flow-control exception thrown by `IgnoreStep()`, following the same pattern as the existing `StepBypassException`.

**Core execution pipeline changes:**
- `RunnableStep.HandleException()` — added a new case to catch `ScenarioExecutionException { InnerException: StepIgnoreException }` and set the step status to `ExecutionStatus.Ignored` with the exception message as status details. Crucially, the exception is **not** captured into the `ExceptionCollector`, so it does not propagate and does not abort execution of subsequent steps.
- `ExceptionCollector.CollectFor()` — added an early-return for empty exception arrays (`if (exceptions.Length == 0) return null`). This is necessary because `IgnoreStep` introduces a new state that didn't previously exist: a step with `ExecutionStatus.Ignored` status but **no captured exception**. With the existing `IgnoreScenario()`, the exception always gets captured into the collector via `ExceptionProcessor`, so the `exceptions` array was never empty when status was `Ignored`. But with `IgnoreStep()`, the exception is deliberately not captured (to allow continuation), meaning `CollectFor()` can now be called with `Ignored` status and an empty array. Without this guard, the original code unconditionally called `.First()` on the empty array, causing an `InvalidOperationException: Sequence contains no elements` crash.

**Decorator support:**
- `StepIgnoreException` can be thrown from `IStepDecoratorAttribute.ExecuteAsync()` implementations to achieve the same step-level ignore behavior declaratively, enabling attribute-based step skipping patterns (e.g. `[IgnoreStepIf(...)]`).

**HTML report — visual distinction for IgnoreStep vs IgnoreScenario:**

Scenarios and composite steps where `IgnoreStep` was used now render with a distinct visual badge, differentiating them from scenarios aborted by `IgnoreScenario`:

- **IgnoreStep scenarios/steps** — status badge uses `class="status passed ignored"` with a green-to-yellow gradient background (`linear-gradient(to right, #1daf26, #fbc800)`) and `✓` checkmark symbol. This indicates the scenario completed execution but had some steps ignored.
- **IgnoreScenario scenarios/steps** — status badge remains `class="status ignored"` with the solid yellow background (`#fbc800`) and `!` symbol, as before.

The detection logic distinguishes the two cases by examining the step tree:
- **IgnoreStep**: scenario/step is `Ignored`, has at least one `Passed` child step, and has **no** `NotRun` steps anywhere in the subtree (because execution continued).
- **IgnoreScenario**: scenario/step is `Ignored`, but has `NotRun` steps somewhere in the subtree (because execution was aborted, leaving remaining steps unexecuted).

This applies recursively — composite steps with ignored substeps also render with the correct badge via `GetStepStatus()`.

Changes made:
- `HtmlResultTextWriter.cs` — added `GetScenarioStatus(IScenarioResult)`, `GetStepStatus(IStepResult)`, `GetPassedIgnoredStatus()`, `IsPassedIgnored(IEnumerable<IStepResult>)`, and `HasNotRunRecursive(IStepResult)` methods. `GetScenario` and `GetStep` call `GetScenarioStatus`/`GetStepStatus` instead of the generic `GetStatus(ExecutionStatus)`. The detection logic uses a single-pass `IsPassedIgnored()` helper that checks for both `Passed` steps and `NotRun` substeps in one traversal, with `HasNotRunRecursive()` performing a simple recursive DFS without LINQ intermediate object allocations — avoiding the overhead of the `GetAllSteps()` recursive LINQ chain and eliminating double enumeration of substep collections.
- `styles.css` — added `.status.passed.ignored` CSS rule with gradient and white text, placed between `.status.passed` and `.status.failed` for correct specificity.

Note: The scenario `<div>` class remains `"scenario ignored"` in both cases, preserving existing JavaScript filter behavior. Only the status badge inside visually changes.

**Other report formatters — no changes required:**
- XML, plain text, and Markdown formatters already fully support `ExecutionStatus.Ignored` because `IgnoreScenario` already produces steps with this status. `IgnoreStep` sets the exact same status value, so steps are automatically rendered correctly in those formats.

**Design notes:**

- **`IgnoreStep` is on `StepExecution` directly, while `IgnoreScenario` is a per-framework extension method.** This asymmetry is intentional. `IgnoreScenario` must throw framework-specific exceptions (xUnit's `IgnoreException`, NUnit's `Assert.Ignore()`, MSTest's `Assert.Inconclusive()`, TUnit's `Skip.Test()`) so the test runner marks the entire test as skipped. Each framework has its own exception type, so `IgnoreScenario` must be defined as an extension method in each integration package. `IgnoreStep` doesn't need this — `StepIgnoreException` is caught internally by `RunnableStep` and never reaches the test runner — so it can live framework-agnostically on `StepExecution` itself.

- **The test framework sees the test as passed, not skipped.** Unlike `IgnoreScenario()` which causes the test to be marked "Skipped" by the external test runner, `IgnoreStep()` does **not** propagate any exception to the test framework. The test passes from the runner's perspective. The step's ignored status is only visible in LightBDD's own execution results and reports (e.g. the FeaturesReport HTML).

- **`IgnoreStep` follows the `Bypass` execution pattern, not the `IgnoreScenario` pattern.** Both `Bypass()` and `IgnoreStep()` set the step status in `HandleException` without capturing the exception into the `ExceptionCollector`, which allows subsequent steps to continue. The difference is the status severity: `Ignored > Bypassed > Passed` in the `ExecutionStatus` enum precedence. By contrast, `IgnoreScenario()` follows a completely different code path through `ExceptionProcessor.UpdateResultsWithException()`, which captures the exception and causes it to propagate up, aborting all remaining steps.

**Core unit tests added (10 new test methods):**
- `StepExecution_tests.IgnoreStep_should_fail_when_called_outside_of_step` — API boundary validation
- `CoreBddRunner_step_metadata_collection_tests.It_should_capture_ignored_step_and_continue_scenario` — single ignored step with continuation
- `CoreBddRunner_step_metadata_collection_tests.It_should_capture_multiple_ignored_steps_and_continue_scenario` — multiple ignored steps in one scenario, all subsequent steps still execute
- `CoreBddRunner_scenario_metadata_collection_tests.It_should_capture_scenario_status_for_step_ignored_via_IgnoreStep` — scenario status becomes `Ignored`
- `CoreBddRunner_scenario_metadata_collection_tests.It_should_capture_failed_scenario_status_when_step_is_ignored_and_later_step_fails` — `Failed > Ignored` status precedence with aggregated `StatusDetails`
- `CoreBddRunner_scenario_metadata_collection_tests.It_should_capture_ignored_scenario_status_when_step_is_ignored_and_another_is_bypassed` — `Ignored > Bypassed` status precedence
- `CoreBddRunner_hierarchical_step_execution_tests.Runner_should_mark_step_ignored_if_substep_uses_IgnoreStep_and_continue_remaining_substeps` — composite step with ignored substep, remaining substeps continue
- `CoreBddRunner_execution_extension_tests.It_should_IGNORE_step_and_continue_scenario_based_on_step_decorator_throwing_StepIgnoreException` — `IStepDecoratorAttribute` throwing `StepIgnoreException` marks step as `Ignored` and continues
- `CoreBddRunner_multiassert_step_execution_tests.Runner_should_continue_multiassert_substeps_when_IgnoreStep_is_used` — `[MultiAssert]` composite with `IgnoreStep`, sub-steps individually ignored while remaining sub-steps and groups continue
- `CoreBddRunner_complex_parameter_step_execution_tests.Runner_should_honor_step_ignored_via_IgnoreStep` — `IgnoreStep` takes precedence over parameter verification failures

**Reporting unit tests added (9 new test methods + 5 test data methods):**

Test data methods in `ReportFormatterTestData.cs`:
- `GetFeatureResultWithIgnoredScenario()` — Passed + Ignored + NotRun steps (IgnoreScenario pattern)
- `GetFeatureResultWithAllStepsIgnored()` — all steps Ignored, no Passed
- `GetFeatureResultWithIgnoredScenarioInCompositeStep()` — composite step with NotRun substep (IgnoreScenario in substep)
- `GetFeatureResultWithIgnoredStepInCompositeStep()` — composite step with Passed + Ignored substeps, no NotRun (IgnoreStep in substep)
- `GetFeatureResultWithAllSubStepsIgnoredInCompositeStep()` — composite step with all Ignored substeps

Test methods in `HtmlReportFormatter_tests.cs`:
- `Should_format_ignored_scenario_with_not_run_steps_as_ignored` — IgnoreScenario renders `!` in plain text
- `Should_format_all_steps_ignored_scenario_as_ignored` — all-Ignored scenario renders `!`
- `Should_use_passed_ignored_css_class_for_step_ignored_scenario` — IgnoreStep scenario gets `class="status passed ignored"` + `✓`, div stays `class="scenario ignored"`
- `Should_use_ignored_css_class_for_scenario_ignored_scenario` — IgnoreScenario gets `class="status ignored"` + `!`
- `Should_use_ignored_css_class_for_all_steps_ignored_scenario` — all-Ignored gets plain `class="status ignored"`
- `Should_include_passed_ignored_css_rule_in_stylesheet` — verifies `.status.passed.ignored` and `linear-gradient` in embedded CSS
- `Should_use_ignored_css_class_for_scenario_ignored_in_composite_step` — IgnoreScenario in substep → both scenario and step show `status ignored`
- `Should_use_passed_ignored_css_class_for_step_ignored_in_composite_step` — IgnoreStep in substep → both scenario and step show `status passed ignored`
- `Should_use_ignored_css_class_for_step_with_all_substeps_ignored` — composite step with all-Ignored substeps → step shows `status ignored`, scenario shows `status passed ignored`

##Manual Testing
Creating some manual tests of various forms create this output in the FeaturesReport.html:

<img width="701" height="1134" alt="image" src="https://github.com/user-attachments/assets/04e01b17-c6a8-4416-b5eb-ec1a277501bc" />

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)