### PR TITLE
#183 - Make DefaultProgressNotifier Customisable And Introduce SimpleIndentedProgressNotifier

### DIFF
--- a/src/LightBDD.Framework/Notification/DefaultProgressNotifier.cs
+++ b/src/LightBDD.Framework/Notification/DefaultProgressNotifier.cs
@@ -16,10 +16,81 @@ namespace LightBDD.Framework.Notification
 {
     /// <summary>
     /// The default implementation of <see cref="IScenarioProgressNotifier"/> and <see cref="IFeatureProgressNotifier"/> which renders the notification text and delegates to provided notification actions configured in constructor.
+    /// <br/>
+    /// This notifier is fully configurable through its properties. By default it produces compact flat output
+    /// with step references as prefixes and no nesting-based indentation.
+    /// <br/>
+    /// To get hierarchical, YAML-like indented output, set <see cref="IndentLength"/> to a positive value
+    /// and adjust the step word positioning properties, or use <see cref="SimpleIndentedProgressNotifier"/>
+    /// which pre-configures these settings.
     /// </summary>
     public class DefaultProgressNotifier : IProgressNotifier, IScenarioProgressNotifier, IFeatureProgressNotifier
     {
         private readonly Action<string> _onNotify;
+
+        /// <summary>
+        /// When set to <c>false</c>, suppresses the finish notification for steps that passed successfully.
+        /// A finish notification is still written for non-passing statuses (Failed, Ignored, Bypassed, etc.).
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool WriteSuccessMessageForBasicSteps { get; set; } = true;
+
+        /// <summary>
+        /// When set to <c>true</c>, includes the total step count alongside the current step number.
+        /// For example, "STEP 1.3/1.5" instead of "STEP 1.3".
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool ShowFinalStepWithEachStep { get; set; } = true;
+
+        /// <summary>
+        /// The number of spaces used to indent each level of sub-step nesting.
+        /// When set to 0 or less, a fixed two-space indent is used regardless of nesting depth.
+        /// When set to a positive value, hierarchical indentation is applied based on nesting level.
+        /// Default is 0 (flat indentation).
+        /// </summary>
+        public int IndentLength { get; set; }
+
+        /// <summary>
+        /// Controls how the step word and number are rendered in <b>step start</b> notifications.
+        /// Default is <see cref="StepWordAndStepNumberBehaviour.IncludeAsPrefix"/>.
+        /// </summary>
+        public StepWordAndStepNumberBehaviour StepWordAndStepNumberOnStart { get; set; } = StepWordAndStepNumberBehaviour.IncludeAsPrefix;
+
+        /// <summary>
+        /// Controls how the step word and number are rendered in <b>step finish</b> notifications.
+        /// Default is <see cref="StepWordAndStepNumberBehaviour.IncludeAsPrefix"/>.
+        /// </summary>
+        public StepWordAndStepNumberBehaviour StepWordAndStepNumberOnFinish { get; set; } = StepWordAndStepNumberBehaviour.IncludeAsPrefix;
+
+        /// <summary>
+        /// When set to <c>true</c>, includes the step name in the finish notification alongside the outcome.
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool IncludeStepNameOnFinish { get; set; } = true;
+
+        /// <summary>
+        /// When set to <c>true</c>, appends "..." after the step name in start notifications.
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool IncludeEllipsisAfterStep { get; set; } = true;
+
+        /// <summary>
+        /// When set to <c>true</c>, writes a blank line after the feature start notification.
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool WriteBlankLineAfterFeatureStart { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, writes a blank line after the scenario start notification.
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool WriteBlankLineAfterScenarioStart { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, writes blank lines before and after the scenario result notification.
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool WriteBlankLinesAroundScenarioFinish { get; set; }
 
         /// <summary>
         /// Initializes the notifier with <paramref name="onNotify"/> actions that will be used to delegate the rendered notification text.
@@ -31,65 +102,118 @@ namespace LightBDD.Framework.Notification
         }
 
         /// <summary>
+        /// Delegates the notification text to the configured notification actions.
+        /// </summary>
+        protected void OnNotify(string message) => _onNotify(message);
+
+        /// <summary>
         /// Notifies that scenario has started.
         /// </summary>
         /// <param name="scenario">Scenario info.</param>
-        public void NotifyScenarioStart(IScenarioInfo scenario)
+        public virtual void NotifyScenarioStart(IScenarioInfo scenario)
         {
             _onNotify($"SCENARIO: {FormatLabels(scenario.Labels)}{scenario.Name}{FormatDescription(scenario.Description)}");
+            if (WriteBlankLineAfterScenarioStart)
+                _onNotify("");
         }
 
         /// <summary>
         /// Notifies that scenario has finished.
         /// </summary>
         /// <param name="scenario">Scenario result.</param>
-        public void NotifyScenarioFinished(IScenarioResult scenario)
+        public virtual void NotifyScenarioFinished(IScenarioResult scenario)
         {
+            if (WriteBlankLinesAroundScenarioFinish)
+                _onNotify("");
+
+            var scenarioIndent = IndentLength > 0 ? "" : "  ";
             var scenarioText = scenario.ExecutionTime != null
-                ? $"  SCENARIO RESULT: {scenario.Status} after {scenario.ExecutionTime.Duration.FormatPretty()}"
-                : $"  SCENARIO RESULT: {scenario.Status}";
+                ? $"{scenarioIndent}SCENARIO RESULT: {scenario.Status} after {scenario.ExecutionTime.Duration.FormatPretty()}"
+                : $"{scenarioIndent}SCENARIO RESULT: {scenario.Status}";
 
             var scenarioDetails = !string.IsNullOrWhiteSpace(scenario.StatusDetails)
                 ? $"{Environment.NewLine}    {scenario.StatusDetails.Replace(Environment.NewLine, Environment.NewLine + "    ")}"
                 : string.Empty;
 
             _onNotify(scenarioText + scenarioDetails);
+
+            if (WriteBlankLinesAroundScenarioFinish)
+                _onNotify("");
         }
 
         /// <summary>
         /// Notifies that step has started.
         /// </summary>
         /// <param name="step">Step info.</param>
-        public void NotifyStepStart(IStepInfo step)
+        public virtual void NotifyStepStart(IStepInfo step)
         {
-            _onNotify($"  STEP {step.GroupPrefix}{step.Number}/{step.GroupPrefix}{step.Total}: {step.Name}...");
+            var indentPrefix = GetIndentPrefix(step);
+            var notification = indentPrefix;
+            var stepWordAndStepNumber = GetStepWordAndStepNumber(step);
+
+            if (StepWordAndStepNumberOnStart == StepWordAndStepNumberBehaviour.IncludeAsPrefix)
+                notification += stepWordAndStepNumber + ": ";
+
+            notification += step.Name;
+
+            if (IncludeEllipsisAfterStep)
+                notification += "...";
+
+            if (StepWordAndStepNumberOnStart == StepWordAndStepNumberBehaviour.IncludeAsSuffix)
+                notification += $" ({stepWordAndStepNumber})";
+
+            _onNotify(notification);
         }
 
         /// <summary>
         /// Notifies that step has finished.
         /// </summary>
         /// <param name="step">Step result.</param>
-        public void NotifyStepFinished(IStepResult step)
+        public virtual void NotifyStepFinished(IStepResult step)
         {
-            var report = new List<string>
+            var indentPrefix = GetIndentPrefix(step.Info);
+            var annotationIndent = GetAnnotationIndent(step.Info);
+            var report = new List<string>();
+
+            if (WriteSuccessMessageForBasicSteps || step.Status != ExecutionStatus.Passed)
             {
-                $"  STEP {step.Info.GroupPrefix}{step.Info.Number}/{step.Info.GroupPrefix}{step.Info.Total}: {step.Info.Name} ({step.Status} after {step.ExecutionTime.Duration.FormatPretty()})"
-            };
+                var notification = indentPrefix;
+                var stepWordAndStepNumber = GetStepWordAndStepNumber(step.Info);
+
+                if (StepWordAndStepNumberOnFinish == StepWordAndStepNumberBehaviour.IncludeAsPrefix)
+                    notification += stepWordAndStepNumber + (IncludeStepNameOnFinish ? ": " : ":");
+
+                if (IncludeStepNameOnFinish)
+                    notification += step.Info.Name;
+
+                if (StepWordAndStepNumberOnFinish != StepWordAndStepNumberBehaviour.IncludeAsPrefix)
+                    notification += "  =>";
+
+                notification += $" ({step.Status} after {step.ExecutionTime.Duration.FormatPretty()})";
+
+                if (StepWordAndStepNumberOnFinish == StepWordAndStepNumberBehaviour.IncludeAsSuffix)
+                    notification += $" ({stepWordAndStepNumber})";
+
+                report.Add(notification);
+            }
+
             foreach (var parameter in step.Parameters)
             {
                 switch (parameter.Details)
                 {
                     case ITabularParameterDetails table:
-                        report.Add($"    {parameter.Name}:");
-                        report.Add(new TextTableRenderer(table).Render("    "));
+                        report.Add($"{annotationIndent}{parameter.Name}:");
+                        report.Add(new TextTableRenderer(table).Render(annotationIndent));
                         break;
                     case ITreeParameterDetails tree:
-                        report.Add($"    {parameter.Name}:");
-                        report.Add(TextTreeRenderer.Render("    ", tree));
+                        report.Add($"{annotationIndent}{parameter.Name}:");
+                        report.Add(TextTreeRenderer.Render(annotationIndent, tree));
                         break;
                 }
             }
-            _onNotify(string.Join(Environment.NewLine, report));
+
+            if (report.Count > 0)
+                _onNotify(string.Join(Environment.NewLine, report));
         }
 
         /// <summary>
@@ -97,31 +221,37 @@ namespace LightBDD.Framework.Notification
         /// </summary>
         /// <param name="step">Step info.</param>
         /// <param name="comment">Comment.</param>
-        public void NotifyStepComment(IStepInfo step, string comment)
+        public virtual void NotifyStepComment(IStepInfo step, string comment)
         {
-            _onNotify($"  STEP {step.GroupPrefix}{step.Number}/{step.GroupPrefix}{step.Total}: /* {comment} */");
+            if (StepWordAndStepNumberOnStart == StepWordAndStepNumberBehaviour.IncludeAsPrefix)
+                _onNotify($"{GetIndentPrefix(step)}{GetStepWordAndStepNumber(step)}: /* {comment} */");
+            else
+                _onNotify($"{GetAnnotationIndent(step)}=> /* {comment} */");
         }
 
         /// <summary>
         /// Notifies that feature has started.
         /// </summary>
         /// <param name="feature">Feature info.</param>
-        public void NotifyFeatureStart(IFeatureInfo feature)
+        public virtual void NotifyFeatureStart(IFeatureInfo feature)
         {
-            _onNotify($"FEATURE: {FormatLabels(feature.Labels)}{feature.Name}{FormatDescription(feature.Description)}");
+            var headerPad = IndentLength > 0 ? "  " : " ";
+            _onNotify($"FEATURE:{headerPad}{FormatLabels(feature.Labels)}{feature.Name}{FormatDescription(feature.Description)}");
+            if (WriteBlankLineAfterFeatureStart)
+                _onNotify("");
         }
 
         /// <summary>
         /// Notifies that feature has finished.
         /// </summary>
         /// <param name="feature">Feature result.</param>
-        public void NotifyFeatureFinished(IFeatureResult feature)
+        public virtual void NotifyFeatureFinished(IFeatureResult feature)
         {
             _onNotify($"FEATURE FINISHED: {feature.Info.Name}");
         }
 
         /// <inheritdoc />
-        public void Notify(ProgressEvent e)
+        public virtual void Notify(ProgressEvent e)
         {
             switch (e)
             {
@@ -152,24 +282,80 @@ namespace LightBDD.Framework.Notification
             }
         }
 
-        private void NotifyStepFileAttached(IStepInfo step, FileAttachment attachment)
+        /// <summary>
+        /// Notifies that a file has been attached to a step.
+        /// </summary>
+        protected virtual void NotifyStepFileAttached(IStepInfo step, FileAttachment attachment)
         {
-            _onNotify($"  STEP {step.GroupPrefix}{step.Number}/{step.GroupPrefix}{step.Total}: 🔗{attachment.Name}: {attachment.FilePath}");
+            if (StepWordAndStepNumberOnStart == StepWordAndStepNumberBehaviour.IncludeAsPrefix)
+                _onNotify($"{GetIndentPrefix(step)}{GetStepWordAndStepNumber(step)}: 🔗{attachment.Name}: {attachment.FilePath}");
+            else
+                _onNotify($"{GetAnnotationIndent(step)}=> 🔗{attachment.Name}: {attachment.FilePath}");
         }
 
-        private static string FormatDescription(string description)
+        /// <summary>
+        /// Formats a description string for display, indenting each line.
+        /// When <see cref="IndentLength"/> is positive, descriptions are indented to align with header content.
+        /// </summary>
+        protected virtual string FormatDescription(string description)
         {
-            return string.IsNullOrWhiteSpace(description)
-                ? string.Empty
-                : $"{Environment.NewLine}  {description.Replace(Environment.NewLine, Environment.NewLine + "  ")}";
+            if (string.IsNullOrWhiteSpace(description))
+                return string.Empty;
+            var indent = IndentLength > 0 ? "          " : "  ";
+            return $"{Environment.NewLine}{indent}{description.Replace(Environment.NewLine, Environment.NewLine + indent)}";
         }
 
-        private static string FormatLabels(IEnumerable<string> labels)
+        /// <summary>
+        /// Formats labels as bracket-delimited tags, e.g. <c>[label1][label2] </c>.
+        /// </summary>
+        protected virtual string FormatLabels(IEnumerable<string> labels)
         {
             var joinedLabels = string.Join("][", labels);
             if (joinedLabels != string.Empty)
                 joinedLabels = "[" + joinedLabels + "] ";
             return joinedLabels;
+        }
+
+        /// <summary>
+        /// Builds a whitespace prefix for the given step.
+        /// When <see cref="IndentLength"/> is 0 or less, returns a fixed two-space indent.
+        /// When positive, returns a hierarchical indent based on the step's nesting depth.
+        /// </summary>
+        protected virtual string GetIndentPrefix(IStepInfo step)
+        {
+            if (IndentLength <= 0)
+                return "  ";
+
+            var parent = step.Parent;
+            var prefix = IndentLength < 2 ? "  " : "";
+
+            while (parent is IStepInfo parentStep)
+            {
+                prefix += new string(' ', IndentLength);
+                parent = parentStep.Parent;
+            }
+
+            prefix += new string(' ', IndentLength);
+            return prefix;
+        }
+
+        /// <summary>
+        /// Builds the indent string used for step annotations (parameters, comments, file attachments)
+        /// that appear indented under a step.
+        /// </summary>
+        protected virtual string GetAnnotationIndent(IStepInfo step)
+        {
+            return GetIndentPrefix(step) + new string(' ', Math.Max(IndentLength, 2));
+        }
+
+        /// <summary>
+        /// Builds the step word and number string (e.g. "STEP 1" or "STEP 1/5").
+        /// </summary>
+        protected virtual string GetStepWordAndStepNumber(IStepInfo step)
+        {
+            return ShowFinalStepWithEachStep
+                ? $"STEP {step.GroupPrefix}{step.Number}/{step.GroupPrefix}{step.Total}"
+                : $"STEP {step.GroupPrefix}{step.Number}";
         }
     }
 }

