### PR TITLE
Add AppendSimpleIndentedNotifier() extension to all integration packages

### DIFF
--- a/src/LightBDD.Fixie3/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.Fixie3/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -46,5 +46,13 @@ namespace LightBDD.Fixie3.Configuration
         {
             return configuration.Append(FixieProgressNotifier.CreateProgressNotifier());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the Fixie3 output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(FixieProgressNotifier.CreateSimpleIndentedNotifier());
+        }
     }
 }

--- a/src/LightBDD.Fixie3/Implementation/FixieProgressNotifier.cs
+++ b/src/LightBDD.Fixie3/Implementation/FixieProgressNotifier.cs
@@ -22,5 +22,10 @@ namespace LightBDD.Fixie3.Implementation
         {
             return ParallelProgressNotifierProvider.Default.CreateProgressNotifier(Console.WriteLine);
         }
+
+        public static IProgressNotifier CreateSimpleIndentedNotifier()
+        {
+            return new SimpleIndentedProgressNotifier(Console.WriteLine);
+        }
     }
 }

--- a/src/LightBDD.MsTest3/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.MsTest3/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -46,5 +46,13 @@ namespace LightBDD.MsTest3.Configuration
         {
             return configuration.Append(MsTest3ProgressNotifier.CreateProgressNotifier());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the MsTest3 output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(MsTest3ProgressNotifier.CreateSimpleIndentedNotifier());
+        }
     }
 }

--- a/src/LightBDD.MsTest3/Implementation/MsTest3ProgressNotifier.cs
+++ b/src/LightBDD.MsTest3/Implementation/MsTest3ProgressNotifier.cs
@@ -26,6 +26,11 @@ namespace LightBDD.MsTest3.Implementation
             return new DefaultProgressNotifier(WriteTestOutput);
         }
 
+        public static IProgressNotifier CreateSimpleIndentedNotifier()
+        {
+            return new SimpleIndentedProgressNotifier(WriteTestOutput);
+        }
+
         public static void WriteTestOutput(string message)
         {
             ScenarioExecutionContext.GetCurrentScenarioFixtureIfPresent<ITestContextProvider>()?.TestContext?.WriteLine(message);

--- a/src/LightBDD.MsTest4/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.MsTest4/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -46,5 +46,13 @@ namespace LightBDD.MsTest4.Configuration
         {
             return configuration.Append(MsTest4ProgressNotifier.CreateProgressNotifier());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the MsTest4 output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(MsTest4ProgressNotifier.CreateSimpleIndentedNotifier());
+        }
     }
 }

--- a/src/LightBDD.MsTest4/Implementation/MsTest4ProgressNotifier.cs
+++ b/src/LightBDD.MsTest4/Implementation/MsTest4ProgressNotifier.cs
@@ -26,6 +26,11 @@ namespace LightBDD.MsTest4.Implementation
             return new DefaultProgressNotifier(WriteTestOutput);
         }
 
+        public static IProgressNotifier CreateSimpleIndentedNotifier()
+        {
+            return new SimpleIndentedProgressNotifier(WriteTestOutput);
+        }
+
         public static void WriteTestOutput(string message)
         {
             ScenarioExecutionContext.GetCurrentScenarioFixtureIfPresent<ITestContextProvider>()?.TestContext?.WriteLine(message);

--- a/src/LightBDD.NUnit3/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.NUnit3/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -46,5 +46,13 @@ namespace LightBDD.NUnit3.Configuration
         {
             return configuration.Append(NUnit3ProgressNotifier.CreateProgressNotifiers());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the NUnit3 output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(NUnit3ProgressNotifier.CreateSimpleIndentedNotifiers());
+        }
     }
 }

--- a/src/LightBDD.NUnit3/Implementation/NUnit3ProgressNotifier.cs
+++ b/src/LightBDD.NUnit3/Implementation/NUnit3ProgressNotifier.cs
@@ -41,5 +41,14 @@ namespace LightBDD.NUnit3.Implementation
                 new DefaultProgressNotifier(WriteOutput)
             };
         }
+
+        public static IProgressNotifier[] CreateSimpleIndentedNotifiers()
+        {
+            return new[]
+            {
+                ParallelProgressNotifierProvider.Default.CreateProgressNotifier(WriteImmediateProgress),
+                new SimpleIndentedProgressNotifier(WriteOutput)
+            };
+        }
     }
 }

