### PR TITLE
#399 Added BypassStepIf and IgnoreScenarioIf attributes

### DIFF
--- a/src/LightBDD.Fixie3/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.Fixie3/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+
+namespace LightBDD.Fixie3
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored by throwing an <see cref="IgnoreException"/>,
+    /// causing Fixie to mark the test as skipped. Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                    throw new IgnoreException(string.Join("; ", _reasons));
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.Framework/BypassStepIfAttribute.cs
+++ b/src/LightBDD.Framework/BypassStepIfAttribute.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.ExecutionContext;
+using LightBDD.Core.Extensibility.Execution;
+
+namespace LightBDD.Framework
+{
+    /// <summary>
+    /// Step decorator attribute that conditionally bypasses the decorated step based on a boolean property
+    /// from the fixture's <see cref="IBypassable{T}.BypassSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the step is bypassed with the specified reasons.
+    /// Otherwise, the step executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IBypassable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the step always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class BypassStepIfAttribute : BypassStepIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IBypassable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class BypassStepIfAttribute<T> : Attribute, IStepDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the step is bypassed.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the bypass message.</param>
+        public BypassStepIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IStep step, Func<Task> stepInvocation)
+        {
+            var settings = (ScenarioExecutionContext.CurrentScenario.Fixture as IBypassable<T>)?.BypassSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                {
+                    StepExecution.Current.Bypass(string.Join("; ", _reasons));
+                    return Task.CompletedTask;
+                }
+            }
+            return stepInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.Framework/IBypassable.cs
+++ b/src/LightBDD.Framework/IBypassable.cs
@@ -1,0 +1,17 @@
+namespace LightBDD.Framework
+{
+    /// <summary>
+    /// Interface for test fixtures that expose a settings object controlling conditional step bypass behavior.
+    /// <para>
+    /// Implement this on the test fixture class to enable <see cref="BypassStepIfAttribute{T}"/>.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object whose boolean properties control conditional bypassing.</typeparam>
+    public interface IBypassable<out T> where T : class
+    {
+        /// <summary>
+        /// Returns the settings object whose boolean properties determine whether steps should be bypassed.
+        /// </summary>
+        T BypassSettings { get; }
+    }
+}

--- a/src/LightBDD.Framework/IIgnorable.cs
+++ b/src/LightBDD.Framework/IIgnorable.cs
@@ -1,0 +1,18 @@
+namespace LightBDD.Framework
+{
+    /// <summary>
+    /// Interface for test fixtures that expose a settings object controlling conditional scenario ignore behavior.
+    /// <para>
+    /// Implement this on the test fixture class to enable framework-specific <c>IgnoreScenarioIfAttribute&lt;T&gt;</c> attributes.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object whose boolean properties control conditional ignoring.</typeparam>
+    public interface IIgnorable<out T> where T : class
+    {
+        /// <summary>
+        /// Returns the settings object whose boolean properties determine whether scenarios should be ignored.
+        /// </summary>
+        T IgnoreSettings { get; }
+    }
+}
+