--- a/src/LightBDD.Framework/Notification/SimpleIndentedProgressNotifier.cs
+++ b/src/LightBDD.Framework/Notification/SimpleIndentedProgressNotifier.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace LightBDD.Framework.Notification
+{
+    /// <summary>
+    /// A progress notifier that produces clean, YAML-like indented output.
+    /// <br/>
+    /// This notifier inherits from <see cref="DefaultProgressNotifier"/> and pre-configures it with:
+    /// <list type="bullet">
+    /// <item><description>Hierarchical indentation for sub-steps (<see cref="DefaultProgressNotifier.IndentLength"/> = 4).</description></item>
+    /// <item><description>Step numbering as a suffix (<see cref="DefaultProgressNotifier.StepWordAndStepNumberOnStart"/> and <see cref="DefaultProgressNotifier.StepWordAndStepNumberOnFinish"/> = <see cref="StepWordAndStepNumberBehaviour.IncludeAsSuffix"/>).</description></item>
+    /// <item><description>Suppressed finish notifications for passing steps (<see cref="DefaultProgressNotifier.WriteSuccessMessageForBasicSteps"/> = false).</description></item>
+    /// <item><description>Blank lines around scenario and feature boundaries for visual separation.</description></item>
+    /// </list>
+    /// </summary>
+    public class SimpleIndentedProgressNotifier : DefaultProgressNotifier
+    {
+        /// <summary>
+        /// Initializes the notifier with <paramref name="onNotify"/> actions that will be used to delegate the rendered notification text.
+        /// </summary>
+        /// <param name="onNotify">One or more actions to receive notification text.</param>
+        public SimpleIndentedProgressNotifier(params Action<string>[] onNotify)
+            : base(onNotify)
+        {
+            WriteSuccessMessageForBasicSteps = false;
+            ShowFinalStepWithEachStep = false;
+            IndentLength = 4;
+            StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            IncludeStepNameOnFinish = false;
+            IncludeEllipsisAfterStep = false;
+            WriteBlankLineAfterFeatureStart = true;
+            WriteBlankLineAfterScenarioStart = true;
+            WriteBlankLinesAroundScenarioFinish = true;
+        }
+    }
+}

--- a/src/LightBDD.Framework/Notification/StepWordAndStepNumberBehaviour.cs
+++ b/src/LightBDD.Framework/Notification/StepWordAndStepNumberBehaviour.cs
@@ -1,0 +1,26 @@
+namespace LightBDD.Framework.Notification
+{
+    /// <summary>
+    /// Controls how the step word (e.g. "STEP") and step number are included in progress notifications.
+    /// </summary>
+    public enum StepWordAndStepNumberBehaviour
+    {
+        /// <summary>
+        /// Includes the step word and number as a prefix followed by a colon.
+        /// <br/>Example: <c>STEP 1.1: Given some condition</c>
+        /// </summary>
+        IncludeAsPrefix,
+
+        /// <summary>
+        /// Includes the step word and number as a suffix in parentheses.
+        /// <br/>Example: <c>Given some condition (STEP 1.1)</c>
+        /// </summary>
+        IncludeAsSuffix,
+
+        /// <summary>
+        /// Excludes the step word and number entirely from the notification.
+        /// <br/>Example: <c>Given some condition</c>
+        /// </summary>
+        Exclude
+    }
+}

--- a/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/DefaultProgressNotifier_tests.cs
@@ -218,5 +218,743 @@ namespace LightBDD.Framework.UnitTests.Notification
             Assert.That(_captured.ToArray(), Is.EqualTo(expected));
         }
 