--- a/src/LightBDD.TUnit/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.TUnit/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -28,5 +28,13 @@ namespace LightBDD.TUnit.Configuration
         {
             return configuration.Append(TUnitProgressNotifier.CreateProgressNotifiers());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the TUnit output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(TUnitProgressNotifier.CreateSimpleIndentedNotifiers());
+        }
     }
 }

--- a/src/LightBDD.TUnit/Implementation/TUnitProgressNotifier.cs
+++ b/src/LightBDD.TUnit/Implementation/TUnitProgressNotifier.cs
@@ -23,5 +23,14 @@ namespace LightBDD.TUnit.Implementation
                 new DefaultProgressNotifier(WriteOutput)
             ];
         }
+
+        public static IProgressNotifier[] CreateSimpleIndentedNotifiers()
+        {
+            return
+            [
+                ParallelProgressNotifierProvider.Default.CreateProgressNotifier(WriteImmediateProgress),
+                new SimpleIndentedProgressNotifier(WriteOutput)
+            ];
+        }
     }
 }

--- a/src/LightBDD.XUnit2/Configuration/TestFrameworkConfigurationExtensions.cs
+++ b/src/LightBDD.XUnit2/Configuration/TestFrameworkConfigurationExtensions.cs
@@ -48,5 +48,13 @@ namespace LightBDD.XUnit2.Configuration
         {
             return configuration.Append(XUnit2ProgressNotifier.CreateProgressNotifiers());
         }
+
+        /// <summary>
+        /// Appends a <see cref="LightBDD.Framework.Notification.SimpleIndentedProgressNotifier"/> pre-configured with the XUnit2 output sinks.
+        /// </summary>
+        public static ProgressNotifierConfiguration AppendSimpleIndentedNotifier(this ProgressNotifierConfiguration configuration)
+        {
+            return configuration.Append(XUnit2ProgressNotifier.CreateSimpleIndentedNotifiers());
+        }
     }
 }

--- a/src/LightBDD.XUnit2/Implementation/XUnit2ProgressNotifier.cs
+++ b/src/LightBDD.XUnit2/Implementation/XUnit2ProgressNotifier.cs
@@ -34,6 +34,15 @@ namespace LightBDD.XUnit2.Implementation
             };
         }
 
+        public static IProgressNotifier[] CreateSimpleIndentedNotifiers()
+        {
+            return new[]
+            {
+                ParallelProgressNotifierProvider.Default.CreateProgressNotifier(Console.WriteLine),
+                new SimpleIndentedProgressNotifier(WriteTestOutput)
+            };
+        }
+
         private static void WriteTestOutput(string message) => ScenarioExecutionContext.GetCurrentScenarioFixtureIfPresent<ITestOutputProvider>()?.TestOutput.WriteLine(message);
     }
 }

--- a/test/LightBDD.Fixie3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.Fixie3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,23 @@
+using LightBDD.Fixie3.Configuration;
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using Shouldly;
+
+namespace LightBDD.Fixie3.UnitTests;
+
+public class AppendSimpleIndentedNotifier_tests
+{
+    public void AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        result.ShouldBeSameAs(cfg);
+    }
+
+    public void AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        cfg.Notifier.ShouldNotBeSameAs(NoProgressNotifier.Default);
+    }
+}

--- a/test/LightBDD.MsTest3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.MsTest3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,26 @@
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using LightBDD.MsTest3.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest3.UnitTests;
+
+[TestClass]
+public class AppendSimpleIndentedNotifier_tests
+{
+    [TestMethod]
+    public void AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        Assert.AreSame(cfg, result);
+    }
+
+    [TestMethod]
+    public void AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        Assert.AreNotSame(NoProgressNotifier.Default, cfg.Notifier);
+    }
+}

--- a/test/LightBDD.MsTest4.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.MsTest4.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,26 @@
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using LightBDD.MsTest4.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LightBDD.MsTest4.UnitTests;
+
+[TestClass]
+public class AppendSimpleIndentedNotifier_tests
+{
+    [TestMethod]
+    public void AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        Assert.AreSame(cfg, result);
+    }
+
+    [TestMethod]
+    public void AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        Assert.AreNotSame(NoProgressNotifier.Default, cfg.Notifier);
+    }
+}

