### PR TITLE
upgrades tunit to newest version

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 LightBDD
 ===========================================
 
+Version 3.12.1
+----------------------------------------
++ #407 (LightBDD.TUnit)(Change) Updated to latest TUnit package versions
+
 Version 3.12
 ----------------------------------------
 + #399 (LightBDD.Framework and intergrations)(Add) Added BypassStepIfAttribute, IgnoreScenarioIfAttribute for conditional ignore, bypass

--- a/src/LightBDD.TUnit/LightBDD.TUnit.csproj
+++ b/src/LightBDD.TUnit/LightBDD.TUnit.csproj
@@ -39,7 +39,7 @@ High level features:
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TUnit" Version="1.0.0" />
+    <PackageReference Include="TUnit" Version="1.53.0" />
   </ItemGroup>
 
 </Project>

--- a/test/LightBDD.TUnit.UnitTests/LightBDD.TUnit.UnitTests.csproj
+++ b/test/LightBDD.TUnit.UnitTests/LightBDD.TUnit.UnitTests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="TUnit" Version="1.0.0" />
+    <PackageReference Include="TUnit" Version="1.53.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded TUnit to 1.53.0, fixing the issue of undiscovered and failing tests.

#### Details

Issue reference: #406 

List of changes:
- Updated TUnit Dependency from 1.0.0 to 1.53.0 (latest) in both the LightBdd.Tunit implementation and the corresponding test project, to ensure compatability with newer (1.40.0) TUnit versions.

#### Checklist
- [ ] Changes are backward compatible with the previous version of Core and Framework,
- [x] Changelog has been updated,
- [ ] Debugging experience is good,
- [ ] Examples have been updated to present new feature (if applicable),
- [ ] Example reports have been updated in examples\ExampleReports directory (if applicable)