+        #region Step start customizations
+
+        [Test]
+        public void NotifyStepStart_should_use_prefix_numbering_by_default()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: Given some condition..."));
+        }
+
+        [Test]
+        public void NotifyStepStart_with_suffix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  Given some condition... (STEP 1/3)"));
+        }
+
+        [Test]
+        public void NotifyStepStart_with_excluded_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.Exclude;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  Given some condition..."));
+        }
+
+        [Test]
+        public void NotifyStepStart_without_ellipsis()
+        {
+            _notifier.IncludeEllipsisAfterStep = false;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: Given some condition"));
+        }
+
+        [Test]
+        public void NotifyStepStart_without_final_step_count()
+        {
+            _notifier.ShowFinalStepWithEachStep = false;
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 2: Given some condition..."));
+        }
+
+        [Test]
+        public void NotifyStepStart_should_include_group_prefix()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "1.");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1.2/1.5: Given some condition..."));
+        }
+
+        [Test]
+        public void NotifyStepStart_without_final_step_count_and_with_group_prefix()
+        {
+            _notifier.ShowFinalStepWithEachStep = false;
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "1.");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1.2: Given some condition..."));
+        }
+
+        [Test]
+        public void NotifyStepStart_suffix_without_ellipsis_and_without_final_step()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.IncludeEllipsisAfterStep = false;
+            _notifier.ShowFinalStepWithEachStep = false;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  Given some condition (STEP 1)"));
+        }
+
+        #endregion
+
+        #region Step finish customizations
+
+        [Test]
+        public void NotifyStepFinished_should_include_step_name_and_prefix_by_default()
+        {
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Passed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: Given some condition (Passed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_suppress_passed_when_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Passed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured, Is.Empty);
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_emit_failed_even_when_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Does.Contain("Failed after 125ms"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_emit_ignored_even_when_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Ignored);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Does.Contain("Ignored after 125ms"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_emit_bypassed_even_when_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Bypassed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Does.Contain("Bypassed after 125ms"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_with_suffix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  Given some condition  => (Failed after 125ms) (STEP 1/3)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_with_excluded_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.Exclude;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  Given some condition  => (Failed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_without_step_name()
+        {
+            _notifier.IncludeStepNameOnFinish = false;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: (Failed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_without_step_name_and_suffix_numbering()
+        {
+            _notifier.IncludeStepNameOnFinish = false;
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    => (Failed after 125ms) (STEP 1/3)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_report_tabular_and_tree_parameters()
+        {
+            var stepResult = CreateStepResultWithParameters();
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            var expectedTable = @"    table:
+    +-+---+----------+----------+
+    |#|Key|Value1    |Value2    |
+    +-+---+----------+----------+
+    |=|1  |abc       |some value|
+    |!|2  |def       |val/value |
+    |-|3  |<null>/XXX|<null>/YYY|
+    |+|4  |XXX/<null>|YYY/<null>|
+    +-+---+----------+----------+"
+                .Replace("\r", "")
+                .Replace("\n", Environment.NewLine);
+
+            var expectedTree = @"    tree:
+    = $: <object>
+    = $.Items: <array:1>
+    ! $.Items[0]: False/True
+    = $.Name: Bob
+    ! $.Surname: Johnson/<none>
+    ! $.LastName: <none>/Johnson"
+                .Replace("\r", "")
+                .Replace("\n", Environment.NewLine);
+
+            var fullMessage = _captured.Single();
+
+            Assert.That(fullMessage, Does.StartWith("  STEP 1/3: Given some condition (Failed after 125ms)"));
+            Assert.That(fullMessage, Does.Contain(expectedTable));
+            Assert.That(fullMessage, Does.Contain(expectedTree));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_report_parameters_even_when_passed_and_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResultWithParameters();
+            stepResult.Status = ExecutionStatus.Passed;
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            var fullMessage = _captured.Single();
+            Assert.That(fullMessage, Does.Not.Contain("Passed after"));
+            Assert.That(fullMessage, Does.Contain("table:"));
+            Assert.That(fullMessage, Does.Contain("tree:"));
+        }
+
+        #endregion
+
+        #region Step comment and file attachment customizations
+
+        [Test]
+        public void NotifyStepComment_should_use_prefix_style_by_default()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepCommented(new EventTime(), stepInfo, "some comment"));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: /* some comment */"));
+        }
+
+        [Test]
+        public void NotifyStepComment_should_use_arrow_style_when_suffix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepCommented(new EventTime(), stepInfo, "some comment"));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    => /* some comment */"));
+        }
+
+        [Test]
+        public void NotifyStepFileAttached_should_use_prefix_style_by_default()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var attachment = new FileAttachment("screenshot", "/path/to/file.png", "file.png");
+            _notifier.Notify(new StepFileAttached(new EventTime(), stepInfo, attachment));
+
+            Assert.That(_captured.Single(), Is.EqualTo("  STEP 1/3: \U0001F517screenshot: /path/to/file.png"));
+        }
+
+        [Test]
+        public void NotifyStepFileAttached_should_use_arrow_style_when_suffix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var attachment = new FileAttachment("screenshot", "/path/to/file.png", "file.png");
+            _notifier.Notify(new StepFileAttached(new EventTime(), stepInfo, attachment));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    => \U0001F517screenshot: /path/to/file.png"));
+        }
+
+        #endregion
+
+        #region Blank line customizations
+
+        [Test]
+        public void NotifyFeatureStart_should_not_write_blank_line_by_default()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = null
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "FEATURE: [Story-1] Shopping cart" }));
+        }
+
+        [Test]
+        public void NotifyFeatureStart_should_write_blank_line_when_configured()
+        {
+            _notifier.WriteBlankLineAfterFeatureStart = true;
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = null
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "FEATURE: [Story-1] Shopping cart", "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioStart_should_not_write_blank_line_by_default()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = null
+            };
+            _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "SCENARIO: [Ticket-42] Adding items" }));
+        }
+
+        [Test]
+        public void NotifyScenarioStart_should_write_blank_line_when_configured()
+        {
+            _notifier.WriteBlankLineAfterScenarioStart = true;
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = null
+            };
+            _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "SCENARIO: [Ticket-42] Adding items", "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioFinished_should_not_write_blank_lines_by_default()
+        {
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = null,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "  SCENARIO RESULT: Passed after 250ms" }));
+        }
+
+        [Test]
+        public void NotifyScenarioFinished_should_write_blank_lines_when_configured()
+        {
+            _notifier.WriteBlankLinesAroundScenarioFinish = true;
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = null,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "", "  SCENARIO RESULT: Passed after 250ms", "" }));
+        }
+
+        #endregion
+
+        #region IndentLength customizations
+
+        [Test]
+        public void Steps_should_use_flat_two_space_indent_by_default()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Does.StartWith("  STEP"));
+        }
+
+        [Test]
+        public void Steps_should_use_hierarchical_indent_when_IndentLength_is_positive()
+        {
+            _notifier.IndentLength = 4;
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.IncludeEllipsisAfterStep = false;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            // IndentLength=4 => base indent is 4 spaces
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition (STEP 1/3)"));
+        }
+
+        [Test]
+        public void Sub_steps_should_be_further_indented_when_IndentLength_is_positive()
+        {
+            _notifier.IndentLength = 4;
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.IncludeEllipsisAfterStep = false;
+            _notifier.ShowFinalStepWithEachStep = false;
+
+            var parentStep = CreateStepInfo("Given a parent step", 1, 3, "");
+            var childStep = CreateStepInfo("And a child step", 1, 2, "1.");
+            childStep.Parent = parentStep;
+
+            _notifier.Notify(new StepStarting(new EventTime(), childStep));
+
+            // Parent level (4) + base level (4) = 8 spaces
+            Assert.That(_captured.Single(), Is.EqualTo("        And a child step (STEP 1.1)"));
+        }
+
+        [Test]
+        public void Deeply_nested_steps_should_increase_indentation()
+        {
+            _notifier.IndentLength = 4;
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.IncludeEllipsisAfterStep = false;
+            _notifier.ShowFinalStepWithEachStep = false;
+
+            var grandparent = CreateStepInfo("Given a grandparent", 1, 3, "");
+            var parent = CreateStepInfo("And a parent", 1, 2, "1.");
+            parent.Parent = grandparent;
+            var child = CreateStepInfo("And a child", 1, 1, "1.1.");
+            child.Parent = parent;
+
+            _notifier.Notify(new StepStarting(new EventTime(), child));
+
+            // grandparent (4) + parent (4) + base (4) = 12 spaces
+            Assert.That(_captured.Single(), Does.StartWith("            And a child"));
+        }
+
+        [Test]
+        public void Flat_indent_should_not_increase_for_nested_steps()
+        {
+            // Default IndentLength=0, so nested steps still get flat "  " indent
+            var parentStep = CreateStepInfo("Given a parent step", 1, 3, "");
+            var childStep = CreateStepInfo("And a child step", 1, 2, "1.");
+            childStep.Parent = parentStep;
+
+            _notifier.Notify(new StepStarting(new EventTime(), parentStep));
+            _notifier.Notify(new StepStarting(new EventTime(), childStep));
+
+            Assert.That(_captured.ElementAt(0), Does.StartWith("  STEP 1/3:"));
+            Assert.That(_captured.ElementAt(1), Does.StartWith("  STEP 1.1/1.2:"));
+        }
+
+        [Test]
+        public void FeatureStart_should_use_double_space_pad_when_IndentLength_is_positive()
+        {
+            _notifier.IndentLength = 4;
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = null
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            // IndentLength > 0 uses "FEATURE:  " (two spaces)
+            Assert.That(_captured.Single(), Is.EqualTo("FEATURE:  [Story-1] Shopping cart"));
+        }
+
+        [Test]
+        public void FeatureStart_should_use_single_space_pad_when_IndentLength_is_zero()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = null
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            // Default IndentLength=0 uses "FEATURE: " (one space)
+            Assert.That(_captured.Single(), Is.EqualTo("FEATURE: [Story-1] Shopping cart"));
+        }
+
+        [Test]
+        public void ScenarioResult_should_have_two_space_indent_when_IndentLength_is_zero()
+        {
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = null,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            Assert.That(_captured.Single(), Does.StartWith("  SCENARIO RESULT:"));
+        }
+
+        [Test]
+        public void ScenarioResult_should_have_no_indent_when_IndentLength_is_positive()
+        {
+            _notifier.IndentLength = 4;
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = null,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("SCENARIO RESULT: Passed after 250ms"));
+        }
+
+        [Test]
+        public void Description_should_use_extended_indent_when_IndentLength_is_positive()
+        {
+            _notifier.IndentLength = 4;
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = Array.Empty<string>(),
+                Description = "As a customer I want to manage my cart"
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            var expected = NormalizeNewlines("""
+                FEATURE:  Shopping cart
+                          As a customer I want to manage my cart
+                """);
+            Assert.That(_captured.Single(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Description_should_use_two_space_indent_when_IndentLength_is_zero()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = Array.Empty<string>(),
+                Description = "As a customer I want to manage my cart"
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            var expected = $"FEATURE: Shopping cart{Environment.NewLine}  As a customer I want to manage my cart";
+            Assert.That(_captured.Single(), Is.EqualTo(expected));
+        }
+
+        #endregion
+
+        #region Full integration: configured like SimpleIndentedProgressNotifier
+
+        [Test]
+        public void It_should_match_SimpleIndentedProgressNotifier_when_configured_equivalently()
+        {
+            // Configure DefaultProgressNotifier to match SimpleIndentedProgressNotifier defaults
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            _notifier.ShowFinalStepWithEachStep = false;
+            _notifier.IndentLength = 4;
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
+            _notifier.IncludeStepNameOnFinish = false;
+            _notifier.IncludeEllipsisAfterStep = false;
+            _notifier.WriteBlankLineAfterFeatureStart = true;
+            _notifier.WriteBlankLineAfterScenarioStart = true;
+            _notifier.WriteBlankLinesAroundScenarioFinish = true;
+
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = "As a customer I want to manage my cart"
+            };
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = "Verifies item addition"
+            };
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            var stepDuration = stepResult.ExecutionTime.Duration.FormatPretty();
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 1: some failure",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            var scenarioDuration = scenarioResult.ExecutionTime.Duration.FormatPretty();
+
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("Shopping cart"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+            _notifier.Notify(new StepStarting(eventTime, stepInfo));
+            _notifier.Notify(new StepCommented(eventTime, stepInfo, "important note"));
+            _notifier.Notify(new StepFileAttached(eventTime, stepInfo, new FileAttachment("screenshot", "/path/screenshot.png", "screenshot.png")));
+            _notifier.Notify(new StepFinished(eventTime, stepResult));
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+            _notifier.Notify(new FeatureFinished(eventTime, featureResult));
+
+            var expected = NormalizeNewlines($"""
+                FEATURE:  [Story-1] Shopping cart
+                          As a customer I want to manage my cart
+
+                SCENARIO: [Ticket-42] Adding items
+                          Verifies item addition
+
+                    Given some condition (STEP 1)
+                        => /* important note */
+                        => 🔗screenshot: /path/screenshot.png
+                      => (Failed after {stepDuration}) (STEP 1)
+
+                SCENARIO RESULT: Failed after {scenarioDuration}
+                    Step 1: some failure
+
+                FEATURE FINISHED: Shopping cart
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static TestResults.TestStepInfo CreateStepInfo(string name, int number, int total, string groupPrefix)
+        {
+            return new TestResults.TestStepInfo
+            {
+                Name = TestResults.CreateStepName(name, null, name),
+                Number = number,
+                Total = total,
+                GroupPrefix = groupPrefix
+            };
+        }
+
+        private static TestResults.TestStepResult CreateStepResult(string name, int number, int total, string groupPrefix, ExecutionStatus status)
+        {
+            return new TestResults.TestStepResult
+            {
+                Info = CreateStepInfo(name, number, total, groupPrefix),
+                Status = status,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(125)
+                }
+            };
+        }
+
+        private TestResults.TestStepResult CreateStepResultWithParameters()
+        {
+            var result = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            result.Parameters = new IParameterResult[]
+            {
+                new TestResults.TestParameterResult("table",
+                    TestResults.CreateTabularParameterDetails(ParameterVerificationStatus.Failure)
+                        .WithKeyColumns("Key")
+                        .WithValueColumns("Value1", "Value2")
+                        .AddRow(TableRowType.Matching,
+                            ParameterVerificationStatus.Success,
+                            TestResults.CreateValueResult("1"),
+                            TestResults.CreateValueResult("abc"),
+                            TestResults.CreateValueResult("some value"))
+                        .AddRow(TableRowType.Matching,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("2"),
+                            TestResults.CreateValueResult("def"),
+                            TestResults.CreateValueResult("value", "val", ParameterVerificationStatus.Failure))
+                        .AddRow(TableRowType.Missing,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("3"),
+                            TestResults.CreateValueResult("XXX", "<null>", ParameterVerificationStatus.NotProvided),
+                            TestResults.CreateValueResult("YYY", "<null>", ParameterVerificationStatus.NotProvided))
+                        .AddRow(TableRowType.Surplus,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("4"),
+                            TestResults.CreateValueResult("<null>", "XXX", ParameterVerificationStatus.Failure),
+                            TestResults.CreateValueResult("<null>", "YYY", ParameterVerificationStatus.Failure))
+                ),
+                new TestResults.TestParameterResult("tree", CreateTreeParameterResult())
+            };
+            return result;
+        }
+
+        private static string NormalizeNewlines(string text) => text.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+
+        #endregion
     }
 }

--- a/test/LightBDD.Framework.UnitTests/Notification/SimpleIndentedProgressNotifier_tests.cs
+++ b/test/LightBDD.Framework.UnitTests/Notification/SimpleIndentedProgressNotifier_tests.cs
@@ -1,0 +1,1481 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LightBDD.Core.Execution;
+using LightBDD.Core.Formatting;
+using LightBDD.Core.Metadata;
+using LightBDD.Core.Notification.Events;
+using LightBDD.Core.Results;
+using LightBDD.Core.Results.Parameters;
+using LightBDD.Core.Results.Parameters.Tabular;
+using LightBDD.Framework.Notification;
+using LightBDD.Framework.Parameters;
+using LightBDD.UnitTests.Helpers;
+using NUnit.Framework;
+
+namespace LightBDD.Framework.UnitTests.Notification
+{
+    [TestFixture]
+    public class SimpleIndentedProgressNotifier_tests
+    {
+        private Queue<string> _captured;
+        private SimpleIndentedProgressNotifier _notifier;
+
+        private void Notify(string message)
+        {
+            _captured.Enqueue(message);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _captured = new Queue<string>();
+            _notifier = new SimpleIndentedProgressNotifier(Notify);
+        }
+
+        #region Feature notifications
+
+        [Test]
+        public void NotifyFeatureStart_should_include_labels_and_description()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = "As a customer I want to manage my cart"
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            var expected = NormalizeNewlines("""
+                FEATURE:  [Story-1] Shopping cart
+                          As a customer I want to manage my cart
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { expected, "" }));
+        }
+
+        [Test]
+        public void NotifyFeatureStart_should_omit_description_if_not_provided()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = null
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "FEATURE:  [Story-1] Shopping cart", "" }));
+        }
+
+        [Test]
+        public void NotifyFeatureStart_should_omit_labels_if_not_provided()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = Array.Empty<string>(),
+                Description = "As a customer I want to manage my cart"
+            };
+            _notifier.Notify(new FeatureStarting(new EventTime(), featureInfo));
+
+            var expected = NormalizeNewlines("""
+                FEATURE:  Shopping cart
+                          As a customer I want to manage my cart
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { expected, "" }));
+        }
+
+        [Test]
+        public void NotifyFeatureFinished_should_include_feature_name()
+        {
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("Shopping cart"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+            _notifier.Notify(new FeatureFinished(new EventTime(), featureResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("FEATURE FINISHED: Shopping cart"));
+        }
+
+        #endregion
+
+        #region Scenario notifications
+
+        [Test]
+        public void NotifyScenarioStart_should_include_labels_and_description()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = "Verifies item addition"
+            };
+            _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO: [Ticket-42] Adding items
+                          Verifies item addition
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { expected, "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioStart_should_omit_description_if_not_provided()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = null
+            };
+            _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "SCENARIO: [Ticket-42] Adding items", "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioStart_should_omit_labels_if_not_provided()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = Array.Empty<string>(),
+                Categories = Array.Empty<string>(),
+                Description = "Verifies item addition"
+            };
+            _notifier.Notify(new ScenarioStarting(new EventTime(), scenarioInfo));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO: Adding items
+                          Verifies item addition
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { expected, "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioFinished_should_include_status_and_execution_time()
+        {
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = "Step 1: some detail",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO RESULT: Passed after 250ms
+                    Step 1: some detail
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "", expected, "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioFinished_should_omit_execution_time_if_not_provided()
+        {
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 1: some failure",
+                ExecutionTime = null
+            };
+
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO RESULT: Failed
+                    Step 1: some failure
+                """);
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "", expected, "" }));
+        }
+
+        [Test]
+        public void NotifyScenarioFinished_should_omit_status_details_if_not_provided()
+        {
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Passed,
+                StatusDetails = null,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+
+            _notifier.Notify(new ScenarioFinished(new EventTime(), scenarioResult));
+
+            Assert.That(_captured.ToArray(), Is.EqualTo(new[] { "", "SCENARIO RESULT: Passed after 250ms", "" }));
+        }
+
+        #endregion
+
+        #region Step start notifications
+
+        [Test]
+        public void NotifyStepStart_should_use_suffix_numbering_by_default()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepStart_with_prefix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsPrefix;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    STEP 1: Given some condition"));
+        }
+
+        [Test]
+        public void NotifyStepStart_with_excluded_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.Exclude;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition"));
+        }
+
+        [Test]
+        public void NotifyStepStart_should_include_ellipsis_when_configured()
+        {
+            _notifier.IncludeEllipsisAfterStep = true;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition... (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepStart_should_show_final_step_count_when_configured()
+        {
+            _notifier.ShowFinalStepWithEachStep = true;
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition (STEP 2/5)"));
+        }
+
+        [Test]
+        public void NotifyStepStart_should_include_group_prefix()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "1.");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition (STEP 1.2)"));
+        }
+
+        [Test]
+        public void NotifyStepStart_should_show_final_step_with_group_prefix_when_configured()
+        {
+            _notifier.ShowFinalStepWithEachStep = true;
+            var stepInfo = CreateStepInfo("Given some condition", 2, 5, "1.");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition (STEP 1.2/1.5)"));
+        }
+
+        #endregion
+
+        #region Step finish notifications
+
+        [Test]
+        public void NotifyStepFinished_should_not_emit_for_passed_steps_by_default()
+        {
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Passed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured, Is.Empty);
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_emit_for_passed_steps_when_WriteSuccessMessageForBasicSteps_is_true()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = true;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Passed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("      => (Passed after 125ms) (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_always_emit_for_failed_steps()
+        {
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("      => (Failed after 125ms) (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_always_emit_for_ignored_steps()
+        {
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Ignored);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("      => (Ignored after 125ms) (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_always_emit_for_bypassed_steps()
+        {
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Bypassed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("      => (Bypassed after 125ms) (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_with_prefix_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsPrefix;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    STEP 1: (Failed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_with_excluded_numbering()
+        {
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.Exclude;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("      => (Failed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_include_step_name_when_configured()
+        {
+            _notifier.IncludeStepNameOnFinish = true;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    Given some condition  => (Failed after 125ms) (STEP 1)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_include_step_name_with_prefix_numbering()
+        {
+            _notifier.IncludeStepNameOnFinish = true;
+            _notifier.StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsPrefix;
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            Assert.That(_captured.Single(), Is.EqualTo("    STEP 1: Given some condition (Failed after 125ms)"));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_report_tabular_and_tree_parameters()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = true;
+            var stepResult = CreateStepResultWithParameters();
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            var expectedTable = NormalizeNewlines("""
+                    table:
+                    +-+---+----------+----------+
+                    |#|Key|Value1    |Value2    |
+                    +-+---+----------+----------+
+                    |=|1  |abc       |some value|
+                    |!|2  |def       |val/value |
+                    |-|3  |<null>/XXX|<null>/YYY|
+                    |+|4  |XXX/<null>|YYY/<null>|
+                    +-+---+----------+----------+
+            """);
+
+            var expectedTree = NormalizeNewlines("""
+                    tree:
+                    = $: <object>
+                    = $.Items: <array:1>
+                    ! $.Items[0]: False/True
+                    = $.Name: Bob
+                    ! $.Surname: Johnson/<none>
+                    ! $.LastName: <none>/Johnson
+            """);
+
+            var fullMessage = _captured.Single();
+
+            Assert.That(fullMessage, Does.StartWith("      => (Failed after 125ms) (STEP 1)"));
+            Assert.That(fullMessage, Does.Contain(expectedTable));
+            Assert.That(fullMessage, Does.Contain(expectedTree));
+        }
+
+        [Test]
+        public void NotifyStepFinished_should_report_parameters_even_when_passed_and_WriteSuccessMessageForBasicSteps_is_false()
+        {
+            _notifier.WriteSuccessMessageForBasicSteps = false;
+            var stepResult = CreateStepResultWithParameters();
+            stepResult.Status = ExecutionStatus.Passed;
+            _notifier.Notify(new StepFinished(new EventTime(), stepResult));
+
+            // Parameters should still be rendered even though the status line is suppressed
+            var fullMessage = _captured.Single();
+            Assert.That(fullMessage, Does.Not.Contain("Passed after"));
+            Assert.That(fullMessage, Does.Contain("table:"));
+            Assert.That(fullMessage, Does.Contain("tree:"));
+        }
+
+        #endregion
+
+        #region Step comment and file attachment
+
+        [Test]
+        public void NotifyStepComment_should_include_indented_comment()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var comment = "some important comment";
+            _notifier.Notify(new StepCommented(new EventTime(), stepInfo, comment));
+
+            Assert.That(_captured.Single(), Is.EqualTo($"        => /* {comment} */"));
+        }
+
+        [Test]
+        public void NotifyStepFileAttached_should_include_indented_attachment_info()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var attachment = new FileAttachment("screenshot", "/path/to/file.png", "file.png");
+            _notifier.Notify(new StepFileAttached(new EventTime(), stepInfo, attachment));
+
+            Assert.That(_captured.Single(), Is.EqualTo("        => \U0001F517screenshot: /path/to/file.png"));
+        }
+
+        #endregion
+
+        #region Indentation
+
+        [Test]
+        public void Steps_should_be_indented_under_scenario()
+        {
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            // Default IndentLength=4, so top-level steps get 4 spaces
+            Assert.That(_captured.Single(), Does.StartWith("    "));
+        }
+
+        [Test]
+        public void Sub_steps_should_be_further_indented()
+        {
+            var parentStep = CreateStepInfo("Given a parent step", 1, 3, "");
+            var childStep = CreateStepInfo("And a child step", 1, 2, "1.");
+            childStep.Parent = parentStep;
+
+            _notifier.Notify(new StepStarting(new EventTime(), childStep));
+
+            // Parent adds IndentLength=4, plus base IndentLength=4 = 8 spaces
+            Assert.That(_captured.Single(), Does.StartWith("        And a child step"));
+        }
+
+        [Test]
+        public void Deeply_nested_steps_should_increase_indentation()
+        {
+            var grandparent = CreateStepInfo("Given a grandparent", 1, 3, "");
+            var parent = CreateStepInfo("And a parent", 1, 2, "1.");
+            parent.Parent = grandparent;
+            var child = CreateStepInfo("And a child", 1, 1, "1.1.");
+            child.Parent = parent;
+
+            _notifier.Notify(new StepStarting(new EventTime(), child));
+
+            // grandparent level + parent level + base = 3 * 4 = 12 spaces
+            Assert.That(_captured.Single(), Does.StartWith("            And a child"));
+        }
+
+        [Test]
+        public void Custom_IndentLength_should_be_respected()
+        {
+            _notifier.IndentLength = 2;
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            _notifier.Notify(new StepStarting(new EventTime(), stepInfo));
+
+            // IndentLength=2 => base indent is "  " (2 spaces)
+            Assert.That(_captured.Single(), Does.StartWith("  Given some condition"));
+        }
+
+        [Test]
+        public void IndentLength_of_1_should_add_minimum_padding()
+        {
+            _notifier.IndentLength = 1;
+            var parentStep = CreateStepInfo("Given a parent", 1, 3, "");
+            var childStep = CreateStepInfo("And a child", 1, 2, "1.");
+            childStep.Parent = parentStep;
+
+            _notifier.Notify(new StepStarting(new EventTime(), parentStep));
+            _notifier.Notify(new StepStarting(new EventTime(), childStep));
+
+            // IndentLength=1, so minimum 2-space padding applies: "  " + " " = "   "
+            Assert.That(_captured.ElementAt(0), Does.StartWith("   Given a parent"));
+            // Child: "  " (min padding) + " " (parent) + " " (base) = "    "
+            Assert.That(_captured.ElementAt(1), Does.StartWith("    And a child"));
+        }
+
+        #endregion
+
+        #region Full integration test
+
+        [Test]
+        public void It_should_capture_meaningful_information_with_defaults()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = "As a customer I want to manage my cart"
+            };
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = "Verifies item addition"
+            };
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            var stepDuration = stepResult.ExecutionTime.Duration.FormatPretty();
+            var comment = "important note";
+            var attachment = new FileAttachment("screenshot", "/path/screenshot.png", "screenshot.png");
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 1: some failure",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("Shopping cart"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+            _notifier.Notify(new StepStarting(eventTime, stepInfo));
+            _notifier.Notify(new StepCommented(eventTime, stepInfo, comment));
+            _notifier.Notify(new StepFileAttached(eventTime, stepInfo, attachment));
+            _notifier.Notify(new StepFinished(eventTime, stepResult));
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+            _notifier.Notify(new FeatureFinished(eventTime, featureResult));
+
+            var expected = NormalizeNewlines($"""
+                FEATURE:  [Story-1] Shopping cart
+                          As a customer I want to manage my cart
+
+                SCENARIO: [Ticket-42] Adding items
+                          Verifies item addition
+
+                    Given some condition (STEP 1)
+                        => /* important note */
+                        => 🔗screenshot: /path/screenshot.png
+                      => (Failed after {stepDuration}) (STEP 1)
+
+                SCENARIO RESULT: Failed after 250ms
+                    Step 1: some failure
+
+                FEATURE FINISHED: Shopping cart
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_capture_meaningful_information_with_known_values()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Shopping cart"),
+                Labels = new[] { "Story-1" },
+                Description = "As a customer I want to manage my cart"
+            };
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Adding items"),
+                Labels = new[] { "Ticket-42" },
+                Categories = Array.Empty<string>(),
+                Description = "Verifies item addition"
+            };
+            var stepInfo = CreateStepInfo("Given some condition", 1, 3, "");
+            var stepResult = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            var stepDuration = stepResult.ExecutionTime.Duration.FormatPretty();
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Adding items"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 1: some failure",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+            var scenarioDuration = scenarioResult.ExecutionTime.Duration.FormatPretty();
+
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("Shopping cart"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+            _notifier.Notify(new StepStarting(eventTime, stepInfo));
+            _notifier.Notify(new StepCommented(eventTime, stepInfo, "important note"));
+            _notifier.Notify(new StepFileAttached(eventTime, stepInfo, new FileAttachment("screenshot", "/path/screenshot.png", "screenshot.png")));
+            _notifier.Notify(new StepFinished(eventTime, stepResult));
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+            _notifier.Notify(new FeatureFinished(eventTime, featureResult));
+
+            var expected = NormalizeNewlines($"""
+                FEATURE:  [Story-1] Shopping cart
+                          As a customer I want to manage my cart
+
+                SCENARIO: [Ticket-42] Adding items
+                          Verifies item addition
+
+                    Given some condition (STEP 1)
+                        => /* important note */
+                        => 🔗screenshot: /path/screenshot.png
+                      => (Failed after {stepDuration}) (STEP 1)
+
+                SCENARIO RESULT: Failed after {scenarioDuration}
+                    Step 1: some failure
+
+                FEATURE FINISHED: Shopping cart
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_capture_meaningful_information_with_composite_steps()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("Checkout flow"),
+                Labels = new[] { "Story-1" },
+                Description = "As a customer I want to complete my purchase"
+            };
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Composite step handling"),
+                Labels = Array.Empty<string>(),
+                Categories = Array.Empty<string>(),
+                Description = $"Verifies nested step rendering{Environment.NewLine}Another line of the scenario description{Environment.NewLine}Third line of the scenario description"
+            };
+
+            // Top-level steps (4 total)
+            var givenInfo = CreateStepInfo("Given some setup happens", 1, 4, "");
+            var whenInfo = CreateStepInfo("When some action happens", 2, 4, "");
+            var thenInfo = CreateStepInfo("Then some top level assertion", 3, 4, "");
+            var andInfo = CreateStepInfo("And some other top level assertion", 4, 4, "");
+
+            // Sub-steps of GIVEN (step 1): 3 sub-steps
+            var given1Info = CreateStepInfo("A start to the setup happens", 1, 3, "1.");
+            given1Info.Parent = givenInfo;
+            var given2Info = CreateStepInfo("The setup is executed", 2, 3, "1.");
+            given2Info.Parent = givenInfo;
+            var given3Info = CreateStepInfo("The setup is verified to be correct", 3, 3, "1.");
+            given3Info.Parent = givenInfo;
+
+            // Sub-steps of THEN (step 3): 2 sub-steps
+            var then1Info = CreateStepInfo("Some nested assertion", 1, 2, "3.");
+            then1Info.Parent = thenInfo;
+            var then2Info = CreateStepInfo("Some second nested assertion", 2, 2, "3.");
+            then2Info.Parent = thenInfo;
+
+            TestResults.TestStepResult ResultFrom(TestResults.TestStepInfo info, ExecutionStatus status) =>
+                new()
+                {
+                    Info = info,
+                    Status = status,
+                    ExecutionTime = new TestResults.TestExecutionTime
+                    {
+                        Start = DateTimeOffset.UtcNow,
+                        Duration = TimeSpan.FromMilliseconds(125)
+                    }
+                };
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Composite step handling"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 1.3: assertion failed",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("Checkout flow"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            // Feature and scenario start
+            _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+
+            // GIVEN composite step with 3 sub-steps (sub-step 3 fails)
+            _notifier.Notify(new StepStarting(eventTime, givenInfo));
+            _notifier.Notify(new StepStarting(eventTime, given1Info));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(given1Info, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, given2Info));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(given2Info, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, given3Info));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(given3Info, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(givenInfo, ExecutionStatus.Failed)));
+
+            // WHEN simple step (passes)
+            _notifier.Notify(new StepStarting(eventTime, whenInfo));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(whenInfo, ExecutionStatus.Passed)));
+
+            // THEN composite step with 2 sub-steps (sub-step 2 fails)
+            _notifier.Notify(new StepStarting(eventTime, thenInfo));
+            _notifier.Notify(new StepStarting(eventTime, then1Info));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(then1Info, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, then2Info));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(then2Info, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(thenInfo, ExecutionStatus.Failed)));
+
+            // AND simple step (ignored after previous failure)
+            _notifier.Notify(new StepStarting(eventTime, andInfo));
+            _notifier.Notify(new StepFinished(eventTime, ResultFrom(andInfo, ExecutionStatus.Ignored)));
+
+            // Scenario and feature finish
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+            _notifier.Notify(new FeatureFinished(eventTime, featureResult));
+
+            var expected = NormalizeNewlines("""
+                FEATURE:  [Story-1] Checkout flow
+                          As a customer I want to complete my purchase
+
+                SCENARIO: Composite step handling
+                          Verifies nested step rendering
+                          Another line of the scenario description
+                          Third line of the scenario description
+
+                    Given some setup happens (STEP 1)
+                        A start to the setup happens (STEP 1.1)
+                        The setup is executed (STEP 1.2)
+                        The setup is verified to be correct (STEP 1.3)
+                          => (Failed after 125ms) (STEP 1.3)
+                      => (Failed after 125ms) (STEP 1)
+                    When some action happens (STEP 2)
+                    Then some top level assertion (STEP 3)
+                        Some nested assertion (STEP 3.1)
+                        Some second nested assertion (STEP 3.2)
+                          => (Failed after 125ms) (STEP 3.2)
+                      => (Failed after 125ms) (STEP 3)
+                    And some other top level assertion (STEP 4)
+                      => (Ignored after 125ms) (STEP 4)
+
+                SCENARIO RESULT: Failed after 250ms
+                    Step 1.3: assertion failed
+
+                FEATURE FINISHED: Checkout flow
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_capture_multiple_passing_scenarios_with_mixed_nesting()
+        {
+            var featureInfo = new TestResults.TestFeatureInfo
+            {
+                Name = TestResults.CreateNameInfo("User management"),
+                Labels = new[] { "Epic-5" },
+                Description = "Covers user lifecycle operations"
+            };
+            var featureResult = new TestResults.TestFeatureResult
+            {
+                Info = new TestResults.TestFeatureInfo
+                {
+                    Name = TestResults.CreateNameInfo("User management"),
+                    Labels = Array.Empty<string>()
+                }
+            };
+
+            TestResults.TestScenarioInfo ScenarioInfo(string name) => new()
+            {
+                Name = TestResults.CreateNameInfo(name),
+                Labels = Array.Empty<string>(),
+                Categories = Array.Empty<string>()
+            };
+
+            TestResults.TestScenarioResult PassedScenarioResult(string name) => new()
+            {
+                Info = ScenarioInfo(name),
+                Status = ExecutionStatus.Passed,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(250)
+                }
+            };
+
+            TestResults.TestStepResult PassedResult(TestResults.TestStepInfo info) => new()
+            {
+                Info = info,
+                Status = ExecutionStatus.Passed,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(125)
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new FeatureStarting(eventTime, featureInfo));
+
+            // --- Scenario 1: flat (0 levels of nesting), has GIVEN-AND and THEN-AND ---
+            var s1 = ScenarioInfo("List users");
+            var s1_given = CreateStepInfo("Given the system has users", 1, 5, "");
+            var s1_givenAnd = CreateStepInfo("And the user has permissions", 2, 5, "");
+            var s1_when = CreateStepInfo("When I request the user list", 3, 5, "");
+            var s1_then = CreateStepInfo("Then all users are returned", 4, 5, "");
+            var s1_thenAnd = CreateStepInfo("And the response contains user details", 5, 5, "");
+
+            _notifier.Notify(new ScenarioStarting(eventTime, s1));
+            _notifier.Notify(new StepStarting(eventTime, s1_given));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s1_given)));
+            _notifier.Notify(new StepStarting(eventTime, s1_givenAnd));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s1_givenAnd)));
+            _notifier.Notify(new StepStarting(eventTime, s1_when));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s1_when)));
+            _notifier.Notify(new StepStarting(eventTime, s1_then));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s1_then)));
+            _notifier.Notify(new StepStarting(eventTime, s1_thenAnd));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s1_thenAnd)));
+            _notifier.Notify(new ScenarioFinished(eventTime, PassedScenarioResult("List users")));
+
+            // --- Scenario 2: 1 level of nesting ---
+            var s2 = ScenarioInfo("Create user");
+            var s2_given = CreateStepInfo("Given valid registration data", 1, 3, "");
+            var s2_when = CreateStepInfo("When the user is created", 2, 3, "");
+            var s2_when1 = CreateStepInfo("The API is called", 1, 3, "2.");
+            s2_when1.Parent = s2_when;
+            var s2_when2 = CreateStepInfo("The response is parsed", 2, 3, "2.");
+            s2_when2.Parent = s2_when;
+            var s2_when3 = CreateStepInfo("The user is stored", 3, 3, "2.");
+            s2_when3.Parent = s2_when;
+            var s2_then = CreateStepInfo("Then the user appears in the system", 3, 3, "");
+
+            _notifier.Notify(new ScenarioStarting(eventTime, s2));
+            _notifier.Notify(new StepStarting(eventTime, s2_given));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_given)));
+            _notifier.Notify(new StepStarting(eventTime, s2_when));
+            _notifier.Notify(new StepStarting(eventTime, s2_when1));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_when1)));
+            _notifier.Notify(new StepStarting(eventTime, s2_when2));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_when2)));
+            _notifier.Notify(new StepStarting(eventTime, s2_when3));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_when3)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_when)));
+            _notifier.Notify(new StepStarting(eventTime, s2_then));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s2_then)));
+            _notifier.Notify(new ScenarioFinished(eventTime, PassedScenarioResult("Create user")));
+
+            // --- Scenario 3: 2 levels of nesting, has THEN-AND ---
+            var s3 = ScenarioInfo("Delete user with cascade");
+            var s3_given = CreateStepInfo("Given a user with nested resources", 1, 4, "");
+            var s3_when = CreateStepInfo("When the user is deleted", 2, 4, "");
+            // sub-steps of s3_when (level 1)
+            var s3_when1 = CreateStepInfo("The dependencies are resolved", 1, 2, "2.");
+            s3_when1.Parent = s3_when;
+            var s3_when2 = CreateStepInfo("The deletion is executed", 2, 2, "2.");
+            s3_when2.Parent = s3_when;
+            // sub-sub-steps of s3_when2 (level 2)
+            var s3_when2a = CreateStepInfo("Child resources are removed", 1, 2, "2.2.");
+            s3_when2a.Parent = s3_when2;
+            var s3_when2b = CreateStepInfo("The user record is removed", 2, 2, "2.2.");
+            s3_when2b.Parent = s3_when2;
+            var s3_then = CreateStepInfo("Then the user no longer exists", 3, 4, "");
+            var s3_thenAnd = CreateStepInfo("And all nested resources are gone", 4, 4, "");
+
+            _notifier.Notify(new ScenarioStarting(eventTime, s3));
+            _notifier.Notify(new StepStarting(eventTime, s3_given));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_given)));
+            _notifier.Notify(new StepStarting(eventTime, s3_when));
+            _notifier.Notify(new StepStarting(eventTime, s3_when1));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_when1)));
+            _notifier.Notify(new StepStarting(eventTime, s3_when2));
+            _notifier.Notify(new StepStarting(eventTime, s3_when2a));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_when2a)));
+            _notifier.Notify(new StepStarting(eventTime, s3_when2b));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_when2b)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_when2)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_when)));
+            _notifier.Notify(new StepStarting(eventTime, s3_then));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_then)));
+            _notifier.Notify(new StepStarting(eventTime, s3_thenAnd));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s3_thenAnd)));
+            _notifier.Notify(new ScenarioFinished(eventTime, PassedScenarioResult("Delete user with cascade")));
+
+            // --- Scenario 4: complex nesting in GIVEN, WHEN and THEN ---
+            var s4 = ScenarioInfo("Transfer user ownership");
+            // GIVEN with nested + double-nested sub-steps
+            var s4_given = CreateStepInfo("Given an owner with resources", 1, 5, "");
+            var s4_given1 = CreateStepInfo("The owner account is loaded", 1, 2, "1.");
+            s4_given1.Parent = s4_given;
+            var s4_given2 = CreateStepInfo("The resources are enumerated", 2, 2, "1.");
+            s4_given2.Parent = s4_given;
+            var s4_given2a = CreateStepInfo("Active resources are found", 1, 2, "1.2.");
+            s4_given2a.Parent = s4_given2;
+            var s4_given2b = CreateStepInfo("Archived resources are found", 2, 2, "1.2.");
+            s4_given2b.Parent = s4_given2;
+            // AND (flat)
+            var s4_givenAnd = CreateStepInfo("And a target user exists", 2, 5, "");
+            // WHEN with nested sub-steps
+            var s4_when = CreateStepInfo("When ownership is transferred", 3, 5, "");
+            var s4_when1 = CreateStepInfo("Permissions are reassigned", 1, 2, "3.");
+            s4_when1.Parent = s4_when;
+            var s4_when2 = CreateStepInfo("Notifications are sent", 2, 2, "3.");
+            s4_when2.Parent = s4_when;
+            // THEN with nested + double-nested sub-steps
+            var s4_then = CreateStepInfo("Then the target owns all resources", 4, 5, "");
+            var s4_then1 = CreateStepInfo("Active resources belong to target", 1, 2, "4.");
+            s4_then1.Parent = s4_then;
+            var s4_then2 = CreateStepInfo("Archived resources belong to target", 2, 2, "4.");
+            s4_then2.Parent = s4_then;
+            var s4_then2a = CreateStepInfo("Read-only archives are transferred", 1, 2, "4.2.");
+            s4_then2a.Parent = s4_then2;
+            var s4_then2b = CreateStepInfo("Mutable archives are transferred", 2, 2, "4.2.");
+            s4_then2b.Parent = s4_then2;
+            // AND (flat)
+            var s4_thenAnd = CreateStepInfo("And the original owner has no resources", 5, 5, "");
+
+            _notifier.Notify(new ScenarioStarting(eventTime, s4));
+            _notifier.Notify(new StepStarting(eventTime, s4_given));
+            _notifier.Notify(new StepStarting(eventTime, s4_given1));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_given1)));
+            _notifier.Notify(new StepStarting(eventTime, s4_given2));
+            _notifier.Notify(new StepStarting(eventTime, s4_given2a));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_given2a)));
+            _notifier.Notify(new StepStarting(eventTime, s4_given2b));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_given2b)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_given2)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_given)));
+            _notifier.Notify(new StepStarting(eventTime, s4_givenAnd));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_givenAnd)));
+            _notifier.Notify(new StepStarting(eventTime, s4_when));
+            _notifier.Notify(new StepStarting(eventTime, s4_when1));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_when1)));
+            _notifier.Notify(new StepStarting(eventTime, s4_when2));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_when2)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_when)));
+            _notifier.Notify(new StepStarting(eventTime, s4_then));
+            _notifier.Notify(new StepStarting(eventTime, s4_then1));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_then1)));
+            _notifier.Notify(new StepStarting(eventTime, s4_then2));
+            _notifier.Notify(new StepStarting(eventTime, s4_then2a));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_then2a)));
+            _notifier.Notify(new StepStarting(eventTime, s4_then2b));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_then2b)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_then2)));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_then)));
+            _notifier.Notify(new StepStarting(eventTime, s4_thenAnd));
+            _notifier.Notify(new StepFinished(eventTime, PassedResult(s4_thenAnd)));
+            _notifier.Notify(new ScenarioFinished(eventTime, PassedScenarioResult("Transfer user ownership")));
+
+            _notifier.Notify(new FeatureFinished(eventTime, featureResult));
+
+            var expected = NormalizeNewlines("""
+                FEATURE:  [Epic-5] User management
+                          Covers user lifecycle operations
+
+                SCENARIO: List users
+
+                    Given the system has users (STEP 1)
+                    And the user has permissions (STEP 2)
+                    When I request the user list (STEP 3)
+                    Then all users are returned (STEP 4)
+                    And the response contains user details (STEP 5)
+
+                SCENARIO RESULT: Passed after 250ms
+
+                SCENARIO: Create user
+
+                    Given valid registration data (STEP 1)
+                    When the user is created (STEP 2)
+                        The API is called (STEP 2.1)
+                        The response is parsed (STEP 2.2)
+                        The user is stored (STEP 2.3)
+                    Then the user appears in the system (STEP 3)
+
+                SCENARIO RESULT: Passed after 250ms
+
+                SCENARIO: Delete user with cascade
+
+                    Given a user with nested resources (STEP 1)
+                    When the user is deleted (STEP 2)
+                        The dependencies are resolved (STEP 2.1)
+                        The deletion is executed (STEP 2.2)
+                            Child resources are removed (STEP 2.2.1)
+                            The user record is removed (STEP 2.2.2)
+                    Then the user no longer exists (STEP 3)
+                    And all nested resources are gone (STEP 4)
+
+                SCENARIO RESULT: Passed after 250ms
+
+                SCENARIO: Transfer user ownership
+
+                    Given an owner with resources (STEP 1)
+                        The owner account is loaded (STEP 1.1)
+                        The resources are enumerated (STEP 1.2)
+                            Active resources are found (STEP 1.2.1)
+                            Archived resources are found (STEP 1.2.2)
+                    And a target user exists (STEP 2)
+                    When ownership is transferred (STEP 3)
+                        Permissions are reassigned (STEP 3.1)
+                        Notifications are sent (STEP 3.2)
+                    Then the target owns all resources (STEP 4)
+                        Active resources belong to target (STEP 4.1)
+                        Archived resources belong to target (STEP 4.2)
+                            Read-only archives are transferred (STEP 4.2.1)
+                            Mutable archives are transferred (STEP 4.2.2)
+                    And the original owner has no resources (STEP 5)
+
+                SCENARIO RESULT: Passed after 250ms
+
+                FEATURE FINISHED: User management
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_show_failure_in_deeply_nested_Then_step()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Transfer user ownership"),
+                Labels = Array.Empty<string>(),
+                Categories = Array.Empty<string>()
+            };
+
+            // GIVEN with nested + double-nested sub-steps (all pass)
+            var given = CreateStepInfo("Given an owner with resources", 1, 5, "");
+            var given1 = CreateStepInfo("The owner account is loaded", 1, 2, "1.");
+            given1.Parent = given;
+            var given2 = CreateStepInfo("The resources are enumerated", 2, 2, "1.");
+            given2.Parent = given;
+            var given2a = CreateStepInfo("Active resources are found", 1, 2, "1.2.");
+            given2a.Parent = given2;
+            var given2b = CreateStepInfo("Archived resources are found", 2, 2, "1.2.");
+            given2b.Parent = given2;
+
+            // AND (passes)
+            var givenAnd = CreateStepInfo("And a target user exists", 2, 5, "");
+
+            // WHEN with nested sub-steps (all pass)
+            var when = CreateStepInfo("When ownership is transferred", 3, 5, "");
+            var when1 = CreateStepInfo("Permissions are reassigned", 1, 2, "3.");
+            when1.Parent = when;
+            var when2 = CreateStepInfo("Notifications are sent", 2, 2, "3.");
+            when2.Parent = when;
+
+            // THEN with nested + double-nested sub-steps (double-nested step fails)
+            var then = CreateStepInfo("Then the target owns all resources", 4, 5, "");
+            var then1 = CreateStepInfo("Active resources belong to target", 1, 2, "4.");
+            then1.Parent = then;
+            var then2 = CreateStepInfo("Archived resources belong to target", 2, 2, "4.");
+            then2.Parent = then;
+            var then2a = CreateStepInfo("Read-only archives are transferred", 1, 2, "4.2.");
+            then2a.Parent = then2;
+            var then2b = CreateStepInfo("Mutable archives are transferred", 2, 2, "4.2.");
+            then2b.Parent = then2;
+
+            // AND (ignored after failure)
+            var thenAnd = CreateStepInfo("And the original owner has no resources", 5, 5, "");
+
+            TestResults.TestStepResult Result(TestResults.TestStepInfo info, ExecutionStatus status) => new()
+            {
+                Info = info,
+                Status = status,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(125)
+                }
+            };
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Transfer user ownership"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 4.2.2: archive transfer failed",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(500)
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+
+            // GIVEN (all pass)
+            _notifier.Notify(new StepStarting(eventTime, given));
+            _notifier.Notify(new StepStarting(eventTime, given1));
+            _notifier.Notify(new StepFinished(eventTime, Result(given1, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, given2));
+            _notifier.Notify(new StepStarting(eventTime, given2a));
+            _notifier.Notify(new StepFinished(eventTime, Result(given2a, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, given2b));
+            _notifier.Notify(new StepFinished(eventTime, Result(given2b, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(given2, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(given, ExecutionStatus.Passed)));
+
+            // AND (passes)
+            _notifier.Notify(new StepStarting(eventTime, givenAnd));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd, ExecutionStatus.Passed)));
+
+            // WHEN (all pass)
+            _notifier.Notify(new StepStarting(eventTime, when));
+            _notifier.Notify(new StepStarting(eventTime, when1));
+            _notifier.Notify(new StepFinished(eventTime, Result(when1, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, when2));
+            _notifier.Notify(new StepFinished(eventTime, Result(when2, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(when, ExecutionStatus.Passed)));
+
+            // THEN (double-nested step 4.2.2 fails, cascades up)
+            _notifier.Notify(new StepStarting(eventTime, then));
+            _notifier.Notify(new StepStarting(eventTime, then1));
+            _notifier.Notify(new StepFinished(eventTime, Result(then1, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, then2));
+            _notifier.Notify(new StepStarting(eventTime, then2a));
+            _notifier.Notify(new StepFinished(eventTime, Result(then2a, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, then2b));
+            _notifier.Notify(new StepFinished(eventTime, Result(then2b, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(then2, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(then, ExecutionStatus.Failed)));
+
+            // AND (ignored after failure)
+            _notifier.Notify(new StepStarting(eventTime, thenAnd));
+            _notifier.Notify(new StepFinished(eventTime, Result(thenAnd, ExecutionStatus.Ignored)));
+
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO: Transfer user ownership
+
+                    Given an owner with resources (STEP 1)
+                        The owner account is loaded (STEP 1.1)
+                        The resources are enumerated (STEP 1.2)
+                            Active resources are found (STEP 1.2.1)
+                            Archived resources are found (STEP 1.2.2)
+                    And a target user exists (STEP 2)
+                    When ownership is transferred (STEP 3)
+                        Permissions are reassigned (STEP 3.1)
+                        Notifications are sent (STEP 3.2)
+                    Then the target owns all resources (STEP 4)
+                        Active resources belong to target (STEP 4.1)
+                        Archived resources belong to target (STEP 4.2)
+                            Read-only archives are transferred (STEP 4.2.1)
+                            Mutable archives are transferred (STEP 4.2.2)
+                              => (Failed after 125ms) (STEP 4.2.2)
+                          => (Failed after 125ms) (STEP 4.2)
+                      => (Failed after 125ms) (STEP 4)
+                    And the original owner has no resources (STEP 5)
+                      => (Ignored after 125ms) (STEP 5)
+
+                SCENARIO RESULT: Failed after 500ms
+                    Step 4.2.2: archive transfer failed
+
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void It_should_show_failure_in_nested_Given_And_step()
+        {
+            var scenarioInfo = new TestResults.TestScenarioInfo
+            {
+                Name = TestResults.CreateNameInfo("Provision team workspace"),
+                Labels = Array.Empty<string>(),
+                Categories = Array.Empty<string>()
+            };
+
+            // GIVEN (passes)
+            var given = CreateStepInfo("Given an organization exists", 1, 4, "");
+
+            // AND with nested sub-steps (nested step fails)
+            var givenAnd = CreateStepInfo("And the team is configured", 2, 4, "");
+            var givenAnd1 = CreateStepInfo("Team roles are assigned", 1, 2, "2.");
+            givenAnd1.Parent = givenAnd;
+            var givenAnd2 = CreateStepInfo("Team quota is validated", 2, 2, "2.");
+            givenAnd2.Parent = givenAnd;
+            var givenAnd2a = CreateStepInfo("Storage quota is checked", 1, 2, "2.2.");
+            givenAnd2a.Parent = givenAnd2;
+            var givenAnd2b = CreateStepInfo("Seat limit is checked", 2, 2, "2.2.");
+            givenAnd2b.Parent = givenAnd2;
+
+            // WHEN (ignored after setup failure)
+            var when = CreateStepInfo("When the workspace is provisioned", 3, 4, "");
+
+            // THEN (ignored after setup failure)
+            var then = CreateStepInfo("Then the workspace is available", 4, 4, "");
+
+            TestResults.TestStepResult Result(TestResults.TestStepInfo info, ExecutionStatus status) => new()
+            {
+                Info = info,
+                Status = status,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(125)
+                }
+            };
+
+            var scenarioResult = new TestResults.TestScenarioResult
+            {
+                Info = new TestResults.TestScenarioInfo
+                {
+                    Name = TestResults.CreateNameInfo("Provision team workspace"),
+                    Labels = Array.Empty<string>(),
+                    Categories = Array.Empty<string>()
+                },
+                Status = ExecutionStatus.Failed,
+                StatusDetails = "Step 2.2.2: seat limit exceeded",
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(300)
+                }
+            };
+
+            var eventTime = new EventTime();
+
+            _notifier.Notify(new ScenarioStarting(eventTime, scenarioInfo));
+
+            // GIVEN (passes)
+            _notifier.Notify(new StepStarting(eventTime, given));
+            _notifier.Notify(new StepFinished(eventTime, Result(given, ExecutionStatus.Passed)));
+
+            // AND (nested step 2.2.2 fails, cascades up)
+            _notifier.Notify(new StepStarting(eventTime, givenAnd));
+            _notifier.Notify(new StepStarting(eventTime, givenAnd1));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd1, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, givenAnd2));
+            _notifier.Notify(new StepStarting(eventTime, givenAnd2a));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd2a, ExecutionStatus.Passed)));
+            _notifier.Notify(new StepStarting(eventTime, givenAnd2b));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd2b, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd2, ExecutionStatus.Failed)));
+            _notifier.Notify(new StepFinished(eventTime, Result(givenAnd, ExecutionStatus.Failed)));
+
+            // WHEN (ignored)
+            _notifier.Notify(new StepStarting(eventTime, when));
+            _notifier.Notify(new StepFinished(eventTime, Result(when, ExecutionStatus.Ignored)));
+
+            // THEN (ignored)
+            _notifier.Notify(new StepStarting(eventTime, then));
+            _notifier.Notify(new StepFinished(eventTime, Result(then, ExecutionStatus.Ignored)));
+
+            _notifier.Notify(new ScenarioFinished(eventTime, scenarioResult));
+
+            var expected = NormalizeNewlines("""
+                SCENARIO: Provision team workspace
+
+                    Given an organization exists (STEP 1)
+                    And the team is configured (STEP 2)
+                        Team roles are assigned (STEP 2.1)
+                        Team quota is validated (STEP 2.2)
+                            Storage quota is checked (STEP 2.2.1)
+                            Seat limit is checked (STEP 2.2.2)
+                              => (Failed after 125ms) (STEP 2.2.2)
+                          => (Failed after 125ms) (STEP 2.2)
+                      => (Failed after 125ms) (STEP 2)
+                    When the workspace is provisioned (STEP 3)
+                      => (Ignored after 125ms) (STEP 3)
+                    Then the workspace is available (STEP 4)
+                      => (Ignored after 125ms) (STEP 4)
+
+                SCENARIO RESULT: Failed after 300ms
+                    Step 2.2.2: seat limit exceeded
+
+                """);
+
+            var actual = NormalizeNewlines(string.Join("\n", _captured));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static TestResults.TestStepInfo CreateStepInfo(string name, int number, int total, string groupPrefix)
+        {
+            return new TestResults.TestStepInfo
+            {
+                Name = TestResults.CreateStepName(name, null, name),
+                Number = number,
+                Total = total,
+                GroupPrefix = groupPrefix
+            };
+        }
+
+        private static TestResults.TestStepResult CreateStepResult(string name, int number, int total, string groupPrefix, ExecutionStatus status)
+        {
+            return new TestResults.TestStepResult
+            {
+                Info = CreateStepInfo(name, number, total, groupPrefix),
+                Status = status,
+                ExecutionTime = new TestResults.TestExecutionTime
+                {
+                    Start = DateTimeOffset.UtcNow,
+                    Duration = TimeSpan.FromMilliseconds(125)
+                }
+            };
+        }
+
+        private static TestResults.TestStepResult CreateStepResultWithParameters()
+        {
+            var result = CreateStepResult("Given some condition", 1, 3, "", ExecutionStatus.Failed);
+            result.Parameters = new IParameterResult[]
+            {
+                new TestResults.TestParameterResult("table",
+                    TestResults.CreateTabularParameterDetails(ParameterVerificationStatus.Failure)
+                        .WithKeyColumns("Key")
+                        .WithValueColumns("Value1", "Value2")
+                        .AddRow(TableRowType.Matching,
+                            ParameterVerificationStatus.Success,
+                            TestResults.CreateValueResult("1"),
+                            TestResults.CreateValueResult("abc"),
+                            TestResults.CreateValueResult("some value"))
+                        .AddRow(TableRowType.Matching,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("2"),
+                            TestResults.CreateValueResult("def"),
+                            TestResults.CreateValueResult("value", "val", ParameterVerificationStatus.Failure))
+                        .AddRow(TableRowType.Missing,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("3"),
+                            TestResults.CreateValueResult("XXX", "<null>", ParameterVerificationStatus.NotProvided),
+                            TestResults.CreateValueResult("YYY", "<null>", ParameterVerificationStatus.NotProvided))
+                        .AddRow(TableRowType.Surplus,
+                            ParameterVerificationStatus.Failure,
+                            TestResults.CreateValueResult("4"),
+                            TestResults.CreateValueResult("<null>", "XXX", ParameterVerificationStatus.Failure),
+                            TestResults.CreateValueResult("<null>", "YYY", ParameterVerificationStatus.Failure))
+                ),
+                new TestResults.TestParameterResult("tree", CreateTreeParameterResult())
+            };
+            return result;
+        }
+
+        private static IParameterDetails CreateTreeParameterResult()
+        {
+            var expected = new
+            {
+                Name = "Bob",
+                Surname = "Johnson",
+                Items = new[] { false }
+            };
+            var actual = new
+            {
+                Name = "Bob",
+                LastName = "Johnson",
+                Items = new[] { true }
+            };
+            var tree = Tree.ExpectEquivalent(expected);
+            tree.SetActual(actual);
+            return tree.Details;
+        }
+
+        /// <summary>
+        /// Normalizes line endings in raw string literals to match <see cref="Environment.NewLine"/>
+        /// so that assertions are platform-independent.
+        /// </summary>
+        private static string NormalizeNewlines(string text) => text.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Make `DefaultProgressNotifier` configurable through 10 public properties (all defaulting to preserve existing behavior). Add new `SimpleIndentedProgressNotifier` that inherits from it and pre-configures hierarchical indented output. No behavior changes unless you actively configure the new properties.