--- a/test/LightBDD.NUnit3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.NUnit3.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,26 @@
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using LightBDD.NUnit3.Configuration;
+using NUnit.Framework;
+
+namespace LightBDD.NUnit3.UnitTests;
+
+[TestFixture]
+public class AppendSimpleIndentedNotifier_tests
+{
+    [Test]
+    public void AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        Assert.That(result, Is.SameAs(cfg));
+    }
+
+    [Test]
+    public void AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        Assert.That(cfg.Notifier, Is.Not.SameAs(NoProgressNotifier.Default));
+    }
+}

--- a/test/LightBDD.TUnit.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.TUnit.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using LightBDD.TUnit.Configuration;
+
+namespace LightBDD.TUnit.UnitTests;
+
+public class AppendSimpleIndentedNotifier_tests
+{
+    [Test]
+    public async Task AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        await Assert.That(result).IsSameReferenceAs(cfg);
+    }
+
+    [Test]
+    public async Task AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        await Assert.That(cfg.Notifier).IsNotSameReferenceAs(NoProgressNotifier.Default);
+    }
+}

--- a/test/LightBDD.XUnit2.UnitTests/AppendSimpleIndentedNotifier_tests.cs
+++ b/test/LightBDD.XUnit2.UnitTests/AppendSimpleIndentedNotifier_tests.cs
@@ -1,0 +1,25 @@
+using LightBDD.Framework.Configuration;
+using LightBDD.Framework.Notification;
+using LightBDD.XUnit2.Configuration;
+using Xunit;
+
+namespace LightBDD.XUnit2.UnitTests;
+
+public class AppendSimpleIndentedNotifier_tests
+{
+    [Fact]
+    public void AppendSimpleIndentedNotifier_should_return_same_configuration_for_chaining()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        var result = cfg.AppendSimpleIndentedNotifier();
+        Assert.Same(cfg, result);
+    }
+
+    [Fact]
+    public void AppendSimpleIndentedNotifier_should_replace_default_notifier()
+    {
+        var cfg = new ProgressNotifierConfiguration();
+        cfg.AppendSimpleIndentedNotifier();
+        Assert.NotSame(NoProgressNotifier.Default, cfg.Notifier);
+    }
+}


### PR DESCRIPTION
Add `AppendSimpleIndentedNotifier()` extension method to each integration package so that `SimpleIndentedProgressNotifier` can be used with zero-config output wiring — matching how `AppendFrameworkDefaultProgressNotifiers()` already works for `DefaultProgressNotifier`.

#### Details

Issue reference: <!-- #NN -->

**Problem**

`SimpleIndentedProgressNotifier` inherits from `DefaultProgressNotifier`, which requires one or more `Action<string>` output sinks via its `params Action<string>[] onNotify` constructor parameter. The intended usage pattern is:

```csharp
configuration.ProgressNotifierConfiguration().Clear().Append(new SimpleIndentedProgressNotifier());
```

But this calls the constructor with zero arguments, causing `Aggregate` to throw `InvalidOperationException: Sequence contains no elements`.

So for xunit2 for example, it instead needs to be:

```csharp
configuration.ProgressNotifierConfiguration().Clear().Append(new SimpleIndentedProgressNotifier(x => ScenarioExecutionContext.GetCurrentScenarioFixtureIfPresent<ITestOutputProvider>()?.TestOutput.WriteLine(x)));
```

The user is expected to provide an output sink (e.g., `Console.WriteLine`), but this is a design mismatch: every integration package already knows its correct output sink and wires it automatically for `DefaultProgressNotifier` via `AppendFrameworkDefaultProgressNotifiers()`. `SimpleIndentedProgressNotifier` should have the same zero-config experience.

**Solution**

Add an `AppendSimpleIndentedNotifier()` extension method to each integration package's `TestFrameworkConfigurationExtensions`, mirroring `AppendFrameworkDefaultProgressNotifiers()`. Each extension creates a `SimpleIndentedProgressNotifier` with the integration's correct output sink(s) pre-wired:

```csharp
// Before (broken):
configuration.ProgressNotifierConfiguration()
    .Clear()
    .Append(new SimpleIndentedProgressNotifier()); // throws InvalidOperationException

// After (works on every integration):
configuration.ProgressNotifierConfiguration()
    .Clear()
    .AppendSimpleIndentedNotifier(); // output sink wired by the integration package
```

**Output sinks per integration:**

| Integration | Output sink | Additional notifier |
|---|---|---|
| NUnit3 | `TestContext.Out.WriteLine` | `ParallelProgressNotifierProvider` → `TestContext.Progress` |
| XUnit2 | `ScenarioExecutionContext` → `ITestOutputProvider.TestOutput.WriteLine` | `ParallelProgressNotifierProvider` → `Console.WriteLine` |
| MsTest3 | `ScenarioExecutionContext` → `ITestContextProvider.TestContext.WriteLine` | — |
| MsTest4 | `ScenarioExecutionContext` → `ITestContextProvider.TestContext.WriteLine` | — |
| TUnit | `TestContext.Current.OutputWriter.WriteLine` | `ParallelProgressNotifierProvider` → same |
| Fixie3 | `Console.WriteLine` | — |

Each integration's `AppendSimpleIndentedNotifier()` mirrors the exact same notifier structure as its `AppendFrameworkDefaultProgressNotifiers()`, but substitutes `SimpleIndentedProgressNotifier` for `DefaultProgressNotifier`.

**List of changes:**

*Source changes (6 integration packages, 2 files each):*

| File | Change |
|---|---|
| `src/LightBDD.NUnit3/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.NUnit3/Implementation/NUnit3ProgressNotifier.cs` | Added `CreateSimpleIndentedNotifiers()` factory method |
| `src/LightBDD.XUnit2/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.XUnit2/Implementation/XUnit2ProgressNotifier.cs` | Added `CreateSimpleIndentedNotifiers()` factory method |
| `src/LightBDD.MsTest3/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.MsTest3/Implementation/MsTest3ProgressNotifier.cs` | Added `CreateSimpleIndentedNotifier()` factory method |
| `src/LightBDD.MsTest4/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.MsTest4/Implementation/MsTest4ProgressNotifier.cs` | Added `CreateSimpleIndentedNotifier()` factory method |
| `src/LightBDD.TUnit/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.TUnit/Implementation/TUnitProgressNotifier.cs` | Added `CreateSimpleIndentedNotifiers()` factory method |
| `src/LightBDD.Fixie3/Configuration/TestFrameworkConfigurationExtensions.cs` | Added `AppendSimpleIndentedNotifier()` extension method |
| `src/LightBDD.Fixie3/Implementation/FixieProgressNotifier.cs` | Added `CreateSimpleIndentedNotifier()` factory method |

*Test changes (1 new test file per integration, 2 tests each):*

| File | Tests |
|---|---|
| `test/LightBDD.NUnit3.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |
| `test/LightBDD.XUnit2.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |
| `test/LightBDD.MsTest3.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |
| `test/LightBDD.MsTest4.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |
| `test/LightBDD.TUnit.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |
| `test/LightBDD.Fixie3.UnitTests/AppendSimpleIndentedNotifier_tests.cs` | New — 2 tests |

Each test verifies:
1. `AppendSimpleIndentedNotifier()` returns the same configuration instance (fluent chaining).
2. The resulting `Notifier` is no longer the `NoProgressNotifier.Default` (a notifier was actually appended).

**Design notes:**

- No changes to `DefaultProgressNotifier` or `SimpleIndentedProgressNotifier` themselves. The constructor bug (`Aggregate` on empty sequence) is not fixed at the class level — instead, users are guided toward the correct usage pattern via the integration extension methods. Calling `new SimpleIndentedProgressNotifier()` with zero args still throws, which is now a clear signal to use `AppendSimpleIndentedNotifier()` instead.
- The `DefaultProgressNotifier` constructor was intentionally left unchanged because it is an existing public API and the `params` zero-arg path was never a supported usage — every existing call site passes at least one `Action<string>`.
- Each integration's factory method is `internal`, matching the existing `CreateProgressNotifiers()` pattern.

#### Checklist
- [x] Changes are backward compatible with the previous version of Core and Framework,
- [ ] Changelog has been updated,
- [x] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