--- a/src/LightBDD.MsTest3/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.MsTest3/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest3
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored using MSTest's <see cref="Assert.Inconclusive(string)"/>.
+    /// Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                {
+                    Assert.Inconclusive(string.Join("; ", _reasons));
+                    return Task.CompletedTask;
+                }
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.MsTest4/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.MsTest4/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest4
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored using MSTest's <see cref="Assert.Inconclusive(string)"/>.
+    /// Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                {
+                    Assert.Inconclusive(string.Join("; ", _reasons));
+                    return Task.CompletedTask;
+                }
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.NUnit3/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.NUnit3/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+using NUnit.Framework;
+
+namespace LightBDD.NUnit3
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored using NUnit's <see cref="Assert.Ignore(string)"/>.
+    /// Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                {
+                    Assert.Ignore(string.Join("; ", _reasons));
+                    return Task.CompletedTask;
+                }
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.TUnit/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.TUnit/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+
+namespace LightBDD.TUnit
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored using TUnit's <c>Skip.Test()</c>,
+    /// causing TUnit to mark the test as skipped. Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                {
+                    Skip.Test(string.Join("; ", _reasons));
+                    return Task.CompletedTask;
+                }
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/src/LightBDD.XUnit2/IgnoreScenarioIfAttribute.cs
+++ b/src/LightBDD.XUnit2/IgnoreScenarioIfAttribute.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Extensibility.Execution;
+using LightBDD.Framework;
+using LightBDD.XUnit2.Implementation.Customization;
+
+namespace LightBDD.XUnit2
+{
+    /// <summary>
+    /// Scenario decorator attribute that conditionally ignores the decorated scenario based on a boolean property
+    /// from the fixture's <see cref="IIgnorable{T}.IgnoreSettings"/> object.
+    /// <para>
+    /// When the setting evaluates to <c>true</c>, the scenario is ignored by throwing an <c>IgnoreException</c>,
+    /// causing xUnit to mark the test as skipped. Otherwise, the scenario executes normally.
+    /// </para>
+    /// <para>
+    /// The test fixture must implement <see cref="IIgnorable{T}"/> for this attribute to take effect.
+    /// If the fixture does not implement the interface, the scenario always executes normally.
+    /// </para>
+    /// <para>
+    /// This is a generic attribute class. To use it, derive a non-generic class that specifies the settings type:
+    /// <code>
+    /// public class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute&lt;MySettings&gt;
+    /// {
+    ///     public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    /// }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the settings object exposed by <see cref="IIgnorable{T}"/>.</typeparam>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class IgnoreScenarioIfAttribute<T> : Attribute, IScenarioDecoratorAttribute where T : class
+    {
+        private readonly string _settingName;
+        private readonly string[] _reasons;
+
+        /// <summary>
+        /// Initializes the attribute with the name of a boolean property on <typeparamref name="T"/>
+        /// and the reasons to report if the scenario is ignored.
+        /// </summary>
+        /// <param name="settingName">The name of a boolean property on <typeparamref name="T"/> to evaluate. Use <c>nameof(...)</c> for compile-time safety.</param>
+        /// <param name="reasons">One or more reasons to include in the ignore message.</param>
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons)
+        {
+            _settingName = settingName;
+            _reasons = reasons;
+        }
+
+        /// <inheritdoc />
+        public Task ExecuteAsync(IScenario scenario, Func<Task> scenarioInvocation)
+        {
+            var settings = (scenario.Fixture as IIgnorable<T>)?.IgnoreSettings;
+            if (settings != null)
+            {
+                var property = typeof(T).GetProperty(_settingName);
+                if (property?.GetValue(settings) is true)
+                    throw new IgnoreException(string.Join("; ", _reasons));
+            }
+            return scenarioInvocation();
+        }
+
+        /// <summary>
+        /// Order in which extensions should be applied, where instances of lower values would be executed first.
+        /// Default value is <c>1</c>.
+        /// </summary>
+        public int Order { get; set; } = 1;
+    }
+}