#### Details

Issue reference: #183

List of changes:

**`DefaultProgressNotifier` (modified)**

The class gained 10 configurable properties, all with defaults that preserve the original behavior:

| Property | Type | Default | Description |
|---|---|---|---|
| `WriteSuccessMessageForBasicSteps` | `bool` | `true` | Whether to emit a finish line for passing steps |
| `ShowFinalStepWithEachStep` | `bool` | `true` | Show total count, e.g. `STEP 1/3` vs `STEP 1` |
| `IndentLength` | `int` | `0` | `0` = flat two-space indent; `> 0` = hierarchical nesting |
| `StepWordAndStepNumberOnStart` | `StepWordAndStepNumberBehaviour` | `IncludeAsPrefix` | Where step reference appears on step start |
| `StepWordAndStepNumberOnFinish` | `StepWordAndStepNumberBehaviour` | `IncludeAsPrefix` | Where step reference appears on step finish |
| `IncludeStepNameOnFinish` | `bool` | `true` | Repeat step name in finish notification |
| `IncludeEllipsisAfterStep` | `bool` | `true` | Append `...` to step start |
| `WriteBlankLineAfterFeatureStart` | `bool` | `false` | Blank line after feature header |
| `WriteBlankLineAfterScenarioStart` | `bool` | `false` | Blank line after scenario header |
| `WriteBlankLinesAroundScenarioFinish` | `bool` | `false` | Blank lines before/after scenario result |

All notification methods (`NotifyScenarioStart`, `NotifyStepStart`, `NotifyStepFinished`, etc.) were made `virtual` so subclasses can override individual behaviors.

Several helpers were promoted from `private`/`static` to `protected virtual`:
- `GetIndentPrefix(IStepInfo)` — builds the whitespace prefix based on nesting depth and `IndentLength`
- `GetAnnotationIndent(IStepInfo)` — builds the indent for annotations (parameters, comments, attachments) that sit under a step
- `GetStepWordAndStepNumber(IStepInfo)` — formats the `STEP X/Y` string
- `FormatDescription(string)` — indents description text
- `FormatLabels(IEnumerable<string>)` — formats `[label]` tags
- `OnNotify(string)` — exposes the notification delegate to subclasses

The `IndentLength` property controls a mode switch:
- **`IndentLength <= 0` (default):** Flat output with a fixed `"  "` indent. `FEATURE:` uses single-space padding. `SCENARIO RESULT` is prefixed with `"  "`.
- **`IndentLength > 0`:** Hierarchical output where each nesting level adds `IndentLength` spaces. `FEATURE:` uses double-space padding (to align with `SCENARIO:`). `SCENARIO RESULT` has no indent prefix.

**`SimpleIndentedProgressNotifier` (new)**