--- a/test/LightBDD.Fixie3.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.Fixie3.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using Shouldly;
+
+namespace LightBDD.Fixie3.UnitTests
+{
+    public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+    {
+        public class TestSettings
+        {
+            public bool ShouldBypass { get; set; }
+            public bool ShouldIgnore { get; set; }
+        }
+
+        private TestSettings _settings = new();
+        public TestSettings BypassSettings => _settings;
+        public TestSettings IgnoreSettings => _settings;
+
+        private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+        {
+            public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+        {
+            public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+        public void Runner_should_bypass_step_when_setting_is_true()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+            result.Status.ShouldBe(ExecutionStatus.Bypassed);
+            result.GetSteps().Single().Status.ShouldBe(ExecutionStatus.Bypassed);
+            result.StatusDetails.ShouldContain("bypass reason");
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+        public void Runner_should_execute_step_when_bypass_setting_is_false()
+        {
+            _settings.ShouldBypass = false;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+            result.Status.ShouldBe(ExecutionStatus.Passed);
+            result.GetSteps().Single().Status.ShouldBe(ExecutionStatus.Passed);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+        public void Runner_should_ignore_scenario_when_setting_is_true()
+        {
+            _settings.ShouldIgnore = true;
+            Should.Throw<IgnoreException>(() => Runner.RunScenario(_ => Some_step()))
+                .Message.ShouldBe("ignore reason");
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+            result.Status.ShouldBe(ExecutionStatus.Ignored);
+            result.StatusDetails.ShouldBe("Scenario: ignore reason");
+            result.GetSteps().Single().Status.ShouldBe(ExecutionStatus.NotRun);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+        public void Runner_should_execute_scenario_when_ignore_setting_is_false()
+        {
+            _settings.ShouldIgnore = false;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+            result.Status.ShouldBe(ExecutionStatus.Passed);
+            result.GetSteps().Single().Status.ShouldBe(ExecutionStatus.Passed);
+        }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+        private void Conditionally_bypassed_step() { }
+
+        private void Some_step() { }
+
+        private IScenarioResult GetScenarioResult(string scenarioId)
+        {
+            return FeatureRunnerProvider.GetRunnerFor(GetType())
+                .GetFeatureResult()
+                .GetScenarios()
+                .Single(s => s.Info.Labels.Contains(scenarioId));
+        }
+    }
+}

--- a/test/LightBDD.MsTest3.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.MsTest3.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest3.UnitTests
+{
+    [TestClass]
+    public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+    {
+        public class TestSettings
+        {
+            public bool ShouldBypass { get; set; }
+            public bool ShouldIgnore { get; set; }
+        }
+
+        private TestSettings _settings = new();
+        public TestSettings BypassSettings => _settings;
+        public TestSettings IgnoreSettings => _settings;
+
+        private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+        {
+            public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+        {
+            public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+        public void Runner_should_bypass_step_when_setting_is_true()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+            Assert.AreEqual(ExecutionStatus.Bypassed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Bypassed, result.GetSteps().Single().Status);
+            StringAssert.Contains(result.StatusDetails, "bypass reason");
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+        public void Runner_should_execute_step_when_bypass_setting_is_false()
+        {
+            _settings.ShouldBypass = false;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+            Assert.AreEqual(ExecutionStatus.Passed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+        public void Runner_should_ignore_scenario_when_setting_is_true()
+        {
+            _settings.ShouldIgnore = true;
+            var ex = Assert.ThrowsExactly<AssertInconclusiveException>(() => Runner.RunScenario(_ => Some_step()));
+            StringAssert.Matches(ex.Message, new Regex("Assert.Inconclusive .*. ignore reason"));
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+            Assert.AreEqual(ExecutionStatus.Ignored, result.Status);
+            StringAssert.Matches(result.StatusDetails, new Regex("Scenario: Assert.Inconclusive .*. ignore reason"));
+            Assert.AreEqual(ExecutionStatus.NotRun, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+        public void Runner_should_execute_scenario_when_ignore_setting_is_false()
+        {
+            _settings.ShouldIgnore = false;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+            Assert.AreEqual(ExecutionStatus.Passed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+        private void Conditionally_bypassed_step() { }
+
+        private void Some_step() { }
+
+        private IScenarioResult GetScenarioResult(string scenarioId)
+        {
+            return FeatureRunnerProvider.GetRunnerFor(GetType())
+                .GetFeatureResult()
+                .GetScenarios()
+                .Single(s => s.Info.Labels.Contains(scenarioId));
+        }
+    }
+}

--- a/test/LightBDD.MsTest4.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.MsTest4.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest4.UnitTests
+{
+    [TestClass]
+    public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+    {
+        public class TestSettings
+        {
+            public bool ShouldBypass { get; set; }
+            public bool ShouldIgnore { get; set; }
+        }
+
+        private TestSettings _settings = new();
+        public TestSettings BypassSettings => _settings;
+        public TestSettings IgnoreSettings => _settings;
+
+        private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+        {
+            public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+        {
+            public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+        public void Runner_should_bypass_step_when_setting_is_true()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+            Assert.AreEqual(ExecutionStatus.Bypassed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Bypassed, result.GetSteps().Single().Status);
+            StringAssert.Contains(result.StatusDetails, "bypass reason");
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+        public void Runner_should_execute_step_when_bypass_setting_is_false()
+        {
+            _settings.ShouldBypass = false;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+            Assert.AreEqual(ExecutionStatus.Passed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+        public void Runner_should_ignore_scenario_when_setting_is_true()
+        {
+            _settings.ShouldIgnore = true;
+            var ex = Assert.ThrowsExactly<AssertInconclusiveException>(() => Runner.RunScenario(_ => Some_step()));
+            StringAssert.Matches(ex.Message, new Regex("Assert.Inconclusive .*. ignore reason"));
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+            Assert.AreEqual(ExecutionStatus.Ignored, result.Status);
+            StringAssert.Matches(result.StatusDetails, new Regex("Scenario: Assert.Inconclusive .*. ignore reason"));
+            Assert.AreEqual(ExecutionStatus.NotRun, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+        public void Runner_should_execute_scenario_when_ignore_setting_is_false()
+        {
+            _settings.ShouldIgnore = false;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+            Assert.AreEqual(ExecutionStatus.Passed, result.Status);
+            Assert.AreEqual(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+        private void Conditionally_bypassed_step() { }
+
+        private void Some_step() { }
+
+        private IScenarioResult GetScenarioResult(string scenarioId)
+        {
+            return FeatureRunnerProvider.GetRunnerFor(GetType())
+                .GetFeatureResult()
+                .GetScenarios()
+                .Single(s => s.Info.Labels.Contains(scenarioId));
+        }
+    }
+}

--- a/test/LightBDD.NUnit3.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.NUnit3.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,217 @@
+using System.Linq;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using NUnit.Framework;
+
+namespace LightBDD.NUnit3.UnitTests
+{
+    [TestFixture]
+    public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+    {
+        public class TestSettings
+        {
+            public bool ShouldBypass { get; set; }
+            public bool ShouldIgnore { get; set; }
+        }
+
+        private TestSettings _settings = new();
+        public TestSettings BypassSettings => _settings;
+        public TestSettings IgnoreSettings => _settings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settings = new TestSettings();
+        }
+
+        private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+        {
+            public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+        {
+            public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+        public void Runner_should_bypass_step_when_setting_is_true()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            Assert.That(result.StatusDetails, Does.Contain("bypass reason"));
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+        public void Runner_should_execute_step_when_bypass_setting_is_false()
+        {
+            _settings.ShouldBypass = false;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+        public void Runner_should_ignore_scenario_when_setting_is_true()
+        {
+            _settings.ShouldIgnore = true;
+            var ex = Assert.Throws<IgnoreException>(() => Runner.RunScenario(_ => Some_step()));
+            Assert.That(ex.Message, Is.EqualTo("ignore reason"));
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Ignored));
+            Assert.That(result.StatusDetails, Is.EqualTo("Scenario: ignore reason"));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.NotRun));
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+        public void Runner_should_execute_scenario_when_ignore_setting_is_false()
+        {
+            _settings.ShouldIgnore = false;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_with_multiple_reasons_joined))]
+        public void Runner_should_bypass_step_with_multiple_reasons_joined()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Step_with_multiple_bypass_reasons());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_with_multiple_reasons_joined));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            Assert.That(result.StatusDetails, Does.Contain("reason one; reason two"));
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_continue_subsequent_steps_after_bypass))]
+        public void Runner_should_continue_subsequent_steps_after_bypass()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(
+                _ => Conditionally_bypassed_step(),
+                _ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_continue_subsequent_steps_after_bypass));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            var steps = result.GetSteps().ToArray();
+            Assert.That(steps[0].Status, Is.EqualTo(ExecutionStatus.Bypassed));
+            Assert.That(steps[1].Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_fixture_does_not_implement_IIgnorable))]
+        public void Runner_should_execute_step_when_fixture_does_not_implement_IIgnorable()
+        {
+            // The attribute targets TestSettings, but BypassStepIfAttribute<OtherSettings> won't find IIgnorable<OtherSettings>
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Step_with_unmatched_settings_type());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_fixture_does_not_implement_IIgnorable));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_setting_property_does_not_exist))]
+        public void Runner_should_execute_step_when_setting_property_does_not_exist()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Step_with_nonexistent_property());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_setting_property_does_not_exist));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "reason one", "reason two")]
+        [Label(nameof(Runner_should_ignore_scenario_with_multiple_reasons_joined))]
+        public void Runner_should_ignore_scenario_with_multiple_reasons_joined()
+        {
+            _settings.ShouldIgnore = true;
+            var ex = Assert.Throws<IgnoreException>(() => Runner.RunScenario(_ => Some_step()));
+            Assert.That(ex.Message, Is.EqualTo("reason one; reason two"));
+        }
+
+        [Scenario]
+        [IgnoreScenarioIfAttribute_with_other_settings(nameof(OtherSettings.Flag), "other")]
+        [Label(nameof(Runner_should_execute_scenario_when_fixture_does_not_implement_IIgnorable_for_settings_type))]
+        public void Runner_should_execute_scenario_when_fixture_does_not_implement_IIgnorable_for_settings_type()
+        {
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_fixture_does_not_implement_IIgnorable_for_settings_type));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf("NonExistentProperty", "should not ignore")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_property_does_not_exist))]
+        public void Runner_should_execute_scenario_when_ignore_setting_property_does_not_exist()
+        {
+            _settings.ShouldIgnore = true;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_property_does_not_exist));
+
+            Assert.That(result.Status, Is.EqualTo(ExecutionStatus.Passed));
+            Assert.That(result.GetSteps().Single().Status, Is.EqualTo(ExecutionStatus.Passed));
+        }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+        private void Conditionally_bypassed_step() { }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "reason one", "reason two")]
+        private void Step_with_multiple_bypass_reasons() { }
+
+        [BypassStepIfAttribute_with_other_settings(nameof(OtherSettings.Flag), "other")]
+        private void Step_with_unmatched_settings_type() { }
+
+        [BypassStepIf("NonExistentProperty", "should not bypass")]
+        private void Step_with_nonexistent_property() { }
+
+        private void Some_step() { }
+
+        public class OtherSettings
+        {
+            public bool Flag { get; set; }
+        }
+
+        private class BypassStepIfAttribute_with_other_settings : BypassStepIfAttribute<OtherSettings>
+        {
+            public BypassStepIfAttribute_with_other_settings(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute_with_other_settings : IgnoreScenarioIfAttribute<OtherSettings>
+        {
+            public IgnoreScenarioIfAttribute_with_other_settings(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private IScenarioResult GetScenarioResult(string scenarioId)
+        {
+            return FeatureRunnerProvider.GetRunnerFor(GetType())
+                .GetFeatureResult()
+                .GetScenarios()
+                .Single(s => s.Info.Labels.Contains(scenarioId));
+        }
+    }
+}

--- a/test/LightBDD.TUnit.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.TUnit.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Threading.Tasks;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using TUnit.Core.Exceptions;
+
+namespace LightBDD.TUnit.UnitTests;
+
+public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+{
+    public class TestSettings
+    {
+        public bool ShouldBypass { get; set; }
+        public bool ShouldIgnore { get; set; }
+    }
+
+    private TestSettings _settings = new();
+    public TestSettings BypassSettings => _settings;
+    public TestSettings IgnoreSettings => _settings;
+
+    private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+    {
+        public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    }
+
+    internal class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+    {
+        public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+    }
+
+    [Scenario]
+    [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+    public async Task Runner_should_bypass_step_when_setting_is_true()
+    {
+        _settings.ShouldBypass = true;
+        Runner.RunScenario(_ => Conditionally_bypassed_step());
+        var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+        await Assert.That(result.Status).IsEqualTo(ExecutionStatus.Bypassed);
+        await Assert.That(result.GetSteps().Single().Status).IsEqualTo(ExecutionStatus.Bypassed);
+        await Assert.That(result.StatusDetails).Contains("bypass reason");
+    }
+
+    [Scenario]
+    [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+    public async Task Runner_should_execute_step_when_bypass_setting_is_false()
+    {
+        _settings.ShouldBypass = false;
+        Runner.RunScenario(_ => Conditionally_bypassed_step());
+        var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+        await Assert.That(result.Status).IsEqualTo(ExecutionStatus.Passed);
+        await Assert.That(result.GetSteps().Single().Status).IsEqualTo(ExecutionStatus.Passed);
+    }
+
+    [Scenario]
+    [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+    [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+    public async Task Runner_should_ignore_scenario_when_setting_is_true()
+    {
+        _settings.ShouldIgnore = true;
+        await Assert.That(() => Runner.RunScenario(_ => Some_step()))
+            .Throws<SkipTestException>()
+            .WithMessage("ignore reason");
+        var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+        await Assert.That(result.Status).IsEqualTo(ExecutionStatus.Ignored);
+        await Assert.That(result.StatusDetails).IsEqualTo("Scenario: ignore reason");
+        await Assert.That(result.GetSteps().Single().Status).IsEqualTo(ExecutionStatus.NotRun);
+    }
+
+    [Scenario]
+    [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+    [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+    public async Task Runner_should_execute_scenario_when_ignore_setting_is_false()
+    {
+        _settings.ShouldIgnore = false;
+        Runner.RunScenario(_ => Some_step());
+        var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+        await Assert.That(result.Status).IsEqualTo(ExecutionStatus.Passed);
+        await Assert.That(result.GetSteps().Single().Status).IsEqualTo(ExecutionStatus.Passed);
+    }
+
+    [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+    private void Conditionally_bypassed_step() { }
+
+    private void Some_step() { }
+
+    private IScenarioResult GetScenarioResult(string scenarioId)
+    {
+        return FeatureRunnerProvider.GetRunnerFor(GetType())
+            .GetFeatureResult()
+            .GetScenarios()
+            .Single(s => s.Info.Labels.Contains(scenarioId));
+    }
+}

--- a/test/LightBDD.XUnit2.UnitTests/ConditionalDecoratorAttribute_tests.cs
+++ b/test/LightBDD.XUnit2.UnitTests/ConditionalDecoratorAttribute_tests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using LightBDD.Core.Results;
+using LightBDD.Framework;
+using LightBDD.Framework.Scenarios;
+using Xunit;
+#pragma warning disable xUnit1026
+
+namespace LightBDD.XUnit2.UnitTests
+{
+    public class ConditionalDecoratorAttribute_tests : FeatureFixture, IBypassable<ConditionalDecoratorAttribute_tests.TestSettings>, IIgnorable<ConditionalDecoratorAttribute_tests.TestSettings>
+    {
+        public class TestSettings
+        {
+            public bool ShouldBypass { get; set; }
+            public bool ShouldIgnore { get; set; }
+        }
+
+        private readonly TestSettings _settings = new();
+        public TestSettings BypassSettings => _settings;
+        public TestSettings IgnoreSettings => _settings;
+
+        private class BypassStepIfAttribute : BypassStepIfAttribute<TestSettings>
+        {
+            public BypassStepIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        private class IgnoreScenarioIfAttribute : IgnoreScenarioIfAttribute<TestSettings>
+        {
+            public IgnoreScenarioIfAttribute(string settingName, params string[] reasons) : base(settingName, reasons) { }
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_bypass_step_when_setting_is_true))]
+        public void Runner_should_bypass_step_when_setting_is_true()
+        {
+            _settings.ShouldBypass = true;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_bypass_step_when_setting_is_true));
+
+            Assert.Equal(ExecutionStatus.Bypassed, result.Status);
+            Assert.Equal(ExecutionStatus.Bypassed, result.GetSteps().Single().Status);
+            Assert.Contains("bypass reason", result.StatusDetails);
+        }
+
+        [Scenario]
+        [Label(nameof(Runner_should_execute_step_when_bypass_setting_is_false))]
+        public void Runner_should_execute_step_when_bypass_setting_is_false()
+        {
+            _settings.ShouldBypass = false;
+            Runner.RunScenario(_ => Conditionally_bypassed_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_step_when_bypass_setting_is_false));
+
+            Assert.Equal(ExecutionStatus.Passed, result.Status);
+            Assert.Equal(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_ignore_scenario_when_setting_is_true))]
+        public void Runner_should_ignore_scenario_when_setting_is_true()
+        {
+            _settings.ShouldIgnore = true;
+            var ex = Assert.ThrowsAny<Exception>(() => Runner.RunScenario(_ => Some_step()));
+            Assert.Equal("ignore reason", ex.Message);
+            var result = GetScenarioResult(nameof(Runner_should_ignore_scenario_when_setting_is_true));
+
+            Assert.Equal(ExecutionStatus.Ignored, result.Status);
+            Assert.Equal("Scenario: ignore reason", result.StatusDetails);
+            Assert.Equal(ExecutionStatus.NotRun, result.GetSteps().Single().Status);
+        }
+
+        [Scenario]
+        [IgnoreScenarioIf(nameof(TestSettings.ShouldIgnore), "ignore reason")]
+        [Label(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false))]
+        public void Runner_should_execute_scenario_when_ignore_setting_is_false()
+        {
+            _settings.ShouldIgnore = false;
+            Runner.RunScenario(_ => Some_step());
+            var result = GetScenarioResult(nameof(Runner_should_execute_scenario_when_ignore_setting_is_false));
+
+            Assert.Equal(ExecutionStatus.Passed, result.Status);
+            Assert.Equal(ExecutionStatus.Passed, result.GetSteps().Single().Status);
+        }
+
+        [BypassStepIf(nameof(TestSettings.ShouldBypass), "bypass reason")]
+        private void Conditionally_bypassed_step() { }
+
+        private void Some_step() { }
+
+        private IScenarioResult GetScenarioResult(string scenarioId)
+        {
+            return FeatureRunnerProvider.GetRunnerFor(GetType())
+                .GetFeatureResult()
+                .GetScenarios()
+                .Single(s => s.Info.Labels.Contains(scenarioId));
+        }
+    }
+}


### PR DESCRIPTION
Add generic decorator attributes that conditionally bypass steps or ignore scenarios based on a boolean property from a fixture's settings object. `BypassStepIfAttribute<T>` calls `StepExecution.Current.Bypass()` for steps; `IgnoreScenarioIfAttribute<T>` triggers the framework-specific ignore/skip mechanism for scenarios.

#### Details

Issue reference: #398

**Motivation:** When running BDD scenarios across different environments or configurations, it's common to need conditional execution — e.g. bypass a step that depends on an unavailable service, or ignore a scenario that doesn't apply to the current deployment target. Today this requires imperative logic inside steps/scenarios. These attributes provide a clean, declarative alternative.

List of changes:

**New interfaces** (`LightBDD.Framework`):

| Interface | Purpose |
|---|---|
| `IBypassable<T>` | Exposes `T BypassSettings { get; }` on the test fixture. Boolean properties on `T` control step bypass. |
| `IIgnorable<T>` | Exposes `T IgnoreSettings { get; }` on the test fixture. Boolean properties on `T` control scenario ignore. |

**New attributes:**

| Attribute | Location | Decorator type | Behavior when setting is `true` |
|---|---|---|---|
| `BypassStepIfAttribute<T>` | `LightBDD.Framework` | `IStepDecoratorAttribute` | Calls `StepExecution.Current.Bypass()` with joined reason(s) |
| `IgnoreScenarioIfAttribute<T>` | Per-framework package | `IScenarioDecoratorAttribute` | Triggers framework-specific ignore/skip |

`IgnoreScenarioIfAttribute<T>` is implemented in each framework integration package because each test runner has its own skip mechanism:

| Framework | Ignore mechanism |
|---|---|
| NUnit3 | `Assert.Ignore()` |
| XUnit2 | `throw new IgnoreException()` |
| MsTest3 / MsTest4 | `Assert.Inconclusive()` |
| Fixie3 | `throw new IgnoreException()` |
| TUnit | `Skip.Test()` |

Both attributes are generic. Users derive a non-generic subclass specifying their settings type:

```csharp
public class BypassStepIfAttribute : BypassStepIfAttribute<MySettings>
{
    public BypassStepIfAttribute(string settingName, params string[] reasons) 
        : base(settingName, reasons) { }
}
```

**Graceful fallback:** If the fixture doesn't implement the required interface, or the named property doesn't exist on `T`, the step/scenario executes normally — no error is thrown.

**Usage example:**

```csharp
public class MySettings
{
    public bool SkipPayments { get; set; }
    public bool SkipSlowTests { get; set; }
}

public class Payment_feature : FeatureFixture, 
    IBypassable<MySettings>, IIgnorable<MySettings>
{
    private readonly MySettings _settings = LoadFromConfig();
    public MySettings BypassSettings => _settings;
    public MySettings IgnoreSettings => _settings;

    [Scenario]
    [IgnoreScenarioIf(nameof(MySettings.SkipSlowTests), "Slow tests disabled")]
    public void Slow_end_to_end_scenario()
    {
        Runner.RunScenario(
            _ => Given_a_payment_request(),
            _ => When_payment_is_processed(),
            _ => Then_receipt_is_generated());
    }

    [BypassStepIf(nameof(MySettings.SkipPayments), "Payment gateway unavailable")]
    private void When_payment_is_processed() { /* ... */ }
}
```

**Files changed:**

Source (9 new files):
- `src/LightBDD.Framework/IBypassable.cs` — `IBypassable<T>` interface
- `src/LightBDD.Framework/IIgnorable.cs` — `IIgnorable<T>` interface
- `src/LightBDD.Framework/BypassStepIfAttribute.cs` — framework-agnostic step bypass decorator
- `src/LightBDD.NUnit3/IgnoreScenarioIfAttribute.cs`
- `src/LightBDD.XUnit2/IgnoreScenarioIfAttribute.cs`
- `src/LightBDD.MsTest3/IgnoreScenarioIfAttribute.cs`
- `src/LightBDD.MsTest4/IgnoreScenarioIfAttribute.cs`
- `src/LightBDD.Fixie3/IgnoreScenarioIfAttribute.cs`
- `src/LightBDD.TUnit/IgnoreScenarioIfAttribute.cs`

Tests (6 new files):
- `test/LightBDD.NUnit3.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 11 tests (comprehensive suite)
- `test/LightBDD.XUnit2.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 4 tests
- `test/LightBDD.MsTest3.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 4 tests
- `test/LightBDD.MsTest4.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 4 tests
- `test/LightBDD.Fixie3.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 4 tests
- `test/LightBDD.TUnit.UnitTests/ConditionalDecoratorAttribute_tests.cs` — 4 tests

**Test coverage:**

| Scenario | NUnit3 | Others |
|---|---|---|
| Bypass fires when setting is `true` | ✅ | ✅ |
| Step executes when bypass setting is `false` | ✅ | ✅ |
| Ignore fires when setting is `true` | ✅ | ✅ |
| Scenario executes when ignore setting is `false` | ✅ | ✅ |
| Multiple reasons joined with `"; "` (bypass) | ✅ | |
| Multiple reasons joined with `"; "` (ignore) | ✅ | |
| Subsequent steps continue after bypass | ✅ | |
| No-op when fixture doesn't implement interface for settings type (bypass) | ✅ | |
| No-op when fixture doesn't implement interface for settings type (ignore) | ✅ | |
| No-op when property name doesn't exist on `T` (bypass) | ✅ | |
| No-op when property name doesn't exist on `T` (ignore) | ✅ | |

All tests pass across NUnit3, XUnit2, MsTest3, MsTest4, Fixie3, and TUnit.

**Design decisions:**

1. **`BypassStepIfAttribute<T>` in Framework, not Core** — it depends on `StepExecution.Current.Bypass()` which is a Framework-level API. Follows the same pattern as `MultiAssertAttribute`.
2. **`IgnoreScenarioIfAttribute<T>` per-framework** — each test runner has a different skip mechanism; no way to unify this in a shared layer.
3. **Separate `IBypassable<T>` and `IIgnorable<T>`** — clean separation of concerns; a fixture can implement one or both independently.
4. **Reflection-based property lookup** — enables `nameof()` compile-time safety for the property name while keeping the attribute generic. Graceful fallback on missing property avoids runtime errors.

**Notes for reviewers:**

<details>
<summary>Different fixture access patterns</summary>

`BypassStepIfAttribute<T>` uses `ScenarioExecutionContext.CurrentScenario.Fixture` because `IStep.ExecuteAsync` doesn't expose the fixture directly. `IgnoreScenarioIfAttribute<T>` uses `scenario.Fixture` from its `IScenario` parameter, which does expose it. This is why the two attributes access the fixture differently — it's not inconsistency, it's dictated by the decorator interfaces.
</details>

<details>
<summary><code>property?.GetValue(settings) is true</code> pattern</summary>

This uses C# pattern matching against the boxed `object` returned by `PropertyInfo.GetValue()`. The `is true` pattern:
- Returns `true` only if the value is a boxed `bool` equal to `true`
- Returns `false` for `null`, non-bool types, or `false` — no cast exceptions possible
- This means if someone points the attribute at a non-boolean property, it silently treats it as `false` (graceful no-op)
</details>

<details>
<summary><code>return Task.CompletedTask</code> vs throwing</summary>

The ignore implementations vary by framework:
- **NUnit3, MsTest3, MsTest4, TUnit**: Call an API (`Assert.Ignore()`, `Assert.Inconclusive()`, `Skip.Test()`) that may or may not throw internally. `return Task.CompletedTask` is added defensively after the call.
- **XUnit2, Fixie3**: Throw an exception (`IgnoreException`) directly — no `return Task.CompletedTask` needed because the throw is the control flow.
</details>

<details>
<summary><code>Order</code> defaults to <code>1</code>, not <code>0</code></summary>

This follows the existing convention in LightBDD (e.g. `MultiAssertAttribute` also defaults to `1`). It ensures these decorators run after any `Order = 0` decorators.
</details>

<details>
<summary>TUnit test class has <code>internal</code> (not <code>private</code>) nested attribute</summary>

TUnit's source generator emits code that references attribute types used on test methods. A `private` nested class is inaccessible to the generated code, causing CS0122. The `IgnoreScenarioIfAttribute` nested class in the TUnit test file is `internal` to work around this. The `BypassStepIfAttribute` nested class can remain `private` because it's applied to step methods (not test methods), so TUnit's source generator doesn't reference it.
</details>

<details>
<summary>TUnit's <code>IgnoreScenarioIfAttribute&lt;T&gt;</code> is missing <code>[AttributeUsage]</code></summary>

The other 5 frameworks have `[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]` but TUnit's does not. This was unintentional — it should be added for consistency.
</details>

<details>
<summary>NUnit3 has 11 tests, other frameworks have 4</summary>

The edge-case tests (unmatched settings type, nonexistent property, multiple reasons, continuation after bypass) are only in the NUnit3 suite because the underlying logic being tested is the same shared reflection/interface code across all frameworks. The per-framework tests focus on the 4 core scenarios that exercise each framework's specific ignore mechanism. This avoids duplicating identical edge-case tests 6 times.
</details>

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [x] ~~Examples have been updated to present new feature (if applicable)~~ — N/A. These are opt-in attributes requiring a user-defined settings type and interface implementation. Adding `IBypassable<T>`, `IIgnorable<T>`, a settings class, and derived attributes would add significant complexity to the examples for a niche feature. The existing examples already demonstrate bypass and ignore concepts via `StepExecution.Current.Bypass()` and `StepExecution.Current.IgnoreScenario()`.
- [x] ~~Example reports have been updated in examples\ExampleReports directory~~ — N/A (no example changes)