A new class that inherits from `DefaultProgressNotifier` and pre-configures properties to produce hierarchical, indented output. The entire implementation is just constructor property assignments:

```csharp
public SimpleIndentedProgressNotifier(params Action<string>[] onNotify)
    : base(onNotify)
{
    WriteSuccessMessageForBasicSteps = false;
    ShowFinalStepWithEachStep = false;
    IndentLength = 4;
    StepWordAndStepNumberOnStart = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
    StepWordAndStepNumberOnFinish = StepWordAndStepNumberBehaviour.IncludeAsSuffix;
    IncludeStepNameOnFinish = false;
    IncludeEllipsisAfterStep = false;
    WriteBlankLineAfterFeatureStart = true;
    WriteBlankLineAfterScenarioStart = true;
    WriteBlankLinesAroundScenarioFinish = true;
}
```

**`StepWordAndStepNumberBehaviour` (new)**

A new enum that controls step reference placement:

- `IncludeAsPrefix` — `STEP 1.1: Given some condition`
- `IncludeAsSuffix` — `Given some condition (STEP 1.1)`
- `Exclude` — `Given some condition`

**Test changes**

| File | Status | master | branch |
|---|---|---|---|
| `DefaultProgressNotifier_tests.cs` | Modified | 198 lines (6 tests) | ~940 lines (47 tests) |
| `SimpleIndentedProgressNotifier_tests.cs` | **New** | — | ~1480 lines (41 tests) |

`DefaultProgressNotifier_tests` — Expanded from 6 tests to 47 tests. New tests cover:
- Step start/finish with each `StepWordAndStepNumberBehaviour` mode
- `WriteSuccessMessageForBasicSteps` suppression (passed steps skipped, failed/ignored/bypassed still emitted)
- `IncludeEllipsisAfterStep` and `IncludeStepNameOnFinish` toggles
- `ShowFinalStepWithEachStep` toggle
- Blank line properties (`WriteBlankLineAfterFeatureStart`, `WriteBlankLineAfterScenarioStart`, `WriteBlankLinesAroundScenarioFinish`)
- `IndentLength` mode switch: flat vs hierarchical, nested step indentation, feature/scenario formatting differences
- Comment and file attachment rendering in prefix vs arrow style
- Parameter rendering (tabular + tree) with and without success message suppression
- A full integration test that configures `DefaultProgressNotifier` identically to `SimpleIndentedProgressNotifier` and verifies identical output

`SimpleIndentedProgressNotifier_tests` (new) — 41 tests covering:
- Feature start/finish notifications with labels, descriptions, blank line formatting
- Scenario start/finish notifications with labels, categories, status details
- Step start notifications with suffix-style step references, hierarchical indentation
- Step finish notifications with arrow-style results, parameter rendering (tabular + tree)
- Step comments and file attachments with arrow-style formatting
- Full integration tests using hardcoded expected strings for readability
- Multi-scenario nesting test with Given-And, Then-And patterns across 4 scenarios exercising deeply nested Given, When, and Then blocks
- Failure propagation tests: failure in a double-nested Then step, failure in a nested Given-And step

**Example output from `SimpleIndentedProgressNotifier`**

The `It_should_capture_multiple_passing_scenarios_with_mixed_nesting` test verifies output including this scenario with complex nesting across Given, When, and Then:

```
Given an owner with resources (STEP 1)
    The owner account is loaded (STEP 1.1)
    The resources are enumerated (STEP 1.2)
        Active resources are found (STEP 1.2.1)
        Archived resources are found (STEP 1.2.2)
And a target user exists (STEP 2)
When ownership is transferred (STEP 3)
    Permissions are reassigned (STEP 3.1)
    Notifications are sent (STEP 3.2)
Then the target owns all resources (STEP 4)
    Active resources belong to target (STEP 4.1)
    Archived resources belong to target (STEP 4.2)
        Read-only archives are transferred (STEP 4.2.1)
        Mutable archives are transferred (STEP 4.2.2)
And the original owner has no resources (STEP 5)
```

**Example output: failure in a double-nested Then step**

The `It_should_show_failure_in_deeply_nested_Then_step` test demonstrates how failures propagate up through nesting. Here step 4.2.2 fails inside `Then`, causing its parent steps to also report failure, and the subsequent `And` step is ignored:

```
SCENARIO: Transfer user ownership

    Given an owner with resources (STEP 1)
        The owner account is loaded (STEP 1.1)
        The resources are enumerated (STEP 1.2)
            Active resources are found (STEP 1.2.1)
            Archived resources are found (STEP 1.2.2)
    And a target user exists (STEP 2)
    When ownership is transferred (STEP 3)
        Permissions are reassigned (STEP 3.1)
        Notifications are sent (STEP 3.2)
    Then the target owns all resources (STEP 4)
        Active resources belong to target (STEP 4.1)
        Archived resources belong to target (STEP 4.2)
            Read-only archives are transferred (STEP 4.2.1)
            Mutable archives are transferred (STEP 4.2.2)
              => (Failed after 125ms) (STEP 4.2.2)
          => (Failed after 125ms) (STEP 4.2)
      => (Failed after 125ms) (STEP 4)
    And the original owner has no resources (STEP 5)
      => (Ignored after 125ms) (STEP 5)

SCENARIO RESULT: Failed after 500ms
    Step 4.2.2: archive transfer failed
```

**Example output: failure in a nested Given-And step**

The `It_should_show_failure_in_nested_Given_And_step` test shows a failure during setup — a nested sub-step of `And` fails, causing the entire `And` step to fail, and subsequent `When`/`Then` steps are ignored:

```
SCENARIO: Provision team workspace

    Given an organization exists (STEP 1)
    And the team is configured (STEP 2)
        Team roles are assigned (STEP 2.1)
        Team quota is validated (STEP 2.2)
            Storage quota is checked (STEP 2.2.1)
            Seat limit is checked (STEP 2.2.2)
              => (Failed after 125ms) (STEP 2.2.2)
          => (Failed after 125ms) (STEP 2.2)
      => (Failed after 125ms) (STEP 2)
    When the workspace is provisioned (STEP 3)
      => (Ignored after 125ms) (STEP 3)
    Then the workspace is available (STEP 4)
      => (Ignored after 125ms) (STEP 4)

SCENARIO RESULT: Failed after 300ms
    Step 2.2.2: seat limit exceeded
```

**Gotchas and things to look out for**

1. **`IndentLength` is a mode switch, not just a spacing number.** When `IndentLength <= 0` (the default), the notifier uses flat `"  "` indentation everywhere — nesting depth is ignored. When `IndentLength > 0`, hierarchical indentation kicks in. This also affects the `FEATURE:` header padding (`" "` vs `"  "`) and whether `SCENARIO RESULT` gets a `"  "` prefix. This is by design to keep `DefaultProgressNotifier`'s default output byte-identical to the old behavior.

2. **Comment and file attachment formatting depends on `StepWordAndStepNumberOnStart`.** When it's `IncludeAsPrefix` (the default), comments/attachments use the prefix style: `STEP 1/3: /* comment */`. When it's anything else, they switch to arrow style: `=> /* comment */`. This matches the original `DefaultProgressNotifier` behavior (prefix style) and gives `SimpleIndentedProgressNotifier` the arrow style.

3. **`GetAnnotationIndent` vs `GetIndentPrefix`.** `GetIndentPrefix` returns the indent for the step line itself. `GetAnnotationIndent` adds an extra level (for parameters, comments, attachments that appear *under* a step). In flat mode, `GetIndentPrefix` returns `"  "` and `GetAnnotationIndent` returns `"    "`. In hierarchical mode, `GetAnnotationIndent` returns `GetIndentPrefix` + `IndentLength` more spaces.

4. **`WriteSuccessMessageForBasicSteps = false` still renders parameters.** If a passing step has tabular or tree parameters, the parameter output is still emitted even though the status line is suppressed. This is intentional — parameter details are always important to show.

5. **All notification methods on `DefaultProgressNotifier` are now `virtual`.** This is a deliberate change to support the inheritance model. However, it means any subclass could override individual methods. The `Notify(ProgressEvent)` dispatcher is also virtual, which wasn't the case before.

6. **The `#pragma warning disable 618` stays on `DefaultProgressNotifier`.** It suppresses the obsolete warning for implementing the deprecated `IScenarioProgressNotifier` and `IFeatureProgressNotifier` interfaces. `SimpleIndentedProgressNotifier` doesn't need the `#pragma` since it inherits rather than directly implements them.

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
